### PR TITLE
feat: add a seachbar with address and qfaults search

### DIFF
--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -47,14 +47,15 @@ const MapWidgets: React.FC = () => {
             container: document.createElement("div"),
             id: 'search-widget',
             popupEnabled: false,
+            allPlaceholder: "Find address, place, or fault zone",
             includeDefaultSources: false,
             sources: [
                 {
                     url: "https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer",
                     singleLineFieldName: "SingleLine",
                     outFields: ["RegionAbbr"],
-                    name: "Utah Geocoding Service",
-                    placeholder: "Address",
+                    name: "Location Search",
+                    placeholder: "Find address or place",
                     maxResults: 1000,
                     filter: {
                         // bounding box of Utah

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -14,8 +14,6 @@ import Graphic from "@arcgis/core/Graphic.js";
 import Polyline from "@arcgis/core/geometry/Polyline.js";
 import SpatialReference from "@arcgis/core/geometry/SpatialReference.js";
 import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol.js";
-import Layer from '@arcgis/core/layers/Layer';
-
 
 const MapWidgets: React.FC = () => {
     const { view, isMobile } = useContext(MapContext);

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -47,7 +47,7 @@ const MapWidgets: React.FC = () => {
             container: document.createElement("div"),
             id: 'search-widget',
             popupEnabled: false,
-            allPlaceholder: "Find address, place, or fault zone",
+            allPlaceholder: "Address, place, or fault",
             includeDefaultSources: false,
             sources: [
                 {
@@ -55,7 +55,7 @@ const MapWidgets: React.FC = () => {
                     singleLineFieldName: "SingleLine",
                     outFields: ["RegionAbbr"],
                     name: "Location Search",
-                    placeholder: "Find address or place",
+                    placeholder: "Address or place",
                     maxResults: 1000,
                     filter: {
                         // bounding box of Utah

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -81,7 +81,7 @@ const MapWidgets: React.FC = () => {
 
                         return data.features.map((item: any) => {
                             return {
-                                text: '<b>' + item.properties.concatnames + '</b>',
+                                text: '<p>' + item.properties.concatnames + '</p>',
                                 key: item.properties.concatnames,
                                 sourceIndex: params.sourceIndex,
                             };
@@ -116,29 +116,23 @@ const MapWidgets: React.FC = () => {
                                 }),
                             });
 
-                            const simpleLineSymbol = new SimpleLineSymbol({
-                                cap: "round",
-                                color: new Color([0, 122, 194, 1]),
-                                join: "round",
-                                miterLimit: 1,
-                                style: "solid",
-                                width: 1
-                            });
-
                             const target = new Graphic({
-                                geometry: polyline,
-                                attributes: item.attributes,
-                                symbol: simpleLineSymbol
+                                geometry: polyline as unknown as Polyline,
+                                attributes: item.attributes
                             });
 
                             return {
-                                extent: polyline.extent,
                                 name: item.properties.concatnames,
                                 feature: target,
                                 target: target
                             };
                         });
                     },
+                    resultSymbol: {
+                        type: "simple-line",
+                        color: 'red',
+                        width: 2
+                    }
                 } as __esri.LayerSearchSourceProperties)
             ]
         })

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -17,7 +17,6 @@ import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol.js";
 import SpatialReference from "@arcgis/core/geometry/SpatialReference.js";
 
 
-
 // ArcGIS JS SDK Widgets that are overlaid on the map
 const MapWidgets: React.FC = () => {
     const { view, isMobile } = useContext(MapContext);
@@ -95,11 +94,11 @@ const MapWidgets: React.FC = () => {
 
                         // Check if a specific suggestion has been selected
                         // If a suggestion was selected (versus just pressing enter on the search box), a sourceIndex will be included in the params
-                        if (params.sourceIndex !== undefined) {
+                        if (params.suggestResult.sourceIndex) {
                             const searchTerm = params.suggestResult.key ? params.suggestResult.key : '';
                             url += `?search_key=${encodeURIComponent(searchTerm)}`;
                         } else {
-                            const searchTerm = params.suggestResult.text
+                            const searchTerm = params.suggestResult.text ? params.suggestResult.text : '';
                             url += `?search_term=${encodeURIComponent(searchTerm)}`;
                         }
 

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -7,6 +7,14 @@ import BasemapGallery from "@arcgis/core/widgets/BasemapGallery.js";
 import { useContext } from 'react';
 import { MapContext } from '../../contexts/MapProvider';
 import Legend from '@arcgis/core/widgets/Legend';
+import Search from '@arcgis/core/widgets/Search';
+import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
+import { poopTemplate } from '../../config/popups';
+import SearchSource from "@arcgis/core/widgets/Search/SearchSource.js";
+import esriRequest from "@arcgis/core/request.js";
+import Graphic from "@arcgis/core/Graphic.js";
+import Polygon from "@arcgis/core/geometry/Polygon.js";
+import { toTitleCase } from '../../config/util/utils';
 
 // ArcGIS JS SDK Widgets that are overlaid on the map
 const MapWidgets: React.FC = () => {
@@ -24,13 +32,130 @@ const MapWidgets: React.FC = () => {
         spatialReference: view?.spatialReference
     };
 
-    const expandConfig = {
+    const basemapExpandConfig = {
         id: 'basemap-gallery-expand',
         view: view,
         content: new BasemapGallery({
             view: view,
             container: document.createElement("div"),
             id: 'basemap-gallery-widget',
+        })
+    }
+
+    const UGRCParcelUrl = 'https://services1.arcgis.com/99lidPhWCzftIe9K/arcgis/rest/services/UtahStatewideParcels/FeatureServer/0/query';
+
+    const searchExpandConfig = {
+        id: 'search-expand',
+        view: view,
+        content: new Search({
+            view: view,
+            container: document.createElement("div"),
+            id: 'search-widget',
+            popupEnabled: false,
+            sources: [
+                {
+                    layer:
+                        new FeatureLayer({
+                            url: "https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0",
+                        }),
+                    exactMatch: false,
+                    displayField: "FaultName",
+                    searchFields: ["FaultZone", "FaultName", "SectionName", "StrandName"],
+                    outFields: ["*"],
+                    name: "Fault Search",
+                    popupTemplate: {
+                        title: "Hazardous (Quaternary age) Faults",
+                        content: poopTemplate
+                    },
+                    placeholder: "ex: Wasatch Fault Zone",
+                    searchTemplate: "{FaultZone}, {FaultName}, {SectionName}, {StrandName}",
+                    suggestionTemplate: "<b>Fault Zone:</b> {FaultZone}, <b>Fault Name:</b> {FaultName}, <b>Section Name:</b> {SectionName}, <b>Strand Name:</b> {StrandName}",
+                    maxSuggestions: 5000,
+                    minSuggestCharacters: 3,
+
+                } as __esri.LayerSearchSourceProperties,
+                // the default results from the UGRC parcel service are returned in all caps
+                // so we need to implement our own custom search source in order to rewrite the 
+                // suggestions and results to be more user friendly
+                new SearchSource({
+                    placeholder: "Search for a parcel",
+                    name: "Parcel Search",
+                    // function that executes when user types in the search box
+                    getSuggestions: (params) => {
+                        // Make a request to search for the parcel
+                        return esriRequest(UGRCParcelUrl, {
+                            query: {
+                                f: "pjson",
+                                resultRecordCount: 6,
+                                where: `(PARCEL_ADD LIKE '${params.suggestTerm.replace(/ /g, " ")}%')`,
+                                outFields: 'PARCEL_ADD,PARCEL_CITY,PARCEL_ZIP,PARCEL_ID,County,OBJECTID',
+                                outSR: 102100,
+                                returnGeometry: false,
+                                spatialRel: "esriSpatialRelIntersects"
+                            },
+                        }).then((results) => {
+                            return results.data.features.map((feature: { attributes: { PARCEL_ADD: string, PARCEL_CITY: string, PARCEL_ZIP: string, County: string, PARCEL_ID: string } }) => {
+                                const { PARCEL_ADD, PARCEL_CITY, PARCEL_ZIP, County } = feature.attributes;
+                                const formattedAddress = `${toTitleCase(PARCEL_ADD)}, ${toTitleCase(PARCEL_CITY)}, ${PARCEL_ZIP} - ${toTitleCase(County)}`;
+                                return {
+                                    key: "name",
+                                    text: `<span class="my-suggest">${formattedAddress}</span>`,
+                                    PARCEL_ID: feature.attributes.PARCEL_ID,
+                                    sourceIndex: params.sourceIndex,
+                                };
+                            });
+                        });
+                    },
+                    // function that executes when user selects a search suggestion
+                    getResults: async (params) => {
+                        console.log({ params });
+
+                        // Make a request to search for the parcel
+                        const searchResults = await esriRequest(UGRCParcelUrl, {
+                            query: {
+                                f: "pjson",
+                                resultRecordCount: 6,
+                                where: `(PARCEL_ID LIKE '${params.suggestResult.PARCEL_ID.replace(/ /g, " ")}%')`,
+                                outFields: 'PARCEL_ADD,PARCEL_CITY,PARCEL_ZIP,PARCEL_ID,County,OBJECTID',
+                                outSR: 102100,
+                                returnGeometry: true,
+                                returnZ: true,
+                                spatialRel: "esriSpatialRelIntersects"
+                            },
+                        });
+                        return searchResults.data.features.map((feature: any) => {
+                            const { PARCEL_ADD, PARCEL_CITY, PARCEL_ZIP, County } = feature.attributes;
+                            const formattedAddress = `${toTitleCase(PARCEL_ADD)}, ${toTitleCase(PARCEL_CITY)}, ${PARCEL_ZIP} - ${toTitleCase(County)}`;
+
+                            const polygon = new Polygon({
+                                rings: feature.geometry.rings,
+                                spatialReference: view?.spatialReference
+                            });
+
+                            const graphic = new Graphic({
+                                geometry: polygon,
+                                attributes: feature.attributes,
+                            });
+
+                            // Open a popup with the parcel's information
+                            view?.openPopup({
+                                title: "Parcel Information",
+                                content: `This is ${formattedAddress}`,
+                                location: graphic.geometry.extent.center
+
+                            });
+
+                            // Return a search result
+                            return {
+                                extent: graphic.geometry.extent,
+                                name: `Parcel: ${formattedAddress}`,
+                                feature: graphic
+                            };
+                        });
+                    }
+
+                } as __esri.LayerSearchSourceProperties)
+            ]
         })
     }
 
@@ -45,9 +170,10 @@ const MapWidgets: React.FC = () => {
         {
             WrappedWidget: Expand,
             position: isMobile ? 'top-left' : 'top-right',
-            config: expandConfig
+            config: basemapExpandConfig
         },
-        { WrappedWidget: Legend, position: 'top-left' }
+        { WrappedWidget: Legend, position: 'top-left' },
+        { WrappedWidget: Expand, position: 'top-right', config: searchExpandConfig }
     ]);
 
     return null;

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -12,8 +12,6 @@ import Extent from "@arcgis/core/geometry/Extent.js";
 import SearchSource from "@arcgis/core/widgets/Search/SearchSource.js";
 import Graphic from "@arcgis/core/Graphic.js";
 import Polyline from "@arcgis/core/geometry/Polyline.js";
-import Color from "@arcgis/core/Color.js";
-import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol.js";
 import SpatialReference from "@arcgis/core/geometry/SpatialReference.js";
 
 

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -113,7 +113,7 @@ const MapWidgets: React.FC = () => {
                             const polyline = new Polyline({
                                 paths: item.geometry.coordinates,
                                 spatialReference: new SpatialReference({
-                                    wkid: 4326 // WGS84 projection
+                                    wkid: 4326
                                 }),
                             });
 
@@ -133,7 +133,6 @@ const MapWidgets: React.FC = () => {
                             });
 
                             return {
-                                // Include extent, feature, name, target
                                 extent: polyline.extent,
                                 name: item.properties.concatnames,
                                 feature: target,
@@ -167,91 +166,3 @@ const MapWidgets: React.FC = () => {
 };
 
 export default MapWidgets;
-
-
-// example of a custom search source below if use case arises
-
-// the default results from the UGRC parcel service are returned in all caps
-// so we need to implement our own custom search source in order to rewrite the
-// suggestions and results to be more user friendly
-
-// const UGRCParcelUrl = 'https://services1.arcgis.com/99lidPhWCzftIe9K/arcgis/rest/services/UtahStatewideParcels/FeatureServer/0/query';
-
-// new SearchSource({
-//     placeholder: "Search for a parcel",
-//     name: "Parcel Search",
-//     // function that executes when user types in the search box
-//     getSuggestions: (params) => {
-//         // Make a request to search for the parcel
-//         return esriRequest(UGRCParcelUrl, {
-//             query: {
-//                 f: "pjson",
-//                 resultRecordCount: 6,
-//                 where: `(PARCEL_ADD LIKE '${params.suggestTerm.replace(/ /g, " ")}%')`,
-//                 outFields: 'PARCEL_ADD,PARCEL_CITY,PARCEL_ZIP,PARCEL_ID,County,OBJECTID',
-//                 outSR: 102100,
-//                 returnGeometry: false,
-//                 spatialRel: "esriSpatialRelIntersects"
-//             },
-//         }).then((results) => {
-//             return results.data.features.map((feature: { attributes: { PARCEL_ADD: string, PARCEL_CITY: string, PARCEL_ZIP: string, County: string, PARCEL_ID: string } }) => {
-//                 const { PARCEL_ADD, PARCEL_CITY, PARCEL_ZIP, County } = feature.attributes;
-//                 const formattedAddress = `${toTitleCase(PARCEL_ADD)}, ${toTitleCase(PARCEL_CITY)}, ${PARCEL_ZIP} - ${toTitleCase(County)}`;
-//                 return {
-//                     key: "name",
-//                     text: `<span class="my-suggest">${formattedAddress}</span>`,
-//                     PARCEL_ID: feature.attributes.PARCEL_ID,
-//                     sourceIndex: params.sourceIndex,
-//                 };
-//             });
-//         });
-//     },
-//     // function that executes when user selects a search suggestion
-//     getResults: async (params) => {
-//         console.log({ params });
-
-//         // Make a request to search for the parcel
-//         const searchResults = await esriRequest(UGRCParcelUrl, {
-//             query: {
-//                 f: "pjson",
-//                 resultRecordCount: 6,
-//                 where: `(PARCEL_ID LIKE '${params.suggestResult.PARCEL_ID.replace(/ /g, " ")}%')`,
-//                 outFields: 'PARCEL_ADD,PARCEL_CITY,PARCEL_ZIP,PARCEL_ID,County,OBJECTID',
-//                 outSR: 102100,
-//                 returnGeometry: true,
-//                 returnZ: true,
-//                 spatialRel: "esriSpatialRelIntersects"
-//             },
-//         });
-//         return searchResults.data.features.map((feature: any) => {
-//             const { PARCEL_ADD, PARCEL_CITY, PARCEL_ZIP, County } = feature.attributes;
-//             const formattedAddress = `${toTitleCase(PARCEL_ADD)}, ${toTitleCase(PARCEL_CITY)}, ${PARCEL_ZIP} - ${toTitleCase(County)}`;
-
-//             const polygon = new Polygon({
-//                 rings: feature.geometry.rings,
-//                 spatialReference: view?.spatialReference
-//             });
-
-//             const graphic = new Graphic({
-//                 geometry: polygon,
-//                 attributes: feature.attributes,
-//             });
-
-//             // Open a popup with the parcel's information
-//             view?.openPopup({
-//                 title: "Parcel Information",
-//                 content: `This is ${formattedAddress}`,
-//                 location: graphic.geometry.extent.center
-
-//             });
-
-//             // Return a search result
-//             return {
-//                 extent: graphic.geometry.extent,
-//                 name: `Parcel: ${formattedAddress}`,
-//                 feature: graphic
-//             };
-//         });
-//     }
-
-// } as __esri.LayerSearchSourceProperties),

--- a/src/components/widgets/MapWidgets.tsx
+++ b/src/components/widgets/MapWidgets.tsx
@@ -56,6 +56,7 @@ const MapWidgets: React.FC = () => {
                     outFields: ["RegionAbbr"],
                     name: "Utah Geocoding Service",
                     placeholder: "Address",
+                    maxResults: 1000,
                     filter: {
                         // bounding box of Utah
                         geometry: new Extent({

--- a/src/components/widgets/util/utils.ts
+++ b/src/components/widgets/util/utils.ts
@@ -1,0 +1,87 @@
+import Graphic from "@arcgis/core/Graphic.js";
+import Polyline from "@arcgis/core/geometry/Polyline.js";
+import SpatialReference from "@arcgis/core/geometry/SpatialReference.js";
+
+// Function to fetch suggestions from the search box
+export const fetchQFaultSuggestions = async (params: { suggestTerm: string, sourceIndex: number }, url: string): Promise<__esri.SuggestResult[]> => {
+    const response = await fetch(`${url}?search_term=${encodeURIComponent(params.suggestTerm)}`);
+    const data = await response.json();
+
+    return data.features.map((item: any) => {
+        return {
+            text: '<p>' + item.properties.concatnames + '</p>',
+            key: item.properties.concatnames,
+            sourceIndex: params.sourceIndex,
+        };
+    });
+};
+
+// Function to fetch results from the search box
+export const fetchQFaultResults = async (params: any, url: string): Promise<__esri.SearchResult[]> => {
+    let searchUrl = url;
+    let searchTerm = '';
+
+    // If the sourceIndex is not null, then the user selected a suggestion from the search box
+    // If the sourceIndex is null, then the user pressed enter in the search box or hit the search button (a non specific search)
+    if (params.suggestResult.sourceIndex !== null) {
+        searchTerm = params.suggestResult.key ? params.suggestResult.key : '';
+        searchUrl += `?search_key=${encodeURIComponent(searchTerm)}`;
+    } else {
+        searchTerm = params.suggestResult.text ? params.suggestResult.text : '';
+        searchUrl += `?search_term=${encodeURIComponent(searchTerm)}`;
+    }
+
+    const response = await fetch(searchUrl);
+    const data = await response.json();
+
+    if (data.features.length === 0) {
+        return [];
+    }
+
+    // Create graphics for each feature returned from the search
+    const graphics: __esri.Graphic[] = data.features.map((item: any) => {
+        const polyline = new Polyline({
+            paths: item.geometry.coordinates,
+            spatialReference: new SpatialReference({
+                wkid: 4326
+            }),
+        });
+
+        return new Graphic({
+            geometry: polyline,
+            attributes: item.attributes
+        });
+    });
+
+    // Create a merged polyline to add the polyline paths to
+    const mergedPolyline = new Polyline({
+        spatialReference: new SpatialReference({ wkid: 4326 })
+    });
+
+    // Add the paths from each graphic to the merged polyline
+    graphics.forEach((graphic: __esri.Graphic) => {
+        const polyline = graphic.geometry as Polyline;
+        const paths = polyline.paths;
+        paths.forEach(path => {
+            mergedPolyline.addPath(path);
+        });
+    });
+
+    // Create attributes for the target graphic
+    const attributes = params.sourceIndex !== null
+        ? { name: data.features[0].properties.concatnames }
+        : { name: `Search results for: ${params.text}` };
+
+    // Create a target graphic to return
+    const target = new Graphic({
+        geometry: mergedPolyline,
+        attributes: attributes
+    });
+
+    return [{
+        extent: mergedPolyline.extent,
+        name: target.attributes.name,
+        feature: target,
+        target: target
+    }];
+};

--- a/src/config/util/utils.ts
+++ b/src/config/util/utils.ts
@@ -2,3 +2,14 @@
 export function addCommas(x: string) {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
+
+// convert a string to title case
+// ex. "hello world" -> "Hello World"
+export function toTitleCase(str: string) {
+    return str.replace(
+        /\w\S*/g,
+        function (txt) {
+            return txt.charAt(0).toUpperCase() + txt.substring(1).toLowerCase();
+        }
+    );
+}


### PR DESCRIPTION
Adding a searchbar to the map. 

![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/9e5a4c31-85f1-4ccd-8ce2-d5886337056c)
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/d4d86565-d9e3-4b5f-888a-830ef619058f)


including a few different sources:
- Default location search
- Quaternary Faults search (https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0)
- UGRC statewide parcel search (https://services1.arcgis.com/99lidPhWCzftIe9K/arcgis/rest/services/UtahStatewideParcels/FeatureServer/0/query)


The results from UGRC came in all caps, so i implemented a custom [SearchSource](https://developers.arcgis.com/javascript/latest/api-reference/esri-widgets-Search-SearchSource.html) in order to get control over the suggestion templates and result selection function.  