### PR TITLE
feat: add a button that will take you to the layers panel (ALL-2236)

### DIFF
--- a/src/components/SidebarComponents/Info.tsx
+++ b/src/components/SidebarComponents/Info.tsx
@@ -36,7 +36,7 @@ function Info() {
           Start Exploring
         </CalciteButton>
         <CalciteButton
-          className='white-orange-button'
+          id='data-disclaimer-button'
           alignment='center'
           onClick={() => setModalOpen(!modalOpen)}
         >

--- a/src/components/SidebarComponents/Info.tsx
+++ b/src/components/SidebarComponents/Info.tsx
@@ -6,9 +6,11 @@ import {
   CalciteModal,
 } from '@esri/calcite-components-react'
 import { Link } from '../shared'
+import { useNavigation } from '../../contexts/NavigationContext';
 
 function Info() {
   const [modalOpen, setModalOpen] = useState(false)
+  const { setCurrentActionName } = useNavigation();
 
   return (
     <CalcitePanel>
@@ -26,8 +28,15 @@ function Info() {
       <CalciteBlock open heading='Data Sources'>
         <p className="mb-2">The data used in this map is from the following sources: lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
       </CalciteBlock>
-      <div className='text-start my-2 mx-2'>
+      <div className='flex justify-between my-2 mx-2'>
         <CalciteButton
+          alignment='center'
+          onClick={() => setCurrentActionName('Layers')}
+        >
+          Start Exploring
+        </CalciteButton>
+        <CalciteButton
+          className='white-orange-button'
           alignment='center'
           onClick={() => setModalOpen(!modalOpen)}
         >

--- a/src/components/SidebarComponents/Layers.tsx
+++ b/src/components/SidebarComponents/Layers.tsx
@@ -3,7 +3,7 @@ import {
 } from '@esri/calcite-components-react';
 import useCustomLayerList from '../../hooks/useCustomLayerList';
 
-const Layers: React.FC = () => {
+function Layers() {
   const layerList = useCustomLayerList();
 
   if (!layerList?.length) {

--- a/src/components/SidebarComponents/__tests__/Info.test.tsx
+++ b/src/components/SidebarComponents/__tests__/Info.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Info from '../Info';
+import { NavigationProvider } from '../../../contexts/NavigationContext';
+
+describe('Info Component', () => {
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        const result = render(
+            <NavigationProvider>
+                <Info />
+            </NavigationProvider>
+        );
+        container = result.container;
+    });
+
+    test('renders and handles Open Data Disclaimer button click', async () => {
+        const openDisclaimerButton = screen.getByText('Open Data Disclaimer');
+        expect(openDisclaimerButton).toBeInTheDocument();
+        fireEvent.click(openDisclaimerButton);
+        await waitFor(() => {
+            expect(screen.getByText('Data Disclaimer')).toBeInTheDocument();
+            expect(screen.getByText(/Although this product represents the work of professional scientists/i)).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByText('Close'));
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    test('renders Contact Webmaster link', () => {
+        const link = screen.getByRole('link', { name: /Contact Webmaster/i });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', 'https://geology.utah.gov/about-us/contact-webmaster/');
+    });
+});

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -12,7 +12,7 @@ const actionItems: ActionItem[] = [
 ];
 
 export function Toolbar() {
-  const { currentAction, actions, shellPanelCollapsed } = useCalciteActionBar(actionItems, undefined);
+  const { currentAction, actions, shellPanelCollapsed } = useCalciteActionBar(actionItems, 'Info');
   const { setTheme, theme } = useTheme();
   return (
     <CalciteShellPanel widthScale='m' slot='panel-start' position='start' collapsed={shellPanelCollapsed}>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,4 +1,5 @@
-import React, { lazy } from 'react'
+// src/components/Toolbar.tsx
+import React, { lazy } from 'react';
 import { CalciteAction, CalciteActionBar, CalciteActionGroup, CalciteShellPanel } from '@esri/calcite-components-react';
 import { useCalciteActionBar, ActionItem } from '../hooks/useCalciteActionBar';
 import { useTheme } from '../contexts/ThemeProvider';
@@ -11,18 +12,10 @@ const actionItems: ActionItem[] = [
 ];
 
 export function Toolbar() {
-  const { currentAction, actions, shellPanelCollapsed } = useCalciteActionBar(
-    actionItems,
-    undefined
-  );
-  const { setTheme, theme } = useTheme()
+  const { currentAction, actions, shellPanelCollapsed } = useCalciteActionBar(actionItems, undefined);
+  const { setTheme, theme } = useTheme();
   return (
-    <CalciteShellPanel
-      widthScale='m'
-      slot='panel-start'
-      position='start'
-      collapsed={shellPanelCollapsed}
-    >
+    <CalciteShellPanel widthScale='m' slot='panel-start' position='start' collapsed={shellPanelCollapsed}>
       <CalciteActionBar slot='action-bar'>
         <CalciteActionGroup>
           {actions}
@@ -40,4 +33,4 @@ export function Toolbar() {
   );
 }
 
-export default Toolbar
+export default Toolbar;

--- a/src/components/__tests__/Toolbar.test.tsx
+++ b/src/components/__tests__/Toolbar.test.tsx
@@ -1,11 +1,12 @@
 import { test } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import Toolbar from '../Toolbar'
+import { NavigationProvider } from '../../contexts/NavigationContext'
 
 let container: HTMLElement
 
 beforeEach(() => {
-    const result = render(<Toolbar />)
+    const result = render(<NavigationProvider><Toolbar /></NavigationProvider>)
     container = result.container
 })
 

--- a/src/components/__tests__/Toolbar.test.tsx
+++ b/src/components/__tests__/Toolbar.test.tsx
@@ -21,10 +21,10 @@ test('renders Info button', () => {
     expect(infoButton).toBeInTheDocument()
 })
 
-// test that the first button is not active by default
-test('Info button is not active by default', () => {
+// test that the Info panel is active by default
+test('Info button is active by default', () => {
     const infoButton = container.querySelector('calcite-action[text="Info"]')
-    expect(infoButton).not.toHaveAttribute('active', 'true')
+    expect(infoButton).toHaveAttribute('active', 'true')
 })
 
 // test that clicking first button triggers the correct action
@@ -59,10 +59,10 @@ test('clicking the Layers button triggers the correct action', () => {
     expect(infoButton).not.toHaveAttribute('active', 'true')
 })
 
-// test if shellPanelCollapsed is true, the panel is collapsed on page load
+// on page load, we should see shellPanelCollapsed as false since the default value is 'Info'
 test('if shellPanelCollapsed is true, the panel is collapsed', () => {
     const panel = container.querySelector('calcite-shell-panel')
-    expect(panel).toHaveAttribute('collapsed', 'true')
+    expect(panel).toHaveAttribute('collapsed', 'false')
 })
 
 // test if clicking the Info button toggles the panel

--- a/src/contexts/NavigationContext.tsx
+++ b/src/contexts/NavigationContext.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface NavigationContextProps {
+    currentActionName: string | undefined;
+    setCurrentActionName: (actionName: string | undefined) => void;
+}
+
+const NavigationContext = createContext<NavigationContextProps | undefined>(undefined);
+
+export const NavigationProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+    const [currentActionName, setCurrentActionName] = useState<string | undefined>(undefined);
+
+    return (
+        <NavigationContext.Provider value={{ currentActionName, setCurrentActionName }}>
+            {children}
+        </NavigationContext.Provider>
+    );
+};
+
+export const useNavigation = () => {
+    const context = useContext(NavigationContext);
+    if (!context) {
+        throw new Error('useNavigation must be used within a NavigationProvider');
+    }
+    return context;
+};

--- a/src/hooks/useCalciteActionBar.tsx
+++ b/src/hooks/useCalciteActionBar.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { CalciteAction } from '@esri/calcite-components-react';
-import { useCallback, useMemo } from 'react';
 import { useNavigation } from '../contexts/NavigationContext';
 
 export type ActionItem = {
@@ -17,25 +16,33 @@ type UseCalciteActionBarProps = {
 
 export function useCalciteActionBar(
   items: ActionItem[],
-  defaultValue: ActionItem['name'] | undefined
+  defaultValue: ActionItem['name']
 ): UseCalciteActionBarProps {
   const { currentActionName, setCurrentActionName } = useNavigation();
   const [shellPanelCollapsed, setShellPanelCollapsed] = useState<boolean>(true);
 
-  // handle the click event for the action buttons
+  // Initialize the current action name with the default value if not already set
+  useEffect(() => {
+    if (!currentActionName && defaultValue) {
+      setCurrentActionName(defaultValue);
+      setShellPanelCollapsed(false);
+    }
+  }, [currentActionName, defaultValue, setCurrentActionName]);
+
+  // Handle the click event for the action buttons
   const handleClick = useCallback((item: ActionItem) => {
     const isActive = currentActionName === item.name;
     setShellPanelCollapsed(isActive);
     setCurrentActionName(isActive ? undefined : item.name);
   }, [currentActionName, setShellPanelCollapsed, setCurrentActionName]);
 
-  // determine which action is currently active
+  // Determine which action is currently active
   const currentAction = useMemo(
     () => items.find((example) => example.name === currentActionName),
     [currentActionName, items]
   );
 
-  // dynamically create the action buttons
+  // Dynamically create the action buttons
   const actions = useMemo(
     () =>
       items.map((item) => (

--- a/src/hooks/useCalciteActionBar.tsx
+++ b/src/hooks/useCalciteActionBar.tsx
@@ -1,10 +1,11 @@
+import { useState } from 'react';
 import { CalciteAction } from '@esri/calcite-components-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useNavigation } from '../contexts/NavigationContext';
 
 export type ActionItem = {
   name: string;
   icon: string;
-  code?: () => Promise<typeof import('*?raw')>;
   component: React.LazyExoticComponent<() => JSX.Element>;
 };
 
@@ -14,12 +15,11 @@ type UseCalciteActionBarProps = {
   shellPanelCollapsed: boolean;
 };
 
-// This hook is used to dynamically create the action bar buttons and handle the state of the action bar
 export function useCalciteActionBar(
   items: ActionItem[],
   defaultValue: ActionItem['name'] | undefined
 ): UseCalciteActionBarProps {
-  const [currentActionName, setCurrentActionName] = useState<string | undefined>(defaultValue);
+  const { currentActionName, setCurrentActionName } = useNavigation();
   const [shellPanelCollapsed, setShellPanelCollapsed] = useState<boolean>(true);
 
   // handle the click event for the action buttons

--- a/src/index.css
+++ b/src/index.css
@@ -38,19 +38,16 @@ calcite-button {
 }
 
 /* customize the data-disclaimer-button for light and dark mode */
-/* Inverted light mode colors */
 .calcite-mode-light #data-disclaimer-button {
-  --calcite-ui-brand: #dedede; /* Inverted brand color */
-  --calcite-ui-brand-hover: #d1d1d1; /* Inverted hover color */
-  --calcite-ui-brand-press: #d1d1d1; /* Inverted press color */
+  --calcite-ui-brand: #dedede;
+  --calcite-ui-brand-hover: #d1d1d1;
+  --calcite-ui-brand-press: #d1d1d1;
   --calcite-ui-text-inverse: #000000
 }
-
-/* Inverted dark mode colors */
 .calcite-mode-dark #data-disclaimer-button {
-  --calcite-ui-brand: #d1d1d1; /* Inverted brand color */
-  --calcite-ui-brand-hover: #bdbdbd; /* Inverted hover color */
-  --calcite-ui-brand-press: #bdbdbd; /* Inverted press color */
+  --calcite-ui-brand: #d1d1d1; 
+  --calcite-ui-brand-hover: #bdbdbd;
+  --calcite-ui-brand-press: #bdbdbd;
   --calcite-ui-text-inverse: #000000
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -37,13 +37,28 @@ calcite-button {
   --calcite-ui-brand-press: #b65c02;
 }
 
+/* customize the data-disclaimer-button for light and dark mode */
+/* Inverted light mode colors */
+.calcite-mode-light #data-disclaimer-button {
+  --calcite-ui-brand: #dedede; /* Inverted brand color */
+  --calcite-ui-brand-hover: #d1d1d1; /* Inverted hover color */
+  --calcite-ui-brand-press: #d1d1d1; /* Inverted press color */
+  --calcite-ui-text-inverse: #000000
+}
+
+/* Inverted dark mode colors */
+.calcite-mode-dark #data-disclaimer-button {
+  --calcite-ui-brand: #d1d1d1; /* Inverted brand color */
+  --calcite-ui-brand-hover: #bdbdbd; /* Inverted hover color */
+  --calcite-ui-brand-press: #bdbdbd; /* Inverted press color */
+  --calcite-ui-text-inverse: #000000
+}
 
 calcite-segmented-control-item[aria-checked="true"] {
   --calcite-ui-brand: #d26e03;
   --calcite-ui-brand-hover: #e77c33;
   --calcite-ui-brand-press: #b65c02;
 }
-
 
 /* 
   basic styling for the text inside of a feature widget, 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import App from './App';
 import { defineCustomElements } from '@esri/calcite-components/dist/loader';
 import { ThemeProvider } from './contexts/ThemeProvider';
 import { MapProvider } from './contexts/MapProvider';
+import { NavigationProvider } from './contexts/NavigationContext';
 
 
 // Create a root element for the application
@@ -22,11 +23,13 @@ defineCustomElements(window);
 root.render(
   <StrictMode>
     <ThemeProvider>
-      <QueryClientProvider client={queryClient}>
-        <MapProvider>
-          <App />
-        </MapProvider>
-      </QueryClientProvider>
+      <NavigationProvider>
+        <QueryClientProvider client={queryClient}>
+          <MapProvider>
+            <App />
+          </MapProvider>
+        </QueryClientProvider>
+      </NavigationProvider>
     </ThemeProvider>
   </StrictMode>
 );


### PR DESCRIPTION
- [x] add functionality to switch to layers list on a button click within 
- [x] Button-size will be the same design as “Data Disclaimer”, and will say “Start Exploring”. 
- [x] Info panel active on load



Button design for “Start Exploring”:
- Orange fill w/dark text
Button design for “Data Disclaimer”:
- White fill w/dark text
- Orange outline

![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/9f216131-e215-425a-9a7d-cc8b6b60007f)
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/b81888d3-b2e9-4574-8da9-033acec48ad8)
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/6feac96e-6357-44b2-8933-1727cea9845b)

