### PR TITLE
feat: highlight qfaults on click, swap data to pgfeatureserv source, format popup

### DIFF
--- a/src/components/widgets/LayerlistAccordion.tsx
+++ b/src/components/widgets/LayerlistAccordion.tsx
@@ -2,8 +2,8 @@ import { useContext, useEffect, useState } from 'react';
 import { CalciteAccordion, CalciteAccordionItem } from '@esri/calcite-components-react';
 import { CalciteSliderCustomEvent } from "@esri/calcite-components";
 import { MapContext } from '../../contexts/MapProvider';
-import useLegendPreview from '../../hooks/useLegendPreview';
-import { RendererProps } from '../../config/types/mappingTypes';
+// import useLegendPreview from '../../hooks/useLegendPreview';
+// import { RendererProps } from '../../config/types/mappingTypes';
 import LayerControls from '../LayerControls';
 import { findLayerById } from '../../config/mapping';
 
@@ -11,7 +11,7 @@ interface LayerAccordionProps { layer: __esri.ListItem }
 
 const LayerAccordion = ({ layer }: LayerAccordionProps) => {
     const { id: layerId, title: layerTitle } = layer.layer;
-    const { activeLayers, getRenderer } = useContext(MapContext);
+    const { activeLayers } = useContext(MapContext);
     const [currentLayer, setCurrentLayer] = useState<__esri.ListItem>();
     const [layerVisibility, setLayerVisibility] = useState<boolean | undefined>();
     const [sublayerVisibility, setSublayerVisibility] = useState<Record<string, boolean>>({});
@@ -19,9 +19,9 @@ const LayerAccordion = ({ layer }: LayerAccordionProps) => {
     const typeNarrowedLayer = layer.layer as __esri.FeatureLayer | __esri.TileLayer | __esri.MapImageLayer | __esri.ImageryLayer;
 
     // this gets around a typescript error because getRenderer can be undefined
-    const defaultGetRenderer: (id: string, url?: string | undefined) => Promise<RendererProps | undefined> = () => Promise.resolve(undefined);
+    // const defaultGetRenderer: (id: string, url?: string | undefined) => Promise<RendererProps | undefined> = () => Promise.resolve(undefined);
 
-    const preview = useLegendPreview(layer.layer.id, typeNarrowedLayer.url, getRenderer || defaultGetRenderer);
+    // const preview = useLegendPreview(layer.layer.id, typeNarrowedLayer.url, getRenderer || defaultGetRenderer);
     useEffect(() => {
         if (activeLayers && layerId) {
             const foundLayer = findLayerById(activeLayers, layerId);

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -236,6 +236,22 @@ const qFaultsConfig: LayerProps = {
     },
 };
 
+const qFaultsFeatureLayerConfig: LayerProps = {
+    type: 'feature',
+    url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0',
+    options: {
+        title: 'Quaternary Faults',
+        elevationInfo: [{ mode: 'on-the-ground' }],
+        visible: true,
+        outFields: ['FaultName'],
+        popupTemplate: {
+            outFields: ['*'],
+            title: '<b>Quaternary Faults</b>',
+            content: poopTemplate,
+        },
+    },
+};
+
 const faultRuptureConfig: LayerProps = {
     type: 'feature',
     url: 'https://services.arcgis.com/ZzrwjTRez6FJiOq4/arcgis/rest/services/Utah_Earthquake_Hazards/FeatureServer/3',
@@ -1061,7 +1077,9 @@ const earthquakesConfig: LayerProps = {
     type: 'group',
     title: 'Earthquake Hazards',
     visible: true,
-    layers: [shakingVectorConfig, liquefactionConfig, faultRuptureConfig, qFaultsConfig],
+    // layers: [shakingVectorConfig, liquefactionConfig, faultRuptureConfig, qFaultsConfig],
+    layers: [qFaultsFeatureLayerConfig],
+    // layers: [qFaultsConfig]
 };
 
 const landslidesConfig: LayerProps = {
@@ -1072,13 +1090,13 @@ const landslidesConfig: LayerProps = {
 };
 
 const layersConfig: LayerProps[] = [
-    quadBoundariesConfig,
-    notMappedConfig,
-    hazardStudyConfig,
-    soilHazardsConfig,
-    landslidesConfig,
+    // quadBoundariesConfig,
+    // notMappedConfig,
+    // hazardStudyConfig,
+    // soilHazardsConfig,
+    // landslidesConfig,
     earthquakesConfig,
-    floodHazardsConfig,
+    // floodHazardsConfig,
 ];
 
 export default layersConfig;

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -211,49 +211,6 @@ const shakingRasterConfig: LayerProps = {
     },
 };
 
-// const qFaultsConfig: LayerProps = {
-//     type: 'map-image',
-//     url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer',
-//     options: {
-//         sublayers: [
-//             {
-//                 title: 'Quaternary_Faults',
-//                 id: 0,
-//                 visible: true,
-//                 popupTemplate: {
-//                     outFields: ['*'],
-//                     title: '<b>Hazardous (Quaternary age) Faults</b>',
-//                     content: poopTemplate,
-//                 },
-//             },
-//             {
-//                 title: 'Labels',
-//                 id: 1,
-//                 visible: true,
-//             },
-//         ],
-//         title: 'Hazardous (Quaternary age) Faults',
-//         listMode: 'hide-children',
-//         visible: true,
-//     },
-// };
-
-// const qFaultsFeatureLayerConfig: LayerProps = {
-//     type: 'feature',
-//     url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0',
-//     options: {
-//         title: 'Quaternary Faults',
-//         elevationInfo: [{ mode: 'on-the-ground' }],
-//         visible: true,
-//         outFields: ['FaultName'],
-//         popupTemplate: {
-//             outFields: ['*'],
-//             title: '<b>Quaternary Faults</b>',
-//             content: poopTemplate,
-//         },
-//     },
-// };
-
 const qFaultsGeoJsonConfig: LayerProps = {
     type: 'geojson',
     url: 'https://pgfeatureserv-souochdo6a-wm.a.run.app/collections/hazards.quaternaryfaults/items.json',

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -14,7 +14,8 @@ import {
     rendererBedrockPot,
     surfaceFaultRuptureRenderer,
     quadRenderer,
-    colorize
+    colorize,
+    qFaultsRenderer
 } from "./renderers";
 import { LayerProps } from "./types/mappingTypes";
 
@@ -249,6 +250,22 @@ const qFaultsFeatureLayerConfig: LayerProps = {
             title: '<b>Quaternary Faults</b>',
             content: poopTemplate,
         },
+    },
+};
+
+const qFaultsGeoJsonConfig: LayerProps = {
+    type: 'geojson',
+    url: 'https://pgfeatureserv-souochdo6a-wm.a.run.app/collections/hazards.quaternaryfaults/items.json',
+    options: {
+        title: 'Quaternary Faults',
+        elevationInfo: [{ mode: 'on-the-ground' }],
+        visible: true,
+        popupTemplate: {
+            title: '<b>Quaternary Faults</b>',
+            content: poopTemplate,
+        },
+        renderer: qFaultsRenderer,
+
     },
 };
 
@@ -1078,7 +1095,7 @@ const earthquakesConfig: LayerProps = {
     title: 'Earthquake Hazards',
     visible: true,
     // layers: [shakingVectorConfig, liquefactionConfig, faultRuptureConfig, qFaultsConfig],
-    layers: [qFaultsFeatureLayerConfig],
+    layers: [qFaultsGeoJsonConfig],
     // layers: [qFaultsConfig]
 };
 

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -966,7 +966,7 @@ const karstFeaturesConfig: LayerProps = {
 const soilHazardsConfig: LayerProps = {
     type: 'group',
     title: 'Problem Soil and Rock Hazards',
-    visible: false,
+    visible: true,
     layers: [eolianSusConfig, solubleSoilConfig, bedrockPotConfig, tectonicDefConfig, radonSusConfig, pipingSusConfig, karstFeaturesConfig, erosionZoneConfig, expansiveSoilConfig, earthFissureConfig, corrosiveSoilConfig, collapsibleSoilConfig, calicheConfig],
 };
 
@@ -1046,7 +1046,7 @@ const notMappedConfig: LayerProps = {
 const floodHazardsConfig: LayerProps = {
     type: 'group',
     title: 'Flooding Hazards',
-    visible: false,
+    visible: true,
     layers: [floodHazardConfig, groundwaterSusConfig],
 };
 
@@ -1060,7 +1060,7 @@ const earthquakesConfig: LayerProps = {
 const landslidesConfig: LayerProps = {
     type: 'group',
     title: 'Landslide Hazards',
-    visible: false,
+    visible: true,
     layers: [landslideCompConfig, landslideSusceptibilityConfig, landslideDepositConfig, rockfallHazConfig],
 };
 

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -216,11 +216,12 @@ const qFaultsGeoJsonConfig: LayerProps = {
     url: 'https://pgfeatureserv-souochdo6a-wm.a.run.app/collections/hazards.quaternaryfaults/items.json',
     options: {
         title: 'Quaternary Faults',
+        outFields: ['faultname', 'faultzone', 'faultclass', 'faultage', 'sliprate', 'dipdirection', 'slipsense', 'mappedscale', 'citation', 'usgs_link', 'summary'],
         elevationInfo: [{ mode: 'on-the-ground' }],
         visible: true,
         popupTemplate: {
             title: '<b>Hazardous (Quaternary age) Faults</b>',
-            content: "<b>Fault Name: </b>{faultname}<br><b>Structure Number: </b>{faultnum}<br><b>Mapped Scale: </b>{mappedscale}<br><b>Dip Direction: </b>{dipdirection}<br><b>Slip Sense: </b>{slipsense}<br><b>Slip Rate: </b>{sliprate}<br><b>Structure Class: </b>{faultclass}<br><b>Structure Age: </b>{faultage}<br><b>Detailed Report: </b><a href={usgs_link} target='_blank'>Opens in new tab</a>",
+            content: qfaultsPopup,
         },
         renderer: qFaultsRenderer,
 

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -218,7 +218,7 @@ const qFaultsGeoJsonConfig: LayerProps = {
         title: 'Quaternary Faults',
         outFields: ['faultname', 'faultzone', 'faultclass', 'faultage', 'sliprate', 'dipdirection', 'slipsense', 'mappedscale', 'citation', 'usgs_link', 'summary'],
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: false,
+        visible: true,
         popupTemplate: {
             title: '<b>Hazardous (Quaternary age) Faults</b>',
             content: qfaultsPopup,

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -218,7 +218,7 @@ const qFaultsGeoJsonConfig: LayerProps = {
         title: 'Quaternary Faults',
         outFields: ['faultname', 'faultzone', 'faultclass', 'faultage', 'sliprate', 'dipdirection', 'slipsense', 'mappedscale', 'citation', 'usgs_link', 'summary'],
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         popupTemplate: {
             title: '<b>Hazardous (Quaternary age) Faults</b>',
             content: qfaultsPopup,
@@ -1000,6 +1000,7 @@ const hazardStudyConfig: LayerProps = {
     type: 'feature',
     url: 'https://services.arcgis.com/ZzrwjTRez6FJiOq4/arcgis/rest/services/Utah_Geologic_Hazards_Supplemental_Data_View/FeatureServer/1',
     options: {
+        visible: true,
         title: 'Mapped Areas',
         elevationInfo: [{ mode: 'on-the-ground' }],
         outFields: ['*'],
@@ -1038,7 +1039,7 @@ const notMappedConfig: LayerProps = {
     options: {
         title: 'Areas Not Mapped within Project Areas',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: false,
+        visible: true,
     },
 };
 

--- a/src/config/layers.ts
+++ b/src/config/layers.ts
@@ -4,7 +4,8 @@ import {
     epicentersPopup,
     miningepicentersPopup,
     poopTemplate,
-    studyAreasPopup
+    studyAreasPopup,
+    qfaultsPopup
 } from "./popups";
 
 import {
@@ -26,7 +27,7 @@ const landslideCompConfig: LayerProps = {
     options: {
         title: 'Legacy Landslide Compilation',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>Legacy Landslide Compilation</b>',
@@ -43,7 +44,7 @@ const landslideDepositConfig: LayerProps = {
     options: {
         title: 'Landslides',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>Landslides</b>',
@@ -59,7 +60,7 @@ const landslideSusceptibilityConfig: LayerProps = {
     options: {
         title: 'Landslide Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>Landslide Susceptibility</b>',
@@ -101,7 +102,7 @@ const epicentersRecentConfig: LayerProps & { featureReduction: object } = {
     options: {
         title: 'Epicenters (1850 to 2016)',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>Earthquake Epicenter Information</b>',
@@ -127,7 +128,7 @@ const epicentersMiningConfig: LayerProps = {
     options: {
         title: 'Mining-Induced Epicenters',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: 'Mining-Induced Epicenters',
@@ -146,7 +147,7 @@ const liquefactionConfig: LayerProps = {
         title: 'Liquefaction Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
         renderer: rendererLiquefaction,
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>Liquefaction Susceptibility</b>',
@@ -189,7 +190,7 @@ const shakingVectorConfig: LayerProps = {
     options: {
         title: 'Earthquake Ground Shaking',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
     },
 };
 
@@ -197,7 +198,7 @@ const shakingRasterConfig: LayerProps = {
     type: 'imagery',
     url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/GroundshakingRaster/ImageServer',
     options: {
-        visible: true,
+        visible: false,
         legendEnabled: false,
         listMode: 'hide',
         title: 'Shaking Raster',
@@ -210,48 +211,48 @@ const shakingRasterConfig: LayerProps = {
     },
 };
 
-const qFaultsConfig: LayerProps = {
-    type: 'map-image',
-    url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer',
-    options: {
-        sublayers: [
-            {
-                title: 'Quaternary_Faults',
-                id: 0,
-                visible: true,
-                popupTemplate: {
-                    outFields: ['*'],
-                    title: '<b>Hazardous (Quaternary age) Faults</b>',
-                    content: poopTemplate,
-                },
-            },
-            {
-                title: 'Labels',
-                id: 1,
-                visible: true,
-            },
-        ],
-        title: 'Hazardous (Quaternary age) Faults',
-        listMode: 'hide-children',
-        visible: true,
-    },
-};
+// const qFaultsConfig: LayerProps = {
+//     type: 'map-image',
+//     url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer',
+//     options: {
+//         sublayers: [
+//             {
+//                 title: 'Quaternary_Faults',
+//                 id: 0,
+//                 visible: true,
+//                 popupTemplate: {
+//                     outFields: ['*'],
+//                     title: '<b>Hazardous (Quaternary age) Faults</b>',
+//                     content: poopTemplate,
+//                 },
+//             },
+//             {
+//                 title: 'Labels',
+//                 id: 1,
+//                 visible: true,
+//             },
+//         ],
+//         title: 'Hazardous (Quaternary age) Faults',
+//         listMode: 'hide-children',
+//         visible: true,
+//     },
+// };
 
-const qFaultsFeatureLayerConfig: LayerProps = {
-    type: 'feature',
-    url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0',
-    options: {
-        title: 'Quaternary Faults',
-        elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
-        outFields: ['FaultName'],
-        popupTemplate: {
-            outFields: ['*'],
-            title: '<b>Quaternary Faults</b>',
-            content: poopTemplate,
-        },
-    },
-};
+// const qFaultsFeatureLayerConfig: LayerProps = {
+//     type: 'feature',
+//     url: 'https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0',
+//     options: {
+//         title: 'Quaternary Faults',
+//         elevationInfo: [{ mode: 'on-the-ground' }],
+//         visible: true,
+//         outFields: ['FaultName'],
+//         popupTemplate: {
+//             outFields: ['*'],
+//             title: '<b>Quaternary Faults</b>',
+//             content: poopTemplate,
+//         },
+//     },
+// };
 
 const qFaultsGeoJsonConfig: LayerProps = {
     type: 'geojson',
@@ -261,8 +262,8 @@ const qFaultsGeoJsonConfig: LayerProps = {
         elevationInfo: [{ mode: 'on-the-ground' }],
         visible: true,
         popupTemplate: {
-            title: '<b>Quaternary Faults</b>',
-            content: poopTemplate,
+            title: '<b>Hazardous (Quaternary age) Faults</b>',
+            content: "<b>Fault Name: </b>{faultname}<br><b>Structure Number: </b>{faultnum}<br><b>Mapped Scale: </b>{mappedscale}<br><b>Dip Direction: </b>{dipdirection}<br><b>Slip Sense: </b>{slipsense}<br><b>Slip Rate: </b>{sliprate}<br><b>Structure Class: </b>{faultclass}<br><b>Structure Age: </b>{faultage}<br><b>Detailed Report: </b><a href={usgs_link} target='_blank'>Opens in new tab</a>",
         },
         renderer: qFaultsRenderer,
 
@@ -276,7 +277,7 @@ const faultRuptureConfig: LayerProps = {
         title: 'Surface Fault Rupture Special Study Zones',
         renderer: surfaceFaultRuptureRenderer,
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/1/HazardName}</b>',
@@ -316,7 +317,7 @@ const eolianSusConfig: LayerProps = {
     options: {
         title: 'Wind-Blown Sand Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>Wind-Blown Sand Susceptibility</b>',
@@ -354,7 +355,7 @@ const tectonicDefConfig: LayerProps = {
     options: {
         title: 'Salt Tectonics-Related Ground Deformation',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/14/HazardName}</b>',
@@ -400,7 +401,7 @@ const bedrockPotConfig: LayerProps = {
         title: 'Shallow Bedrock Potential',
         elevationInfo: [{ mode: 'on-the-ground' }],
         renderer: rendererBedrockPot,
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/15/HazardName}</b>',
@@ -445,7 +446,7 @@ const rockfallHazConfig: LayerProps = {
     options: {
         title: 'Rockfall Hazard',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/13/HazardName}</b>',
@@ -490,7 +491,7 @@ const pipingSusConfig: LayerProps = {
     options: {
         title: 'Piping and Erosion Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/11/HazardName}</b>',
@@ -530,7 +531,7 @@ const expansiveSoilConfig: LayerProps = {
     options: {
         title: 'Expansive Soil and Rock Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/9/HazardName}</b>',
@@ -570,7 +571,7 @@ const groundwaterSusConfig: LayerProps = {
     options: {
         title: 'Shallow Groundwater Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/1/HazardName}</b>',
@@ -610,7 +611,7 @@ const radonSusConfig: LayerProps = {
     options: {
         title: 'Geologic Radon Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/12/HazardName}</b>',
@@ -650,7 +651,7 @@ const corrosiveSoilConfig: LayerProps = {
     options: {
         title: 'Corrosive Soil and Rock Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/6/HazardName}</b>',
@@ -690,7 +691,7 @@ const collapsibleSoilConfig: LayerProps = {
     options: {
         title: 'Collapsible Soil Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/5/HazardName}</b>',
@@ -730,7 +731,7 @@ const solubleSoilConfig: LayerProps = {
     options: {
         title: 'Soluble Soil and Rock Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/16/HazardName}</b>',
@@ -770,7 +771,7 @@ const calicheConfig: LayerProps = {
     options: {
         title: 'Caliche Susceptibility',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/4/HazardName}</b>',
@@ -810,7 +811,7 @@ const floodHazardConfig: LayerProps = {
     options: {
         title: 'Flood and Debris-Flow Hazard',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/0/HazardName}</b>',
@@ -850,7 +851,7 @@ const earthFissureConfig: LayerProps = {
     options: {
         title: 'Earth Fissure Hazard',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/7/HazardName}</b>',
@@ -890,7 +891,7 @@ const erosionZoneConfig: LayerProps = {
     options: {
         title: 'J.E. Fuller Flood Erosion Hazard Zones',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/8/HazardName}</b>',
@@ -930,7 +931,7 @@ const groundSubsidenceConfig: LayerProps = {
     options: {
         title: 'Ground Subsidence Potential',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/5/HazardName}</b>',
@@ -970,7 +971,7 @@ const karstFeaturesConfig: LayerProps = {
     options: {
         title: 'Karst Features',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         outFields: ['*'],
         popupTemplate: {
             title: '<b>{relationships/10/HazardName}</b>',
@@ -1007,7 +1008,7 @@ const karstFeaturesConfig: LayerProps = {
 const soilHazardsConfig: LayerProps = {
     type: 'group',
     title: 'Problem Soil and Rock Hazards',
-    visible: true,
+    visible: false,
     layers: [eolianSusConfig, solubleSoilConfig, bedrockPotConfig, tectonicDefConfig, radonSusConfig, pipingSusConfig, karstFeaturesConfig, erosionZoneConfig, expansiveSoilConfig, earthFissureConfig, corrosiveSoilConfig, collapsibleSoilConfig, calicheConfig],
 };
 
@@ -1033,7 +1034,7 @@ const quadBoundariesConfig: LayerProps = {
             },
         },
         renderer: quadRenderer,
-        visible: true,
+        visible: false,
     },
 };
 
@@ -1058,7 +1059,7 @@ const lidarBoundsConfig: LayerProps = {
     options: {
         title: 'Lidar Extents',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
     },
 };
 
@@ -1068,7 +1069,7 @@ const airphotoPointsConfig: LayerProps = {
     options: {
         title: 'Aerial Imagery Centerpoints',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
         minScale: 500000,
     },
 };
@@ -1079,14 +1080,14 @@ const notMappedConfig: LayerProps = {
     options: {
         title: 'Areas Not Mapped within Project Areas',
         elevationInfo: [{ mode: 'on-the-ground' }],
-        visible: true,
+        visible: false,
     },
 };
 
 const floodHazardsConfig: LayerProps = {
     type: 'group',
     title: 'Flooding Hazards',
-    visible: true,
+    visible: false,
     layers: [floodHazardConfig, groundwaterSusConfig],
 };
 
@@ -1094,26 +1095,24 @@ const earthquakesConfig: LayerProps = {
     type: 'group',
     title: 'Earthquake Hazards',
     visible: true,
-    // layers: [shakingVectorConfig, liquefactionConfig, faultRuptureConfig, qFaultsConfig],
-    layers: [qFaultsGeoJsonConfig],
-    // layers: [qFaultsConfig]
+    layers: [shakingVectorConfig, liquefactionConfig, faultRuptureConfig, qFaultsGeoJsonConfig],
 };
 
 const landslidesConfig: LayerProps = {
     type: 'group',
     title: 'Landslide Hazards',
-    visible: true,
+    visible: false,
     layers: [landslideCompConfig, landslideSusceptibilityConfig, landslideDepositConfig, rockfallHazConfig],
 };
 
 const layersConfig: LayerProps[] = [
-    // quadBoundariesConfig,
-    // notMappedConfig,
-    // hazardStudyConfig,
-    // soilHazardsConfig,
-    // landslidesConfig,
+    quadBoundariesConfig,
+    notMappedConfig,
+    hazardStudyConfig,
+    soilHazardsConfig,
+    landslidesConfig,
     earthquakesConfig,
-    // floodHazardsConfig,
+    floodHazardsConfig,
 ];
 
 export default layersConfig;

--- a/src/config/popups.ts
+++ b/src/config/popups.ts
@@ -77,22 +77,59 @@ const miningepicentersPopup = function (feature: any) {
 }
 
 // qfaultspopup template
-const qfaultsPopup = function () {
-    let content = ""
+const qfaultsPopup = function (event: any) {
+    const div = document.createElement("div");
 
-    content += "<b>Fault Name: </b>{faultname}<br>";
-    content += "<b>Structure Number: </b>{faultnum}<br>";
-    content += "<b>Mapped Scale: </b>{mappedscale}<br>";
-    content += "<b>Dip Direction: </b>{dipdirection}<br>";
-    content += "<b>Slip Sense: </b>{slipsense}<br>";
-    content += "<b>Slip Rate: </b>{sliprate}<br>";
-    content += "<b>Structure Class: </b>{faultclass}<br>";
-    content += "<b>Structure Age: </b>{faultage}<br>";
-    content += "<b>Detailed Report: </b><a href={usgs_link} target='_blank'>Opens in new tab</a>";
+    if (event.graphic.attributes.faultzone) {
+        div.innerHTML += `
+            <span><b>Fault Zone: </b></span>
+            <calcite-link id="faultzone-tooltip">${event.graphic.attributes.faultzone}</calcite-link>
+            <calcite-tooltip label="Data disclaimer" reference-element="faultzone-tooltip">
+                <span>${event.graphic.attributes.summary}</span>
+            </calcite-tooltip>
+            <br>
+        `;
+    }
+    if (event.graphic.attributes.faultname) {
+        div.innerHTML += `<b>Fault Name: </b>${event.graphic.attributes.faultname}<br>`;
+    }
+    if (event.graphic.attributes.sectionname) {
+        div.innerHTML += `<b>Section Name: </b>${event.graphic.attributes.sectionname}<br>`;
+    }
+    if (event.graphic.attributes.strandname) {
+        div.innerHTML += `<b>Strand Name: </b>${event.graphic.attributes.strandname}<br>`;
+    }
+    if (event.graphic.attributes.faultnum) {
+        div.innerHTML += `<b>Structure Number: </b>${event.graphic.attributes.faultnum}<br>`;
+    }
+    if (event.graphic.attributes.mappedscale) {
+        div.innerHTML += `<b>Mapped Scale: </b>${event.graphic.attributes.mappedscale}<br>`;
+    }
+    if (event.graphic.attributes.dipdirection) {
+        div.innerHTML += `<b>Dip Direction: </b>${event.graphic.attributes.dipdirection}<br>`;
+    }
+    if (event.graphic.attributes.slipsense) {
+        div.innerHTML += `<b>Slip Sense: </b>${event.graphic.attributes.slipsense}<br>`;
+    }
+    if (event.graphic.attributes.sliprate) {
+        div.innerHTML += `<b>Slip Rate: </b>${event.graphic.attributes.sliprate}<br>`;
+    }
+    if (event.graphic.attributes.faultclass) {
+        div.innerHTML += `<b>Structure Class: </b>${event.graphic.attributes.faultclass}<br>`;
+    }
+    if (event.graphic.attributes.faultage) {
+        div.innerHTML += `<b>Structure Age: </b>${event.graphic.attributes.faultage}<br>`;
+    }
+    if (event.graphic.attributes.usgs_link) {
+        div.innerHTML += `
+            <span><b>Detailed Report: </b></span>
+            <calcite-link href=${event.graphic.attributes.usgs_link} icon-end="launch" target="_blank">
+                Opens in new tab
+            </calcite-link>
+        `;
+    }
 
-
-
-    return content;
+    return div;
 }
 
 //qfaults popup code

--- a/src/config/popups.ts
+++ b/src/config/popups.ts
@@ -76,6 +76,25 @@ const miningepicentersPopup = function (feature: any) {
     return content;
 }
 
+// qfaultspopup template
+const qfaultsPopup = function () {
+    let content = ""
+
+    content += "<b>Fault Name: </b>{faultname}<br>";
+    content += "<b>Structure Number: </b>{faultnum}<br>";
+    content += "<b>Mapped Scale: </b>{mappedscale}<br>";
+    content += "<b>Dip Direction: </b>{dipdirection}<br>";
+    content += "<b>Slip Sense: </b>{slipsense}<br>";
+    content += "<b>Slip Rate: </b>{sliprate}<br>";
+    content += "<b>Structure Class: </b>{faultclass}<br>";
+    content += "<b>Structure Age: </b>{faultage}<br>";
+    content += "<b>Detailed Report: </b><a href={usgs_link} target='_blank'>Opens in new tab</a>";
+
+
+
+    return content;
+}
+
 //qfaults popup code
 const poopTemplate =
     (event: any) => {
@@ -482,4 +501,4 @@ const landslideCompPopup = function (feature: any) {
     return content;
 }
 
-export { studyAreasPopup, epicentersPopup, miningepicentersPopup, poopTemplate, fchPopup, lssPopup, landslideSourcePopup, landslideDepositPopup, landslideCompPopup };
+export { studyAreasPopup, epicentersPopup, miningepicentersPopup, poopTemplate, fchPopup, lssPopup, landslideSourcePopup, landslideDepositPopup, landslideCompPopup, qfaultsPopup };

--- a/src/config/renderers.ts
+++ b/src/config/renderers.ts
@@ -316,9 +316,9 @@ const qFaultsRenderer = new UniqueValueRenderer({
             valueExpression: "$view.scale",
             // target: "outline",
             stops: [
-                { value: 10000, size: 10 },
-                { value: 250000, size: 6 },
-                { value: 1000000, size: 3 },
+                { value: 10000, size: 20 },
+                { value: 250000, size: 15 },
+                { value: 1000000, size: 5 },
                 { value: 3000000, size: 1.5 },
             ]
         } as __esri.SizeVariable

--- a/src/config/renderers.ts
+++ b/src/config/renderers.ts
@@ -314,12 +314,17 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             type: "size",
             valueExpression: "$view.scale",
+            legendOptions: {
+                showLegend: false
+            },
             // target: "outline",
             stops: [
-                { value: 10000, size: 20 },
-                { value: 250000, size: 15 },
-                { value: 1000000, size: 5 },
-                { value: 3000000, size: 1.5 },
+                { value: 5000, size: 17 },
+                { value: 20000, size: 8 },
+                { value: 50000, size: 4 },
+                { value: 250000, size: 1.5 },
+                { value: 1000000, size: 1 },
+                { value: 3000000, size: .25 },
             ]
         } as __esri.SizeVariable
     ],
@@ -362,7 +367,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<15,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "short-dash",
+                style: "short-dot",
                 color: new Color([230, 152, 0, 255]),
                 width: 1
             }),
@@ -389,7 +394,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<130,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "short-dash",
+                style: "short-dot",
                 color: new Color([76, 230, 0, 255]),
                 width: 1
             }),
@@ -416,7 +421,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<750,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "short-dash",
+                style: "short-dot",
                 color: new Color([0, 92, 230, 255]),
                 width: 1
             }),
@@ -443,7 +448,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<2,600,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "dash",
+                style: "short-dot",
                 color: new Color([0, 0, 0, 255]),
                 width: 1
             }),
@@ -470,7 +475,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "undetermined;inferred",
             symbol: new SimpleLineSymbol({
-                style: "short-dash",
+                style: "short-dot",
                 color: new Color([169, 0, 230, 255]),
                 width: 1
             }),

--- a/src/config/renderers.ts
+++ b/src/config/renderers.ts
@@ -310,6 +310,19 @@ const quadRenderer = {
 }
 
 const qFaultsRenderer = new UniqueValueRenderer({
+    visualVariables: [
+        {
+            type: "size",
+            valueExpression: "$view.scale",
+            // target: "outline",
+            stops: [
+                { value: 10000, size: 10 },
+                { value: 250000, size: 6 },
+                { value: 1000000, size: 3 },
+                { value: 3000000, size: 1.5 },
+            ]
+        } as __esri.SizeVariable
+    ],
     field: "FaultAge",
     field2: "MappingConstraint",
     fieldDelimiter: ";",

--- a/src/config/renderers.ts
+++ b/src/config/renderers.ts
@@ -340,7 +340,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<15,000;moderately constrained",
             symbol: new SimpleLineSymbol({
-                style: "solid",
+                style: "long-dash",
                 color: new Color([230, 152, 0, 255]),
                 width: 1
             }),
@@ -349,7 +349,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<15,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "dash",
+                style: "short-dash",
                 color: new Color([230, 152, 0, 255]),
                 width: 1
             }),
@@ -367,7 +367,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<130,000;moderately constrained",
             symbol: new SimpleLineSymbol({
-                style: "solid",
+                style: "long-dash",
                 color: new Color([76, 230, 0, 255]),
                 width: 1
             }),
@@ -376,7 +376,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<130,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "dash",
+                style: "short-dash",
                 color: new Color([76, 230, 0, 255]),
                 width: 1
             }),
@@ -394,7 +394,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<750,000;moderately constrained",
             symbol: new SimpleLineSymbol({
-                style: "solid",
+                style: "long-dash",
                 color: new Color([0, 92, 230, 255]),
                 width: 1
             }),
@@ -403,7 +403,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<750,000;inferred",
             symbol: new SimpleLineSymbol({
-                style: "dash",
+                style: "short-dash",
                 color: new Color([0, 92, 230, 255]),
                 width: 1
             }),
@@ -421,7 +421,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "<2,600,000;moderately constrained",
             symbol: new SimpleLineSymbol({
-                style: "solid",
+                style: "long-dash",
                 color: new Color([0, 0, 0, 255]),
                 width: 1
             }),
@@ -439,7 +439,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "undetermined;well constrained",
             symbol: new SimpleLineSymbol({
-                style: "solid",
+                style: "short-dash",
                 color: new Color([169, 0, 230, 255]),
                 width: 1
             }),
@@ -448,7 +448,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "undetermined;moderately constrained",
             symbol: new SimpleLineSymbol({
-                style: "solid",
+                style: "long-dash",
                 color: new Color([169, 0, 230, 255]),
                 width: 1
             }),
@@ -457,7 +457,7 @@ const qFaultsRenderer = new UniqueValueRenderer({
         {
             value: "undetermined;inferred",
             symbol: new SimpleLineSymbol({
-                style: "dash",
+                style: "short-dash",
                 color: new Color([169, 0, 230, 255]),
                 width: 1
             }),

--- a/src/config/renderers.ts
+++ b/src/config/renderers.ts
@@ -1,3 +1,7 @@
+import Color from "@arcgis/core/Color";
+import SimpleLineSymbol from "@arcgis/core/symbols/SimpleLineSymbol";
+import UniqueValueRenderer from "@arcgis/core/renderers/UniqueValueRenderer.js";
+
 const recentSym = {
     type: "simple-marker", // autocasts as new SimpleMarkerSymbol()
     color: "red",
@@ -305,4 +309,161 @@ const quadRenderer = {
     }
 }
 
-export { rendererRecent, rendererMining, rendererLiquefaction, colorize, surfaceFaultRuptureRenderer, rendererBedrockPot, quadRenderer };
+const qFaultsRenderer = new UniqueValueRenderer({
+    field: "FaultAge",
+    field2: "MappingConstraint",
+    fieldDelimiter: ";",
+    defaultSymbol: new SimpleLineSymbol({
+        style: "solid",
+        color: new Color([130, 130, 130, 255]),
+        width: 1
+    }),
+    uniqueValueInfos: [
+        {
+            value: "<150;well constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([230, 0, 0, 255]),
+                width: 1
+            }),
+            label: "<150 Years, Well Constrained"
+        },
+        {
+            value: "<15,000;well constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([230, 152, 0, 255]),
+                width: 1
+            }),
+            label: "<15,000 Years, Well Constrained"
+        },
+        {
+            value: "<15,000;moderately constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([230, 152, 0, 255]),
+                width: 1
+            }),
+            label: "<15,000 Years, Moderately Constrained"
+        },
+        {
+            value: "<15,000;inferred",
+            symbol: new SimpleLineSymbol({
+                style: "dash",
+                color: new Color([230, 152, 0, 255]),
+                width: 1
+            }),
+            label: "<15,000 Years, Inferred"
+        },
+        {
+            value: "<130,000;well constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([76, 230, 0, 255]),
+                width: 1
+            }),
+            label: "<130,000 Years, Well Constrained"
+        },
+        {
+            value: "<130,000;moderately constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([76, 230, 0, 255]),
+                width: 1
+            }),
+            label: "<130,000 Years, Moderately Constrained"
+        },
+        {
+            value: "<130,000;inferred",
+            symbol: new SimpleLineSymbol({
+                style: "dash",
+                color: new Color([76, 230, 0, 255]),
+                width: 1
+            }),
+            label: "<130,000 Years, Inferred"
+        },
+        {
+            value: "<750,000;well constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([0, 92, 230, 255]),
+                width: 1
+            }),
+            label: "<750,000 Years, Well Constrained"
+        },
+        {
+            value: "<750,000;moderately constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([0, 92, 230, 255]),
+                width: 1
+            }),
+            label: "<750,000 Years, Moderately Constrained"
+        },
+        {
+            value: "<750,000;inferred",
+            symbol: new SimpleLineSymbol({
+                style: "dash",
+                color: new Color([0, 92, 230, 255]),
+                width: 1
+            }),
+            label: "<750,000 Years, Inferred"
+        },
+        {
+            value: "<2,600,000;well constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([0, 0, 0, 255]),
+                width: 1
+            }),
+            label: "<2.6 Million Years, Well Constrained"
+        },
+        {
+            value: "<2,600,000;moderately constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([0, 0, 0, 255]),
+                width: 1
+            }),
+            label: "<2.6 Million Years, Moderately Constrained"
+        },
+        {
+            value: "<2,600,000;inferred",
+            symbol: new SimpleLineSymbol({
+                style: "dash",
+                color: new Color([0, 0, 0, 255]),
+                width: 1
+            }),
+            label: "<2.6 Million Years, Inferred"
+        },
+        {
+            value: "undetermined;well constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([169, 0, 230, 255]),
+                width: 1
+            }),
+            label: "Undetermined, Well Constrained"
+        },
+        {
+            value: "undetermined;moderately constrained",
+            symbol: new SimpleLineSymbol({
+                style: "solid",
+                color: new Color([169, 0, 230, 255]),
+                width: 1
+            }),
+            label: "Undetermined, Moderately Constrained"
+        },
+        {
+            value: "undetermined;inferred",
+            symbol: new SimpleLineSymbol({
+                style: "dash",
+                color: new Color([169, 0, 230, 255]),
+                width: 1
+            }),
+            label: "Undetermined, Inferred"
+        }
+    ]
+});
+
+export { rendererRecent, rendererMining, rendererLiquefaction, colorize, surfaceFaultRuptureRenderer, rendererBedrockPot, quadRenderer, qFaultsRenderer };

--- a/src/config/types/mappingTypes.ts
+++ b/src/config/types/mappingTypes.ts
@@ -1,4 +1,5 @@
 import FeatureLayer from "@arcgis/core/layers/FeatureLayer"
+import GeoJSONLayer from "@arcgis/core/layers/GeoJSONLayer"
 import GroupLayer from "@arcgis/core/layers/GroupLayer"
 import ImageryLayer from "@arcgis/core/layers/ImageryLayer"
 import MapImageLayer from "@arcgis/core/layers/MapImageLayer"
@@ -6,7 +7,7 @@ import TileLayer from "@arcgis/core/layers/TileLayer"
 import MapView from "@arcgis/core/views/MapView"
 import SceneView from "@arcgis/core/views/SceneView"
 
-export type LayerType = 'feature' | 'tile' | 'map-image' | 'imagery' | 'group'
+export type LayerType = 'feature' | 'tile' | 'map-image' | 'imagery' | 'group' | 'geojson'
 export interface LayerProps {
     type: LayerType
     url?: string
@@ -23,6 +24,7 @@ export const layerTypeMapping = {
     'map-image': MapImageLayer,
     'imagery': ImageryLayer,
     'group': GroupLayer,
+    'geojson': GeoJSONLayer
     // Add other layer types here
 };
 

--- a/src/config/util/mappingUtils.ts
+++ b/src/config/util/mappingUtils.ts
@@ -12,6 +12,7 @@ import Color from "@arcgis/core/Color";
 import BasemapGallery from "@arcgis/core/widgets/BasemapGallery";
 import Expand from "@arcgis/core/widgets/Expand";
 import Popup from "@arcgis/core/widgets/Popup";
+import GeoJSONLayer from "@arcgis/core/layers/GeoJSONLayer";
 
 
 // Create a new map
@@ -83,7 +84,7 @@ function createLayerFromUrl(layer: LayerProps, LayerType: any) {
     if (layer.type === 'group') {
         if (layer.layers) {
             // Create an array of group layers by mapping the layers and filtering out any undefined elements
-            const groupedLayers = layer.layers.map(createLayer).filter(layer => layer !== undefined) as (FeatureLayer | TileLayer | GroupLayer | MapImageLayer)[];
+            const groupedLayers = layer.layers.map(createLayer).filter(layer => layer !== undefined) as (FeatureLayer | TileLayer | GroupLayer | MapImageLayer | GeoJSONLayer)[];
             return groupedLayers;
         }
     }
@@ -94,10 +95,10 @@ function createLayerFromUrl(layer: LayerProps, LayerType: any) {
 }
 
 // Create a layer based on the layer props
-export const createLayer = (layer: LayerProps): FeatureLayer | TileLayer | GroupLayer | MapImageLayer | undefined => {
+export const createLayer = (layer: LayerProps): FeatureLayer | TileLayer | GroupLayer | MapImageLayer | GeoJSONLayer | undefined => {
     // Handle the special case for group layers
     if (layer.type === 'group' && layer.layers) {
-        const groupLayers = layer.layers.map(createLayer).filter(layer => layer !== undefined) as (FeatureLayer | TileLayer | GroupLayer | MapImageLayer)[];
+        const groupLayers = layer.layers.map(createLayer).filter(layer => layer !== undefined) as (FeatureLayer | TileLayer | GroupLayer | MapImageLayer | GeoJSONLayer)[];
         return new GroupLayer({
             title: layer.title,
             visible: layer.visible,

--- a/src/contexts/MapProvider.tsx
+++ b/src/contexts/MapProvider.tsx
@@ -64,7 +64,7 @@ export function MapProvider({ children }: { children: React.ReactNode }) {
     async function loadMap(container: HTMLDivElement) {
         if (view) return;
         const { init } = await import("../config/mapping")
-        setView(init(container, isMobile, 'scene'))
+        setView(init(container, isMobile, 'map'))
     }
 
     async function getRenderer(id: string, url: string): Promise<RendererProps | undefined> {

--- a/src/hooks/useArcGISWidget.tsx
+++ b/src/hooks/useArcGISWidget.tsx
@@ -60,6 +60,8 @@ function useArcGISWidget(widgets: ArcGISWidgetProps[]) {
                     x: view.center.longitude.toFixed(3),
                     y: view.center.latitude.toFixed(3)
                 }
+                console.log('view.scale', view.scale);
+
                 updatePopupTemplate({ widget, xyPoint, scale: view.scale });
             });
 


### PR DESCRIPTION
use [qfaults pgfeatureserv](https://pgfeatureserv-souochdo6a-wm.a.run.app/collections/hazards.quaternaryfaults) json output instead of [arcgis rest service](https://webmaps.geology.utah.gov/arcgis/rest/services/Hazards/quaternary_faults_with_labels/MapServer/0)

Clicking features highlights the features and opens popup
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/a0c35169-2ea9-485f-9d9c-a24c070fb04d)

Searching and selecting a result from the Faults search bar and then selecting features with a mouse click preserves the search highlight and adds the click highlight
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/5b48fa84-81b3-4424-bd4b-cce1f654d2b6)

There is a tooltip that replaces the modal in the legacy app
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/94c884a4-8500-4082-8323-ba6d05c39224)

Match visible layers to legacy app
![image](https://github.com/UGS-GIO/geohaz-v2/assets/24685932/791135f9-3cac-4225-8248-e116e2210d48)
