### PR TITLE
fix: ensure panel closes after initial open ALL-1509

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -13,12 +13,9 @@ const actionItems: ActionItem[] = [
 export function Toolbar() {
   const { currentAction, actions, shellPanelCollapsed } = useCalciteActionBar(
     actionItems,
-    window.location.hash
-      ? decodeURI(window.location.hash.slice(1))
-      : actionItems[0].name
+    undefined
   );
   const { setTheme, theme } = useTheme()
-
   return (
     <CalciteShellPanel
       widthScale='l'

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -11,7 +11,7 @@ const actionItems: ActionItem[] = [
 ];
 
 export function Toolbar() {
-  const { currentAction, actions } = useCalciteActionBar(
+  const { currentAction, actions, shellPanelCollapsed } = useCalciteActionBar(
     actionItems,
     window.location.hash
       ? decodeURI(window.location.hash.slice(1))
@@ -24,6 +24,7 @@ export function Toolbar() {
       widthScale='l'
       slot='panel-start'
       position='start'
+      collapsed={shellPanelCollapsed}
     >
       <CalciteActionBar slot='action-bar'>
         <CalciteActionGroup>

--- a/src/components/__tests__/Toolbar.test.tsx
+++ b/src/components/__tests__/Toolbar.test.tsx
@@ -1,0 +1,73 @@
+import { test } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import Toolbar from '../Toolbar'
+
+let container: HTMLElement
+
+beforeEach(() => {
+    const result = render(<Toolbar />)
+    container = result.container
+})
+
+// test that the component renders
+test('renders Toolbar component', () => {
+    expect(container.querySelector('calcite-action-bar')).toBeInTheDocument()
+})
+
+// test that the component renders the info button
+test('renders Info button', () => {
+    const infoButton = container.querySelector('calcite-action[text="Info"]')
+    expect(infoButton).toBeInTheDocument()
+})
+
+// test that the first button is not active by default
+test('Info button is not active by default', () => {
+    const infoButton = container.querySelector('calcite-action[text="Info"]')
+    expect(infoButton).not.toHaveAttribute('active', 'true')
+})
+
+// test that clicking first button triggers the correct action
+test('clicking the Info button triggers the correct action', () => {
+    const infoButton = container.querySelector('calcite-action[text="Info"]')
+    const layersButton = container.querySelector('calcite-action[text="Layers"]')
+    fireEvent.click(infoButton as Element)
+
+    // test that it was clicked and is active
+    expect(infoButton).toHaveAttribute('active', 'true')
+
+    // test that the other button was not clicked or active
+    expect(layersButton).not.toHaveAttribute('active', 'true')
+})
+
+// test that the component renders the layers button
+test('renders Layers button', () => {
+    const layersButton = container.querySelector('calcite-action[text="Layers"]')
+    expect(layersButton).toBeInTheDocument()
+})
+
+// test that clicking a different button triggers the correct action
+test('clicking the Layers button triggers the correct action', () => {
+    const infoButton = container.querySelector('calcite-action[text="Info"]')
+    const layersButton = container.querySelector('calcite-action[text="Layers"]')
+    fireEvent.click(layersButton as Element)
+
+    // test that it was clicked and is active
+    expect(layersButton).toHaveAttribute('active', 'true')
+
+    // test that the other button was not clicked or active
+    expect(infoButton).not.toHaveAttribute('active', 'true')
+})
+
+// test if shellPanelCollapsed is true, the panel is collapsed on page load
+test('if shellPanelCollapsed is true, the panel is collapsed', () => {
+    const panel = container.querySelector('calcite-shell-panel')
+    expect(panel).toHaveAttribute('collapsed', 'true')
+})
+
+// test if clicking the Info button toggles the panel
+test('clicking the Info button toggles the panel', () => {
+    const infoButton = container.querySelector('calcite-action[text="Info"]')
+    fireEvent.click(infoButton as Element)
+    const panel = container.querySelector('calcite-shell-panel')
+    expect(panel).not.toHaveAttribute('collapsed', 'true')
+})

--- a/src/hooks/calciteHooks.tsx
+++ b/src/hooks/calciteHooks.tsx
@@ -1,5 +1,5 @@
 import { CalciteAction } from '@esri/calcite-components-react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 export type ActionItem = {
   name: string;
@@ -14,18 +14,28 @@ export type UseCalciteActionBarProps = {
   shellPanelCollapsed: boolean;
 };
 
+// This hook is used to dynamically create the action bar buttons and handle the state of the action bar
 export function useCalciteActionBar(
   items: ActionItem[],
-  defaultValue: ActionItem['name']
+  defaultValue: ActionItem['name'] | undefined
 ): UseCalciteActionBarProps {
   const [currentActionName, setCurrentActionName] = useState<string | undefined>(defaultValue);
   const [shellPanelCollapsed, setShellPanelCollapsed] = useState<boolean>(true);
 
+  // handle the click event for the action buttons
+  const handleClick = useCallback((item: ActionItem) => {
+    const isActive = currentActionName === item.name;
+    setShellPanelCollapsed(isActive);
+    setCurrentActionName(isActive ? undefined : item.name);
+  }, [currentActionName, setShellPanelCollapsed, setCurrentActionName]);
+
+  // determine which action is currently active
   const currentAction = useMemo(
     () => items.find((example) => example.name === currentActionName),
     [currentActionName, items]
   );
 
+  // dynamically create the action buttons
   const actions = useMemo(
     () =>
       items.map((item) => (
@@ -33,15 +43,11 @@ export function useCalciteActionBar(
           key={item.name}
           text={item.name}
           icon={item.icon}
-          onClick={() => {
-            const isActive = currentActionName === item.name;
-            setShellPanelCollapsed(isActive);
-            setCurrentActionName(isActive ? undefined : item.name);
-          }}
+          onClick={() => handleClick(item)}
           active={currentActionName === item.name ? true : undefined}
         />
       )),
-    [currentActionName, items]
+    [currentActionName, items, handleClick]
   );
 
   return {

--- a/src/hooks/calciteHooks.tsx
+++ b/src/hooks/calciteHooks.tsx
@@ -8,14 +8,18 @@ export type ActionItem = {
   component: React.LazyExoticComponent<() => JSX.Element>;
 };
 
+export type UseCalciteActionBarProps = {
+  currentAction?: ActionItem;
+  actions: JSX.Element[];
+  shellPanelCollapsed: boolean;
+};
+
 export function useCalciteActionBar(
   items: ActionItem[],
   defaultValue: ActionItem['name']
-): {
-  currentAction: ActionItem | undefined;
-  actions: JSX.Element[];
-} {
-  const [currentActionName, setCurrentActionName] = useState(defaultValue);
+): UseCalciteActionBarProps {
+  const [currentActionName, setCurrentActionName] = useState<string | undefined>(defaultValue);
+  const [shellPanelCollapsed, setShellPanelCollapsed] = useState<boolean>(true);
 
   const currentAction = useMemo(
     () => items.find((example) => example.name === currentActionName),
@@ -29,7 +33,11 @@ export function useCalciteActionBar(
           key={item.name}
           text={item.name}
           icon={item.icon}
-          onClick={() => setCurrentActionName(item.name)}
+          onClick={() => {
+            const isActive = currentActionName === item.name;
+            setShellPanelCollapsed(isActive);
+            setCurrentActionName(isActive ? undefined : item.name);
+          }}
           active={currentActionName === item.name ? true : undefined}
         />
       )),
@@ -39,5 +47,6 @@ export function useCalciteActionBar(
   return {
     currentAction,
     actions,
+    shellPanelCollapsed,
   };
 }


### PR DESCRIPTION
This PR addresses the issue where the panel does not close after its initial opening. The changes introduced ensure that the panel collapses and expands when the user clicks on the sidebar buttons.

Key changes include:

- Added a new state shellPanelCollapsed in the useCalciteActionBar hook to track whether the panel is collapsed.
- Updated the onClick handler in the CalciteAction component to toggle the shellPanelCollapsed state based on the current active action.
- Passed the shellPanelCollapsed state to the CalciteShellPanel component to control its collapsed state.
- Updated the Toolbar component to use the shellPanelCollapsed state from the useCalciteActionBar hook.


https://github.com/UGS-GIO/geohaz-v2/assets/24685932/6f9d6ec6-fc42-4e8e-a5ee-72af63ad2624

