### PR TITLE
feat: remove the layer controls panel title

### DIFF
--- a/src/components/SidebarComponents/Layers.tsx
+++ b/src/components/SidebarComponents/Layers.tsx
@@ -1,6 +1,3 @@
-import {
-  CalciteBlock,
-} from '@esri/calcite-components-react';
 import useCustomLayerList from '../../hooks/useCustomLayerList';
 
 function Layers() {
@@ -12,7 +9,6 @@ function Layers() {
 
   return (
     <div>
-      <CalciteBlock heading='Layer List and Controls' className='mb-1' />
       {layerList}
     </div>
   );


### PR DESCRIPTION
Here is the title to remove
<img width="435" alt="image" src="https://github.com/UGS-GIO/geohaz-v2/assets/24685932/097f8820-6b70-4cee-8191-fcf5c98adb4a">


Heading removed
<img width="483" alt="image" src="https://github.com/UGS-GIO/geohaz-v2/assets/24685932/f07a2c7c-db7d-48a9-92d2-1bd3efe0d3b7">
