### PR TITLE
feat(common): PLSS township/range and sections SLD styles

### DIFF
--- a/sld/plss-sections.sld
+++ b/sld/plss-sections.sld
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>PLSS Sections</Name>
+    <UserStyle>
+      <Title>PLSS Sections</Title>
+      <!-- Source: BLM_Natl_PLSS_CadNSDI/MapServer/2 -->
+      <!-- FRSTDIVLAB label field, visible from 1:250,000 in -->
+      <FeatureTypeStyle>
+        <Rule>
+          <MaxScaleDenominator>250000</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill-opacity">0</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#FF7F7F</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>FRSTDIVLAB</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">8</CssParameter>
+              <CssParameter name="font-style">normal</CssParameter>
+              <CssParameter name="font-weight">normal</CssParameter>
+            </Font>
+            <LabelPlacement>
+              <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>0.5</AnchorPointX>
+                  <AnchorPointY>0.5</AnchorPointY>
+                </AnchorPoint>
+              </PointPlacement>
+            </LabelPlacement>
+            <Fill>
+              <CssParameter name="fill">#FF7F7F</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/sld/plss-sections.sld
+++ b/sld/plss-sections.sld
@@ -19,7 +19,7 @@
               <CssParameter name="fill-opacity">0</CssParameter>
             </Fill>
             <Stroke>
-              <CssParameter name="stroke">#FF7F7F</CssParameter>
+              <CssParameter name="stroke">#000000</CssParameter>
               <CssParameter name="stroke-width">1</CssParameter>
             </Stroke>
           </PolygonSymbolizer>
@@ -42,7 +42,7 @@
               </PointPlacement>
             </LabelPlacement>
             <Fill>
-              <CssParameter name="fill">#FF7F7F</CssParameter>
+              <CssParameter name="fill">#000000</CssParameter>
             </Fill>
           </TextSymbolizer>
         </Rule>

--- a/sld/township-range.sld
+++ b/sld/township-range.sld
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Township and Range</Name>
+    <UserStyle>
+      <Title>Township and Range</Title>
+      <!-- Source: ArcGIS Core_Locations_Supporting_Data/FeatureServer/3 -->
+      <!-- TWNSHPLAB label field, visible to 1:500,000 -->
+      <FeatureTypeStyle>
+        <Rule>
+          <MaxScaleDenominator>500000</MaxScaleDenominator>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill-opacity">0</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#FF0000</CssParameter>
+              <CssParameter name="stroke-width">1</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>TWNSHPLAB</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">8</CssParameter>
+              <CssParameter name="font-style">italic</CssParameter>
+              <CssParameter name="font-weight">bold</CssParameter>
+            </Font>
+            <LabelPlacement>
+              <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>0.5</AnchorPointX>
+                  <AnchorPointY>0.5</AnchorPointY>
+                </AnchorPoint>
+              </PointPlacement>
+            </LabelPlacement>
+            <Fill>
+              <CssParameter name="fill">#E60000</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/sld/ucrc-basins.sld
+++ b/sld/ucrc-basins.sld
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>UCRC Basins</Name>
+    <UserStyle>
+      <Title>UCRC Basins</Title>
+      <!-- Source: ArcGIS Core_Locations_Supporting_Data/FeatureServer/0 -->
+      <!-- Unique value renderer on Label field — Paradox purple, Uinta blue -->
+      <!-- GeoServer layer: enmin_ucrc_basins_current -->
+      <FeatureTypeStyle>
+        <!-- Paradox Basin -->
+        <Rule>
+          <Name>Paradox Basin</Name>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>label</ogc:PropertyName>
+              <ogc:Literal>Paradox Basin</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#8400A8</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>label</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">9</CssParameter>
+              <CssParameter name="font-style">italic</CssParameter>
+              <CssParameter name="font-weight">bold</CssParameter>
+            </Font>
+            <Fill>
+              <CssParameter name="fill">#8400A8</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+        <!-- Uinta Basin -->
+        <Rule>
+          <Name>Uinta Basin</Name>
+          <ogc:Filter>
+            <ogc:PropertyIsEqualTo>
+              <ogc:PropertyName>label</ogc:PropertyName>
+              <ogc:Literal>Uinta Basin</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+          </ogc:Filter>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#005CE6</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>label</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">9</CssParameter>
+              <CssParameter name="font-style">italic</CssParameter>
+              <CssParameter name="font-weight">bold</CssParameter>
+            </Font>
+            <Fill>
+              <CssParameter name="fill">#005CE6</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+        <!-- Fallback for any other basins -->
+        <Rule>
+          <Name>Other</Name>
+          <ElseFilter/>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#808080</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>label</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">9</CssParameter>
+              <CssParameter name="font-style">italic</CssParameter>
+              <CssParameter name="font-weight">bold</CssParameter>
+            </Font>
+            <Fill>
+              <CssParameter name="fill">#808080</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/sld/ucrc-wells.sld
+++ b/sld/ucrc-wells.sld
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>UCRC Wells</Name>
+    <UserStyle>
+      <Title>UCRC Wells</Title>
+      <!-- Source: ArcGIS UCRC_Database_App_View/FeatureServer/0 (rockcore app) -->
+      <!-- GeoServer layer: energy_mineral:enmin_ucrc_wells_django_test_current -->
+      <!-- Simple circle, #73B2FF light blue, 8px, no outline -->
+      <FeatureTypeStyle>
+        <Rule>
+          <PointSymbolizer>
+            <Graphic>
+              <Mark>
+                <WellKnownName>circle</WellKnownName>
+                <Fill>
+                  <CssParameter name="fill">#73B2FF</CssParameter>
+                </Fill>
+              </Mark>
+              <Size>8</Size>
+            </Graphic>
+          </PointSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/sld/utah-counties.sld
+++ b/sld/utah-counties.sld
@@ -18,7 +18,7 @@
               <CssParameter name="fill-opacity">0</CssParameter>
             </Fill>
             <Stroke>
-              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke">#808080</CssParameter>
               <CssParameter name="stroke-width">1.5</CssParameter>
             </Stroke>
           </PolygonSymbolizer>
@@ -41,7 +41,7 @@
               </PointPlacement>
             </LabelPlacement>
             <Fill>
-              <CssParameter name="fill">#000000</CssParameter>
+              <CssParameter name="fill">#808080</CssParameter>
             </Fill>
           </TextSymbolizer>
         </Rule>

--- a/sld/utah-counties.sld
+++ b/sld/utah-counties.sld
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor version="1.0.0"
+  xmlns="http://www.opengis.net/sld"
+  xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>Utah Counties</Name>
+    <UserStyle>
+      <Title>Utah Counties</Title>
+      <!-- Source: ArcGIS Core_Locations_Supporting_Data/FeatureServer/1 -->
+      <!-- NAME label field, black outline 1.5px, transparent fill -->
+      <FeatureTypeStyle>
+        <Rule>
+          <PolygonSymbolizer>
+            <Fill>
+              <CssParameter name="fill-opacity">0</CssParameter>
+            </Fill>
+            <Stroke>
+              <CssParameter name="stroke">#000000</CssParameter>
+              <CssParameter name="stroke-width">1.5</CssParameter>
+            </Stroke>
+          </PolygonSymbolizer>
+          <TextSymbolizer>
+            <Label>
+              <ogc:PropertyName>NAME</ogc:PropertyName>
+            </Label>
+            <Font>
+              <CssParameter name="font-family">Arial</CssParameter>
+              <CssParameter name="font-size">9</CssParameter>
+              <CssParameter name="font-style">normal</CssParameter>
+              <CssParameter name="font-weight">bold</CssParameter>
+            </Font>
+            <LabelPlacement>
+              <PointPlacement>
+                <AnchorPoint>
+                  <AnchorPointX>0.5</AnchorPointX>
+                  <AnchorPointY>0.5</AnchorPointY>
+                </AnchorPoint>
+              </PointPlacement>
+            </LabelPlacement>
+            <Fill>
+              <CssParameter name="fill">#000000</CssParameter>
+            </Fill>
+          </TextSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
## Summary
- Adds `sld/township-range.sld` — red outline, transparent fill, `TWNSHPLAB` labels (Arial 8pt bold italic `#E60000`), visible to 1:500k
- Adds `sld/plss-sections.sld` — salmon outline `#FF7F7F`, transparent fill, `FRSTDIVLAB` labels (Arial 8pt normal), visible to 1:250k
- Styles sourced from rockcore app (ArcGIS Core_Locations_Supporting_Data/FeatureServer/3 and BLM_Natl_PLSS_CadNSDI/MapServer/2)