### PR TITLE
fix(common): export full feature attributes from attribute table CSV/GeoJSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "driver.js": "^1.4.0",
         "embla-carousel-react": "^8.3.0",
         "fast-xml-parser": "^5.3.7",
+        "fflate": "^0.8.2",
         "firebase": "^12.3.0",
         "jspdf": "^4.2.0",
         "lucide-react": "^0.544.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "driver.js": "^1.4.0",
     "embla-carousel-react": "^8.3.0",
     "fast-xml-parser": "^5.3.7",
+    "fflate": "^0.8.2",
     "firebase": "^12.3.0",
     "jspdf": "^4.2.0",
     "lucide-react": "^0.544.0",

--- a/src/components/data-table/query-results-table.tsx
+++ b/src/components/data-table/query-results-table.tsx
@@ -26,6 +26,9 @@ import {
     DropdownMenuTrigger,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuCheckboxItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import {
     X,
@@ -77,6 +80,7 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
     const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
     const [expandedTables, setExpandedTables] = useState<Record<string, number | null>>({});
     const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
+    const [includeRelatedInExport, setIncludeRelatedInExport] = useState(true);
     const lastClickedRowRef = useRef<number | null>(null);
 
     // Clamp selectedLayerIndex if layersWithData shrinks
@@ -261,8 +265,11 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
             columnConfigs,
             relatedTables: selectedLayer?.relatedTables || [],
             relatedDataMaps,
+            includeRelated: includeRelatedInExport,
         });
-    }, [hasSelection, selectedRows, table, selectedLayer, columnConfigs, relatedDataMaps]);
+    }, [hasSelection, selectedRows, table, selectedLayer, columnConfigs, relatedDataMaps, includeRelatedInExport]);
+
+    const hasRelatedTables = (selectedLayer?.relatedTables?.length ?? 0) > 0;
 
     // Total count across all layers (includes raster-only as 1)
     const totalCount = layersWithData.reduce((sum, layer) => {
@@ -417,6 +424,21 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
                         <DropdownMenuItem onClick={() => handleExport('geojson')}>
                             GeoJSON
                         </DropdownMenuItem>
+                        {hasRelatedTables && (
+                            <>
+                                <DropdownMenuSeparator />
+                                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                                    Options
+                                </DropdownMenuLabel>
+                                <DropdownMenuCheckboxItem
+                                    checked={includeRelatedInExport}
+                                    onCheckedChange={setIncludeRelatedInExport}
+                                    onSelect={(e) => e.preventDefault()}
+                                >
+                                    Include related data
+                                </DropdownMenuCheckboxItem>
+                            </>
+                        )}
                     </DropdownMenuContent>
                 </DropdownMenu>
 

--- a/src/components/data-table/query-results-table.tsx
+++ b/src/components/data-table/query-results-table.tsx
@@ -172,15 +172,6 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
         onSelectedFeaturesChange?.([]);
     }, [onSelectedFeaturesChange]);
 
-    const selectedRows = useMemo(() => {
-        return Object.keys(rowSelection)
-            .filter(key => rowSelection[key])
-            .map(key => rowData[parseInt(key)])
-            .filter(Boolean);
-    }, [rowSelection, rowData]);
-
-    const hasSelection = selectedRows.length > 0;
-
     const handleRowSelectionChange = useCallback((updater: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)) => {
         const newSelection = typeof updater === 'function' ? updater(rowSelection) : updater;
         const selectedIndices = Object.keys(newSelection).filter(key => newSelection[key]).map(Number);
@@ -202,12 +193,6 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
             }));
         onHighlightChange?.(highlights);
     }, [rowSelection, rowData, rowIndicesToFeatureRefs, onSelectedFeaturesChange, onHighlightChange]);
-
-    const handleZoomToSelected = useCallback(() => {
-        if (selectedRows.length === 0) return;
-        const features = selectedRows.map(r => r.feature);
-        zoomToAll(features, selectedRows[0].sourceCRS, { maxZoom: selectedRows[0].maxZoomLevel });
-    }, [selectedRows, zoomToAll]);
 
     const handleClearSelection = useCallback(() => {
         onSelectedFeaturesChange?.([]);
@@ -253,6 +238,18 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
             relatedLoading,
         },
     });
+
+    const selectedRows = useMemo(
+        () => table.getSelectedRowModel().rows.map(r => r.original),
+        [table, rowSelection],
+    );
+    const hasSelection = selectedRows.length > 0;
+
+    const handleZoomToSelected = useCallback(() => {
+        if (selectedRows.length === 0) return;
+        const features = selectedRows.map(r => r.feature);
+        zoomToAll(features, selectedRows[0].sourceCRS, { maxZoom: selectedRows[0].maxZoomLevel });
+    }, [selectedRows, zoomToAll]);
 
     // Export emits all feature properties (not just popupFields/visible columns).
     // Filter state determines row scope; column visibility is UI-only.

--- a/src/components/data-table/query-results-table.tsx
+++ b/src/components/data-table/query-results-table.tsx
@@ -60,11 +60,13 @@ interface QueryResultsTableProps {
     selectedFeatureRefs?: SelectedFeatureRef[];
     onSelectedFeaturesChange?: (refs: SelectedFeatureRef[]) => void;
     onHighlightChange?: (features: HighlightFeature[]) => void;
+    /** When true, hide the export dropdown. Stakeholder request for apps that require unmodified source data. */
+    disableExport?: boolean;
 }
 
 const EMPTY_COLUMN_FILTERS: { id: string; value: string }[] = [];
 
-export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeChange, selectedFeatureRefs = [], onSelectedFeaturesChange, onHighlightChange }: QueryResultsTableProps) {
+export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeChange, selectedFeatureRefs = [], onSelectedFeaturesChange, onHighlightChange, disableExport = false }: QueryResultsTableProps) {
     const { zoomTo, zoomToAll } = useZoomToFeature({ onHighlightChange });
 
     const layersWithData = useMemo(() =>
@@ -403,41 +405,43 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
                     </>
                 )}
 
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs text-muted-foreground"
-                            title={hasSelection ? `Export ${selectedRows.length} selected` : 'Export all'}
-                        >
-                            <Download className="h-3 w-3" />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => handleExport('csv')}>
-                            CSV
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={() => handleExport('geojson')}>
-                            GeoJSON
-                        </DropdownMenuItem>
-                        {hasRelatedTables && (
-                            <>
-                                <DropdownMenuSeparator />
-                                <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-                                    Options
-                                </DropdownMenuLabel>
-                                <DropdownMenuCheckboxItem
-                                    checked={includeRelatedInExport}
-                                    onCheckedChange={setIncludeRelatedInExport}
-                                    onSelect={(e) => e.preventDefault()}
-                                >
-                                    Include related data
-                                </DropdownMenuCheckboxItem>
-                            </>
-                        )}
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                {!disableExport && (
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-6 px-2 text-xs text-muted-foreground"
+                                title={hasSelection ? `Export ${selectedRows.length} selected` : 'Export all'}
+                            >
+                                <Download className="h-3 w-3" />
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem onClick={() => handleExport('csv')}>
+                                CSV
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onClick={() => handleExport('geojson')}>
+                                GeoJSON
+                            </DropdownMenuItem>
+                            {hasRelatedTables && (
+                                <>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                                        Options
+                                    </DropdownMenuLabel>
+                                    <DropdownMenuCheckboxItem
+                                        checked={includeRelatedInExport}
+                                        onCheckedChange={setIncludeRelatedInExport}
+                                        onSelect={(e) => e.preventDefault()}
+                                    >
+                                        Include related data
+                                    </DropdownMenuCheckboxItem>
+                                </>
+                            )}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                )}
 
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/src/components/data-table/query-results-table.tsx
+++ b/src/components/data-table/query-results-table.tsx
@@ -250,18 +250,19 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
         },
     });
 
-    // Uses TanStack's filtered model to match what's visible in the table
+    // Export emits all feature properties (not just popupFields/visible columns).
+    // Filter state determines row scope; column visibility is UI-only.
     const handleExport = useCallback((format: 'csv' | 'geojson') => {
         const filteredRows = table.getFilteredRowModel().rows.map(r => r.original);
         exportTableData({
             format,
             dataToExport: hasSelection ? selectedRows : filteredRows,
             layerTitle: selectedLayer?.layerTitle || '',
-            visibleConfigs: columnConfigs.filter(c => columnVisibility[c.id] !== false),
+            columnConfigs,
             relatedTables: selectedLayer?.relatedTables || [],
             relatedDataMaps,
         });
-    }, [hasSelection, selectedRows, table, selectedLayer, columnConfigs, columnVisibility, relatedDataMaps]);
+    }, [hasSelection, selectedRows, table, selectedLayer, columnConfigs, relatedDataMaps]);
 
     // Total count across all layers (includes raster-only as 1)
     const totalCount = layersWithData.reduce((sum, layer) => {

--- a/src/components/data-table/table-export-utils.ts
+++ b/src/components/data-table/table-export-utils.ts
@@ -1,5 +1,5 @@
 import { isValidElement } from 'react';
-import type { RelatedTable } from '@/lib/types/mapping-types';
+import type { RelatedTable, FieldConfig } from '@/lib/types/mapping-types';
 import type { RelatedDataMap } from '@/hooks/use-bulk-related-table';
 import { downloadCSV, downloadGeoJSON, geojsonToWKT } from '@/lib/download-utils';
 import { formatFieldValue } from '@/lib/field-formatting';
@@ -12,43 +12,81 @@ interface ExportRow {
     relatedTableIndex: number | null;
 }
 
+interface MainColumn {
+    field: string;
+    label: string;
+    fieldConfig?: FieldConfig;
+}
+
 export interface TableExportParams {
     format: 'csv' | 'geojson';
     dataToExport: RowData[];
     layerTitle: string;
-    visibleConfigs: ColumnConfig[];
+    columnConfigs: ColumnConfig[];
     relatedTables: RelatedTable[];
     relatedDataMaps: RelatedDataMap[];
+}
+
+// Union of all property keys across rows, merged with configured labels/formatting.
+// Configured (popupField) columns come first in their declared order; remaining raw
+// property keys are appended alphabetically. Internal/_-prefixed keys are dropped.
+function buildMainColumns(data: RowData[], columnConfigs: ColumnConfig[]): MainColumn[] {
+    const cols: MainColumn[] = [];
+    const seen = new Set<string>();
+
+    for (const cfg of columnConfigs) {
+        if (cfg.fieldConfig?.type === 'custom') continue;
+        if (seen.has(cfg.field)) continue;
+        seen.add(cfg.field);
+        cols.push({ field: cfg.field, label: cfg.label, fieldConfig: cfg.fieldConfig });
+    }
+
+    const extras: string[] = [];
+    for (const row of data) {
+        for (const key of Object.keys(row.properties)) {
+            if (seen.has(key)) continue;
+            if (key === 'geometry' || key === 'bbox' || key.startsWith('_')) continue;
+            seen.add(key);
+            extras.push(key);
+        }
+    }
+    extras.sort();
+    for (const key of extras) {
+        cols.push({ field: key, label: key });
+    }
+
+    return cols;
 }
 
 export function exportTableData({
     format,
     dataToExport,
     layerTitle,
-    visibleConfigs,
+    columnConfigs,
     relatedTables,
     relatedDataMaps,
 }: TableExportParams): void {
     const timestamp = new Date().toISOString().split('T')[0];
     const layerName = (layerTitle || 'export').replace(/\s+/g, '-').toLowerCase();
     const filename = `${layerName}-${timestamp}`;
+    const mainColumns = buildMainColumns(dataToExport, columnConfigs);
 
     if (format === 'csv') {
-        exportAsCSV(dataToExport, filename, visibleConfigs, relatedTables, relatedDataMaps);
+        exportAsCSV(dataToExport, filename, mainColumns, relatedTables, relatedDataMaps);
     } else {
-        exportAsGeoJSON(dataToExport, filename, visibleConfigs);
+        exportAsGeoJSON(dataToExport, filename, mainColumns);
     }
 }
 
 function exportAsCSV(
     dataToExport: RowData[],
     filename: string,
-    visibleConfigs: ColumnConfig[],
+    mainColumns: MainColumn[],
     relatedTables: RelatedTable[],
     relatedDataMaps: RelatedDataMap[],
 ): void {
-    // Build headers: visible columns + related table columns + geometry
-    const mainHeaders = visibleConfigs.map(c => c.label);
+    const mainHeaders = mainColumns.map(c => c.label);
+    const columnByLabel = new Map(mainColumns.map(c => [c.label, c]));
     const relatedHeaders: string[] = [];
 
     relatedTables.forEach((table) => {
@@ -60,7 +98,6 @@ function exportAsCSV(
 
     const allHeaders = [...mainHeaders, ...relatedHeaders, 'geometry'];
 
-    // Build denormalized rows: one row per related record (or one row if no related data)
     const expandedRows: ExportRow[] = [];
 
     for (const row of dataToExport) {
@@ -91,14 +128,15 @@ function exportAsCSV(
             return geojsonToWKT(row.feature.geometry as Parameters<typeof geojsonToWKT>[0]) || '';
         }
 
-        // Check main columns
-        const config = visibleConfigs.find(c => c.label === header);
-        if (config) {
-            const rawValue = row.properties[config.field];
-            return formatFieldValue(config.fieldConfig, rawValue, row.properties);
+        const mainCol = columnByLabel.get(header);
+        if (mainCol) {
+            const rawValue = row.properties[mainCol.field];
+            if (mainCol.fieldConfig) {
+                return formatFieldValue(mainCol.fieldConfig, rawValue, row.properties);
+            }
+            return rawValue ?? '';
         }
 
-        // Check related tables
         for (let tableIndex = 0; tableIndex < relatedTables.length; tableIndex++) {
             const table = relatedTables[tableIndex];
             const prefix = `${table.fieldLabel || 'Related'}: `;
@@ -132,12 +170,12 @@ function exportAsCSV(
 function exportAsGeoJSON(
     dataToExport: RowData[],
     filename: string,
-    visibleConfigs: ColumnConfig[],
+    mainColumns: MainColumn[],
 ): void {
-    const visibleFields = new Set(visibleConfigs.map(c => c.field));
+    const includedFields = new Set(mainColumns.map(c => c.field));
     const geoData = dataToExport.map(row => {
         const filtered: Record<string, unknown> = {};
-        for (const field of visibleFields) {
+        for (const field of includedFields) {
             if (field in row.properties) filtered[field] = row.properties[field];
         }
         filtered.geometry = row.feature.geometry;

--- a/src/components/data-table/table-export-utils.ts
+++ b/src/components/data-table/table-export-utils.ts
@@ -1,16 +1,10 @@
 import { isValidElement } from 'react';
 import type { RelatedTable, FieldConfig } from '@/lib/types/mapping-types';
 import type { RelatedDataMap } from '@/hooks/use-bulk-related-table';
-import { downloadCSV, downloadGeoJSON, geojsonToWKT } from '@/lib/download-utils';
+import { buildCSV, downloadCsvString, downloadGeoJSON, downloadZip, geojsonToWKT } from '@/lib/download-utils';
 import { formatFieldValue } from '@/lib/field-formatting';
 import { formatNumeric } from '@/lib/utils';
 import type { RowData, ColumnConfig } from './types';
-
-interface ExportRow {
-    feature: RowData;
-    relatedRecord: Record<string, unknown> | null;
-    relatedTableIndex: number | null;
-}
 
 interface MainColumn {
     field: string;
@@ -25,15 +19,12 @@ export interface TableExportParams {
     columnConfigs: ColumnConfig[];
     relatedTables: RelatedTable[];
     relatedDataMaps: RelatedDataMap[];
-    /** When false, related table data is dropped — emits one CSV row per feature. */
+    /** When false, related table data is dropped — single CSV with main features only. */
     includeRelated: boolean;
 }
 
-// Empty-string fieldLabel is intentional ("no prefix"). Only undefined gets the default.
-function relatedHeaderPrefix(fieldLabel: string | undefined): string {
-    if (fieldLabel === undefined) return 'Related: ';
-    if (fieldLabel === '') return '';
-    return `${fieldLabel}: `;
+function safeName(s: string): string {
+    return s.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').toLowerCase() || 'related';
 }
 
 // Union of all property keys across rows, merged with configured labels/formatting.
@@ -86,8 +77,77 @@ export function exportTableData({
     if (format === 'csv') {
         exportAsCSV(dataToExport, filename, mainColumns, effectiveRelated, effectiveDataMaps);
     } else {
-        exportAsGeoJSON(dataToExport, filename, mainColumns);
+        exportAsGeoJSON(dataToExport, filename, mainColumns, effectiveRelated, effectiveDataMaps);
     }
+}
+
+const FEATURE_KEY_HEADER = '_feature_key';
+
+function buildMainCsv(dataToExport: RowData[], mainColumns: MainColumn[], relatedTables: RelatedTable[]): string {
+    const headers = [...mainColumns.map(c => c.label), 'geometry'];
+    // Append a feature_key column when related tables exist so per-table CSVs can join back.
+    if (relatedTables.length > 0) headers.push(FEATURE_KEY_HEADER);
+
+    return buildCSV(dataToExport, headers, (row, header) => {
+        if (header === 'geometry') {
+            return geojsonToWKT(row.feature.geometry as Parameters<typeof geojsonToWKT>[0]) || '';
+        }
+        if (header === FEATURE_KEY_HEADER) {
+            return featureKey(row, relatedTables);
+        }
+        const col = mainColumns.find(c => c.label === header);
+        if (!col) return '';
+        const rawValue = row.properties[col.field];
+        if (col.fieldConfig) return formatFieldValue(col.fieldConfig, rawValue, row.properties);
+        return rawValue ?? '';
+    });
+}
+
+function buildRelatedCsv(
+    dataToExport: RowData[],
+    table: RelatedTable,
+    dataMap: RelatedDataMap | undefined,
+): string {
+    const displayFields = table.displayFields || [];
+    const headers = [FEATURE_KEY_HEADER, ...displayFields.map(df => df.label || df.field)];
+
+    const rows: { key: string; record: Record<string, unknown> }[] = [];
+    for (const row of dataToExport) {
+        const targetValue = String(row.properties[table.targetField] ?? '');
+        const records = dataMap?.get(targetValue) || [];
+        const key = String(row.properties[table.targetField] ?? row.feature.id ?? '');
+        for (const record of records) {
+            rows.push({ key, record });
+        }
+    }
+
+    return buildCSV(rows, headers, (row, header) => {
+        if (header === FEATURE_KEY_HEADER) return row.key;
+        const df = displayFields.find(d => (d.label || d.field) === header);
+        if (!df) return '';
+        const raw = row.record[df.field];
+        const formatted = formatNumeric(raw, df.format);
+        if (df.transform) {
+            const result = df.transform(formatted);
+            if (isValidElement(result)) {
+                const props = result.props as { to?: string; href?: string };
+                return props.to || props.href || formatted;
+            }
+            return result;
+        }
+        return formatted;
+    });
+}
+
+/**
+ * Pick a stable key per feature so per-table CSVs can rejoin to main.
+ * Prefers the targetField of the first related table (since that's what the
+ * related tables themselves index by). Falls back to feature id.
+ */
+function featureKey(row: RowData, relatedTables: RelatedTable[]): string {
+    const target = relatedTables[0]?.targetField;
+    if (target && row.properties[target] != null) return String(row.properties[target]);
+    return String(row.feature.id ?? '');
 }
 
 function exportAsCSV(
@@ -97,100 +157,43 @@ function exportAsCSV(
     relatedTables: RelatedTable[],
     relatedDataMaps: RelatedDataMap[],
 ): void {
-    const mainHeaders = mainColumns.map(c => c.label);
-    const columnByLabel = new Map(mainColumns.map(c => [c.label, c]));
-    const relatedHeaders: string[] = [];
+    const mainCsv = buildMainCsv(dataToExport, mainColumns, relatedTables);
 
-    relatedTables.forEach((table) => {
-        const prefix = relatedHeaderPrefix(table.fieldLabel);
-        table.displayFields?.forEach(df => {
-            relatedHeaders.push(`${prefix}${df.label || df.field}`);
-        });
-    });
-
-    const allHeaders = [...mainHeaders, ...relatedHeaders, 'geometry'];
-
-    // Denormalized: one row per related record (or one row when no related data).
-    // Easier for downstream tools (Excel, pandas, QGIS) to filter/group than `; `-joined cells.
-    const expandedRows: ExportRow[] = [];
-
-    for (const row of dataToExport) {
-        const allRelatedRecords: { record: Record<string, unknown>; tableIndex: number }[] = [];
-
-        relatedTables.forEach((table, tableIndex) => {
-            const targetValue = String(row.properties[table.targetField] ?? '');
-            const dataMap = relatedDataMaps[tableIndex];
-            const records = dataMap?.get(targetValue) || [];
-            records.forEach(record => {
-                allRelatedRecords.push({ record, tableIndex });
-            });
-        });
-
-        if (allRelatedRecords.length === 0) {
-            expandedRows.push({ feature: row, relatedRecord: null, relatedTableIndex: null });
-        } else {
-            for (const { record, tableIndex } of allRelatedRecords) {
-                expandedRows.push({ feature: row, relatedRecord: record, relatedTableIndex: tableIndex });
-            }
-        }
+    if (relatedTables.length === 0) {
+        downloadCsvString(mainCsv, filename);
+        return;
     }
 
-    downloadCSV(expandedRows, filename, allHeaders, (exportRow, header) => {
-        const { feature: row, relatedRecord, relatedTableIndex } = exportRow;
-
-        if (header === 'geometry') {
-            return geojsonToWKT(row.feature.geometry as Parameters<typeof geojsonToWKT>[0]) || '';
-        }
-
-        const mainCol = columnByLabel.get(header);
-        if (mainCol) {
-            const rawValue = row.properties[mainCol.field];
-            if (mainCol.fieldConfig) {
-                return formatFieldValue(mainCol.fieldConfig, rawValue, row.properties);
-            }
-            return rawValue ?? '';
-        }
-
-        for (let tableIndex = 0; tableIndex < relatedTables.length; tableIndex++) {
-            const table = relatedTables[tableIndex];
-            const prefix = relatedHeaderPrefix(table.fieldLabel);
-
-            const displayField = table.displayFields?.find(
-                df => `${prefix}${df.label || df.field}` === header
-            );
-
-            if (displayField) {
-                if (relatedRecord && relatedTableIndex === tableIndex) {
-                    const raw = relatedRecord[displayField.field];
-                    const formatted = formatNumeric(raw, displayField.format);
-                    if (displayField.transform) {
-                        const result = displayField.transform(formatted);
-                        if (isValidElement(result)) {
-                            const props = result.props as { to?: string; href?: string };
-                            return props.to || props.href || formatted;
-                        }
-                        return result;
-                    }
-                    return formatted;
-                }
-                return '';
-            }
-        }
-
-        return '';
+    const files: Record<string, string> = { 'main.csv': mainCsv };
+    relatedTables.forEach((table, idx) => {
+        const name = safeName(table.fieldLabel || `table-${idx + 1}`);
+        files[`related-${name}.csv`] = buildRelatedCsv(dataToExport, table, relatedDataMaps[idx]);
     });
+    downloadZip(files, filename);
 }
 
 function exportAsGeoJSON(
     dataToExport: RowData[],
     filename: string,
     mainColumns: MainColumn[],
+    relatedTables: RelatedTable[],
+    relatedDataMaps: RelatedDataMap[],
 ): void {
     const includedFields = new Set(mainColumns.map(c => c.field));
     const geoData = dataToExport.map(row => {
         const filtered: Record<string, unknown> = {};
         for (const field of includedFields) {
             if (field in row.properties) filtered[field] = row.properties[field];
+        }
+        if (relatedTables.length > 0) {
+            const related: Record<string, Record<string, unknown>[]> = {};
+            relatedTables.forEach((table, idx) => {
+                const targetValue = String(row.properties[table.targetField] ?? '');
+                const records = relatedDataMaps[idx]?.get(targetValue) || [];
+                const key = table.fieldLabel || `table-${idx + 1}`;
+                related[key] = records;
+            });
+            filtered.related = related;
         }
         filtered.geometry = row.feature.geometry;
         return filtered;

--- a/src/components/data-table/table-export-utils.ts
+++ b/src/components/data-table/table-export-utils.ts
@@ -6,18 +6,16 @@ import { formatFieldValue } from '@/lib/field-formatting';
 import { formatNumeric } from '@/lib/utils';
 import type { RowData, ColumnConfig } from './types';
 
+interface ExportRow {
+    feature: RowData;
+    relatedRecord: Record<string, unknown> | null;
+    relatedTableIndex: number | null;
+}
+
 interface MainColumn {
     field: string;
     label: string;
     fieldConfig?: FieldConfig;
-}
-
-type DisplayField = NonNullable<RelatedTable['displayFields']>[number];
-
-interface RelatedColumn {
-    header: string;
-    tableIndex: number;
-    displayField: DisplayField;
 }
 
 export interface TableExportParams {
@@ -27,9 +25,9 @@ export interface TableExportParams {
     columnConfigs: ColumnConfig[];
     relatedTables: RelatedTable[];
     relatedDataMaps: RelatedDataMap[];
+    /** When false, related table data is dropped — emits one CSV row per feature. */
+    includeRelated: boolean;
 }
-
-const RELATED_VALUE_SEPARATOR = '; ';
 
 // Empty-string fieldLabel is intentional ("no prefix"). Only undefined gets the default.
 function relatedHeaderPrefix(fieldLabel: string | undefined): string {
@@ -69,33 +67,6 @@ function buildMainColumns(data: RowData[], columnConfigs: ColumnConfig[]): MainC
     return cols;
 }
 
-function buildRelatedColumns(relatedTables: RelatedTable[]): RelatedColumn[] {
-    const cols: RelatedColumn[] = [];
-    relatedTables.forEach((table, tableIndex) => {
-        const prefix = relatedHeaderPrefix(table.fieldLabel);
-        table.displayFields?.forEach(df => {
-            cols.push({
-                header: `${prefix}${df.label || df.field}`,
-                tableIndex,
-                displayField: df,
-            });
-        });
-    });
-    return cols;
-}
-
-function formatRelatedValue(record: Record<string, unknown>, df: DisplayField): string {
-    const raw = record[df.field];
-    const formatted = formatNumeric(raw, df.format);
-    if (!df.transform) return formatted;
-    const result = df.transform(formatted);
-    if (isValidElement(result)) {
-        const props = result.props as { to?: string; href?: string };
-        return props.to || props.href || formatted;
-    }
-    return result == null ? '' : String(result);
-}
-
 export function exportTableData({
     format,
     dataToExport,
@@ -103,14 +74,17 @@ export function exportTableData({
     columnConfigs,
     relatedTables,
     relatedDataMaps,
+    includeRelated,
 }: TableExportParams): void {
     const timestamp = new Date().toISOString().split('T')[0];
     const layerName = (layerTitle || 'export').replace(/\s+/g, '-').toLowerCase();
     const filename = `${layerName}-${timestamp}`;
     const mainColumns = buildMainColumns(dataToExport, columnConfigs);
+    const effectiveRelated = includeRelated ? relatedTables : [];
+    const effectiveDataMaps = includeRelated ? relatedDataMaps : [];
 
     if (format === 'csv') {
-        exportAsCSV(dataToExport, filename, mainColumns, relatedTables, relatedDataMaps);
+        exportAsCSV(dataToExport, filename, mainColumns, effectiveRelated, effectiveDataMaps);
     } else {
         exportAsGeoJSON(dataToExport, filename, mainColumns);
     }
@@ -125,11 +99,45 @@ function exportAsCSV(
 ): void {
     const mainHeaders = mainColumns.map(c => c.label);
     const columnByLabel = new Map(mainColumns.map(c => [c.label, c]));
-    const relatedColumns = buildRelatedColumns(relatedTables);
-    const relatedByHeader = new Map(relatedColumns.map(c => [c.header, c]));
-    const allHeaders = [...mainHeaders, ...relatedColumns.map(c => c.header), 'geometry'];
+    const relatedHeaders: string[] = [];
 
-    downloadCSV(dataToExport, filename, allHeaders, (row, header) => {
+    relatedTables.forEach((table) => {
+        const prefix = relatedHeaderPrefix(table.fieldLabel);
+        table.displayFields?.forEach(df => {
+            relatedHeaders.push(`${prefix}${df.label || df.field}`);
+        });
+    });
+
+    const allHeaders = [...mainHeaders, ...relatedHeaders, 'geometry'];
+
+    // Denormalized: one row per related record (or one row when no related data).
+    // Easier for downstream tools (Excel, pandas, QGIS) to filter/group than `; `-joined cells.
+    const expandedRows: ExportRow[] = [];
+
+    for (const row of dataToExport) {
+        const allRelatedRecords: { record: Record<string, unknown>; tableIndex: number }[] = [];
+
+        relatedTables.forEach((table, tableIndex) => {
+            const targetValue = String(row.properties[table.targetField] ?? '');
+            const dataMap = relatedDataMaps[tableIndex];
+            const records = dataMap?.get(targetValue) || [];
+            records.forEach(record => {
+                allRelatedRecords.push({ record, tableIndex });
+            });
+        });
+
+        if (allRelatedRecords.length === 0) {
+            expandedRows.push({ feature: row, relatedRecord: null, relatedTableIndex: null });
+        } else {
+            for (const { record, tableIndex } of allRelatedRecords) {
+                expandedRows.push({ feature: row, relatedRecord: record, relatedTableIndex: tableIndex });
+            }
+        }
+    }
+
+    downloadCSV(expandedRows, filename, allHeaders, (exportRow, header) => {
+        const { feature: row, relatedRecord, relatedTableIndex } = exportRow;
+
         if (header === 'geometry') {
             return geojsonToWKT(row.feature.geometry as Parameters<typeof geojsonToWKT>[0]) || '';
         }
@@ -143,15 +151,30 @@ function exportAsCSV(
             return rawValue ?? '';
         }
 
-        const relatedCol = relatedByHeader.get(header);
-        if (relatedCol) {
-            const table = relatedTables[relatedCol.tableIndex];
-            const targetValue = String(row.properties[table.targetField] ?? '');
-            const records = relatedDataMaps[relatedCol.tableIndex]?.get(targetValue) || [];
-            return records
-                .map(record => formatRelatedValue(record, relatedCol.displayField))
-                .filter(v => v !== '')
-                .join(RELATED_VALUE_SEPARATOR);
+        for (let tableIndex = 0; tableIndex < relatedTables.length; tableIndex++) {
+            const table = relatedTables[tableIndex];
+            const prefix = relatedHeaderPrefix(table.fieldLabel);
+
+            const displayField = table.displayFields?.find(
+                df => `${prefix}${df.label || df.field}` === header
+            );
+
+            if (displayField) {
+                if (relatedRecord && relatedTableIndex === tableIndex) {
+                    const raw = relatedRecord[displayField.field];
+                    const formatted = formatNumeric(raw, displayField.format);
+                    if (displayField.transform) {
+                        const result = displayField.transform(formatted);
+                        if (isValidElement(result)) {
+                            const props = result.props as { to?: string; href?: string };
+                            return props.to || props.href || formatted;
+                        }
+                        return result;
+                    }
+                    return formatted;
+                }
+                return '';
+            }
         }
 
         return '';

--- a/src/components/data-table/table-export-utils.ts
+++ b/src/components/data-table/table-export-utils.ts
@@ -6,16 +6,18 @@ import { formatFieldValue } from '@/lib/field-formatting';
 import { formatNumeric } from '@/lib/utils';
 import type { RowData, ColumnConfig } from './types';
 
-interface ExportRow {
-    feature: RowData;
-    relatedRecord: Record<string, unknown> | null;
-    relatedTableIndex: number | null;
-}
-
 interface MainColumn {
     field: string;
     label: string;
     fieldConfig?: FieldConfig;
+}
+
+type DisplayField = NonNullable<RelatedTable['displayFields']>[number];
+
+interface RelatedColumn {
+    header: string;
+    tableIndex: number;
+    displayField: DisplayField;
 }
 
 export interface TableExportParams {
@@ -25,6 +27,15 @@ export interface TableExportParams {
     columnConfigs: ColumnConfig[];
     relatedTables: RelatedTable[];
     relatedDataMaps: RelatedDataMap[];
+}
+
+const RELATED_VALUE_SEPARATOR = '; ';
+
+// Empty-string fieldLabel is intentional ("no prefix"). Only undefined gets the default.
+function relatedHeaderPrefix(fieldLabel: string | undefined): string {
+    if (fieldLabel === undefined) return 'Related: ';
+    if (fieldLabel === '') return '';
+    return `${fieldLabel}: `;
 }
 
 // Union of all property keys across rows, merged with configured labels/formatting.
@@ -58,6 +69,33 @@ function buildMainColumns(data: RowData[], columnConfigs: ColumnConfig[]): MainC
     return cols;
 }
 
+function buildRelatedColumns(relatedTables: RelatedTable[]): RelatedColumn[] {
+    const cols: RelatedColumn[] = [];
+    relatedTables.forEach((table, tableIndex) => {
+        const prefix = relatedHeaderPrefix(table.fieldLabel);
+        table.displayFields?.forEach(df => {
+            cols.push({
+                header: `${prefix}${df.label || df.field}`,
+                tableIndex,
+                displayField: df,
+            });
+        });
+    });
+    return cols;
+}
+
+function formatRelatedValue(record: Record<string, unknown>, df: DisplayField): string {
+    const raw = record[df.field];
+    const formatted = formatNumeric(raw, df.format);
+    if (!df.transform) return formatted;
+    const result = df.transform(formatted);
+    if (isValidElement(result)) {
+        const props = result.props as { to?: string; href?: string };
+        return props.to || props.href || formatted;
+    }
+    return result == null ? '' : String(result);
+}
+
 export function exportTableData({
     format,
     dataToExport,
@@ -87,43 +125,11 @@ function exportAsCSV(
 ): void {
     const mainHeaders = mainColumns.map(c => c.label);
     const columnByLabel = new Map(mainColumns.map(c => [c.label, c]));
-    const relatedHeaders: string[] = [];
+    const relatedColumns = buildRelatedColumns(relatedTables);
+    const relatedByHeader = new Map(relatedColumns.map(c => [c.header, c]));
+    const allHeaders = [...mainHeaders, ...relatedColumns.map(c => c.header), 'geometry'];
 
-    relatedTables.forEach((table) => {
-        const prefix = `${table.fieldLabel || 'Related'}: `;
-        table.displayFields?.forEach(df => {
-            relatedHeaders.push(`${prefix}${df.label || df.field}`);
-        });
-    });
-
-    const allHeaders = [...mainHeaders, ...relatedHeaders, 'geometry'];
-
-    const expandedRows: ExportRow[] = [];
-
-    for (const row of dataToExport) {
-        const allRelatedRecords: { record: Record<string, unknown>; tableIndex: number }[] = [];
-
-        relatedTables.forEach((table, tableIndex) => {
-            const targetValue = String(row.properties[table.targetField] ?? '');
-            const dataMap = relatedDataMaps[tableIndex];
-            const records = dataMap?.get(targetValue) || [];
-            records.forEach(record => {
-                allRelatedRecords.push({ record, tableIndex });
-            });
-        });
-
-        if (allRelatedRecords.length === 0) {
-            expandedRows.push({ feature: row, relatedRecord: null, relatedTableIndex: null });
-        } else {
-            for (const { record, tableIndex } of allRelatedRecords) {
-                expandedRows.push({ feature: row, relatedRecord: record, relatedTableIndex: tableIndex });
-            }
-        }
-    }
-
-    downloadCSV(expandedRows, filename, allHeaders, (exportRow, header) => {
-        const { feature: row, relatedRecord, relatedTableIndex } = exportRow;
-
+    downloadCSV(dataToExport, filename, allHeaders, (row, header) => {
         if (header === 'geometry') {
             return geojsonToWKT(row.feature.geometry as Parameters<typeof geojsonToWKT>[0]) || '';
         }
@@ -137,30 +143,15 @@ function exportAsCSV(
             return rawValue ?? '';
         }
 
-        for (let tableIndex = 0; tableIndex < relatedTables.length; tableIndex++) {
-            const table = relatedTables[tableIndex];
-            const prefix = `${table.fieldLabel || 'Related'}: `;
-
-            const displayField = table.displayFields?.find(
-                df => `${prefix}${df.label || df.field}` === header
-            );
-
-            if (displayField) {
-                if (relatedRecord && relatedTableIndex === tableIndex) {
-                    const raw = relatedRecord[displayField.field];
-                    const formatted = formatNumeric(raw, displayField.format);
-                    if (displayField.transform) {
-                        const result = displayField.transform(formatted);
-                        if (isValidElement(result)) {
-                            const props = result.props as { to?: string; href?: string };
-                            return props.to || props.href || formatted;
-                        }
-                        return result;
-                    }
-                    return formatted;
-                }
-                return '';
-            }
+        const relatedCol = relatedByHeader.get(header);
+        if (relatedCol) {
+            const table = relatedTables[relatedCol.tableIndex];
+            const targetValue = String(row.properties[table.targetField] ?? '');
+            const records = relatedDataMaps[relatedCol.tableIndex]?.get(targetValue) || [];
+            return records
+                .map(record => formatRelatedValue(record, relatedCol.displayField))
+                .filter(v => v !== '')
+                .join(RELATED_VALUE_SEPARATOR);
         }
 
         return '';

--- a/src/components/maps/data-map.tsx
+++ b/src/components/maps/data-map.tsx
@@ -27,6 +27,7 @@ import { useFeatureQuery } from '@/hooks/use-feature-query'
 import type { ClickedFeature, DataMapProps } from './types'
 import { LoadingOverlay } from '@/components/ui/loading-spinner'
 import { MapContextMenu, type ContextMenuCoords } from './map-context-menu'
+import { useToast } from '@/hooks/use-toast'
 
 // Re-export types for consumers
 export type { DrawMode, SpatialFilter, HighlightFeature, ClickedFeature, DataMapProps } from './types'
@@ -297,15 +298,24 @@ export default function DataMap({
   // Ref to store WFS features from polygon query (populated before WMS query completes)
   const polygonWfsLayerFeaturesRef = useRef<WfsLayerFeature[]>([])
 
-  // Feature query mutations
+  const { toast } = useToast()
+
+  const notifyTruncated = useCallback(() => {
+    toast({
+      title: 'Result limit reached',
+      description: 'Showing first 10,000 features. Narrow your selection for the rest.',
+      variant: 'destructive',
+    })
+  }, [toast])
+
   const { clickQuery, boxSelectQuery, polygonQuery, isLoading: queryLoading } = useFeatureQuery({
-    onPolygonQuerySuccess: (wmsFeatures) => {
-      // Merge WMS results with pre-queried WFS features
+    onPolygonQuerySuccess: ({ features: wmsFeatures, truncated }) => {
       const allFeatures = [...wmsFeatures, ...polygonWfsLayerFeaturesRef.current]
-      polygonWfsLayerFeaturesRef.current = [] // Clear for next query
+      polygonWfsLayerFeaturesRef.current = []
       if (onFeatureClick && allFeatures.length > 0) {
         onFeatureClick(allFeatures, { additive: false })
       }
+      if (truncated) notifyTruncated()
     },
   })
 
@@ -556,8 +566,9 @@ export default function DataMap({
         layerFilters,
       },
       {
-        onSuccess: (wmsFeatures) => {
+        onSuccess: ({ features: wmsFeatures, truncated }) => {
           dispatchFeatures([...wmsFeatures, ...wfsFeatures], isAdditiveMode)
+          if (truncated) notifyTruncated()
         },
       }
     )

--- a/src/components/maps/data-map.tsx
+++ b/src/components/maps/data-map.tsx
@@ -27,7 +27,7 @@ import { useFeatureQuery } from '@/hooks/use-feature-query'
 import type { ClickedFeature, DataMapProps } from './types'
 import { LoadingOverlay } from '@/components/ui/loading-spinner'
 import { MapContextMenu, type ContextMenuCoords } from './map-context-menu'
-import { useToast } from '@/hooks/use-toast'
+import { toast } from 'sonner'
 
 // Re-export types for consumers
 export type { DrawMode, SpatialFilter, HighlightFeature, ClickedFeature, DataMapProps } from './types'
@@ -298,15 +298,12 @@ export default function DataMap({
   // Ref to store WFS features from polygon query (populated before WMS query completes)
   const polygonWfsLayerFeaturesRef = useRef<WfsLayerFeature[]>([])
 
-  const { toast } = useToast()
-
   const notifyTruncated = useCallback(() => {
-    toast({
-      title: 'Result limit reached',
+    toast.warning('Result limit reached', {
       description: 'Showing first 10,000 features. Narrow your selection for the rest.',
-      variant: 'destructive',
+      duration: 8000,
     })
-  }, [toast])
+  }, [])
 
   const { clickQuery, boxSelectQuery, polygonQuery, isLoading: queryLoading } = useFeatureQuery({
     onPolygonQuerySuccess: ({ features: wmsFeatures, truncated }) => {

--- a/src/components/maps/generic-map-container.tsx
+++ b/src/components/maps/generic-map-container.tsx
@@ -217,6 +217,8 @@ interface GenericMapContainerProps {
   layerConfigKey?: string
   /** Called when all selections are cleared (context menu, popup close, etc.) */
   onClearSearch?: () => void
+  /** Hide attribute table CSV/GeoJSON + per-layer parquet downloads. Used by apps that require unmodified source data only. */
+  disableExport?: boolean
 }
 
 export default function GenericMapContainer({
@@ -226,6 +228,7 @@ export default function GenericMapContainer({
   vectorLayerSymbology = {},
   layerConfigKey = 'layers',
   onClearSearch,
+  disableExport = false,
 }: GenericMapContainerProps) {
   const isMobile = useIsMobile()
   const currentPage = useGetCurrentPage()
@@ -646,6 +649,7 @@ export default function GenericMapContainer({
             selectedFeatureRefs={selectedFeatureRefs}
             onSelectedFeaturesChange={setSelectedFeatureRefs}
             onHighlightChange={handleHighlightChange}
+            disableExport={disableExport}
           />
         )}
       </div>

--- a/src/components/maps/popups/popup-content-with-pagination.tsx
+++ b/src/components/maps/popups/popup-content-with-pagination.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, memo, useCallback, useRef } from "react"
 import { Button } from "@/components/ui/button"
-import { Shrink } from "lucide-react"
+import { Shrink, ChevronLeft, ChevronRight } from "lucide-react"
 import { PopupContentDisplay } from "@/components/maps/popups/popup-content-display"
 import { useGetPopupButtons } from "@/hooks/use-get-popup-buttons"
 import { useZoomToFeature } from "@/hooks/use-zoom-to-feature"
@@ -9,6 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
 import { useBulkRelatedTable, RelatedDataMap } from "@/hooks/use-bulk-related-table"
 import { ExtendedFeature, LayerContentProps, hasRasterData, getLayerCountText } from "./types"
+
+const POPUP_PAGE_SIZE = 10
 
 interface PopupButtonsProps {
     feature: ExtendedFeature;
@@ -68,6 +70,73 @@ const FeatureCard = memo(({
     )
 });
 FeatureCard.displayName = 'FeatureCard';
+
+// Renders a layer's features with internal pagination so popup DOM stays small
+// even when layer.features has thousands of entries (cap is 10k per WFS query).
+const PaginatedFeatureList = memo(({
+    layer,
+    buttons,
+    handleZoomToFeature,
+    bulkRelatedData,
+}: {
+    layer: LayerContentProps,
+    buttons: React.ReactNode[] | null,
+    handleZoomToFeature: (feature: ExtendedFeature, sourceCRS: string, maxZoomLevel?: number) => void,
+    bulkRelatedData?: RelatedDataMap[],
+}) => {
+    const [page, setPage] = useState(0)
+    const total = layer.features.length
+    const totalPages = Math.max(1, Math.ceil(total / POPUP_PAGE_SIZE))
+    const safePage = Math.min(page, totalPages - 1)
+    const start = safePage * POPUP_PAGE_SIZE
+    const end = Math.min(start + POPUP_PAGE_SIZE, total)
+    const slice = useMemo(() => layer.features.slice(start, end), [layer.features, start, end])
+    const showPager = total > POPUP_PAGE_SIZE
+
+    return (
+        <>
+            {showPager && (
+                <div className="flex items-center justify-between text-xs text-muted-foreground px-1 pb-1">
+                    <span>{start + 1}–{end} of {total}</span>
+                    <div className="flex items-center gap-1">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 w-6 p-0"
+                            disabled={safePage === 0}
+                            onClick={() => setPage(p => Math.max(0, p - 1))}
+                            aria-label="Previous page"
+                        >
+                            <ChevronLeft className="h-4 w-4" />
+                        </Button>
+                        <span>{safePage + 1}/{totalPages}</span>
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 w-6 p-0"
+                            disabled={safePage >= totalPages - 1}
+                            onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                            aria-label="Next page"
+                        >
+                            <ChevronRight className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
+            )}
+            {slice.map((feature, idx) => (
+                <FeatureCard
+                    key={`${feature.id ?? start + idx}`}
+                    layer={layer}
+                    feature={feature}
+                    buttons={buttons}
+                    handleZoomToFeature={handleZoomToFeature}
+                    bulkRelatedData={bulkRelatedData}
+                />
+            ))}
+        </>
+    )
+})
+PaginatedFeatureList.displayName = 'PaginatedFeatureList'
 
 // Raster-only card for layers with no vector features but with raster data
 const RasterOnlyCard = memo(({ layer }: { layer: LayerContentProps }) => {
@@ -243,16 +312,12 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                                 {/* Features or raster-only content */}
                                 <div className="space-y-2">
                                     {hasFeatures ? (
-                                        layer.features.map((feature, featureIdx) => (
-                                            <FeatureCard
-                                                key={`${feature.id || featureIdx}`}
-                                                layer={layer}
-                                                feature={feature}
-                                                buttons={buttons}
-                                                handleZoomToFeature={handleZoomToFeature}
-                                                bulkRelatedData={layer.relatedTables?.length ? bulkRelatedData : undefined}
-                                            />
-                                        ))
+                                        <PaginatedFeatureList
+                                            layer={layer}
+                                            buttons={buttons}
+                                            handleZoomToFeature={handleZoomToFeature}
+                                            bulkRelatedData={layer.relatedTables?.length ? bulkRelatedData : undefined}
+                                        />
                                     ) : hasRaster ? (
                                         <RasterOnlyCard layer={layer} />
                                     ) : null}
@@ -261,19 +326,14 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                         );
                     })
                 ) : selectedLayer ? (
-                    // Show features from selected layer only
                     <div className="space-y-2">
                         {selectedLayer.features.length > 0 ? (
-                            selectedLayer.features.map((feature, featureIdx) => (
-                                <FeatureCard
-                                    key={`${feature.id || featureIdx}`}
-                                    layer={selectedLayer}
-                                    feature={feature}
-                                    buttons={buttons}
-                                    handleZoomToFeature={handleZoomToFeature}
-                                    bulkRelatedData={selectedLayer.relatedTables?.length ? bulkRelatedData : undefined}
-                                />
-                            ))
+                            <PaginatedFeatureList
+                                layer={selectedLayer}
+                                buttons={buttons}
+                                handleZoomToFeature={handleZoomToFeature}
+                                bulkRelatedData={selectedLayer.relatedTables?.length ? bulkRelatedData : undefined}
+                            />
                         ) : hasRasterData(selectedLayer) ? (
                             <RasterOnlyCard layer={selectedLayer} />
                         ) : null}

--- a/src/components/maps/popups/popup-content-with-pagination.tsx
+++ b/src/components/maps/popups/popup-content-with-pagination.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, memo, useCallback, useRef } from "react"
 import { Button } from "@/components/ui/button"
-import { Shrink, ChevronLeft, ChevronRight } from "lucide-react"
+import { Shrink } from "lucide-react"
+import { Pager } from "@/components/ui/pager"
 import { PopupContentDisplay } from "@/components/maps/popups/popup-content-display"
 import { useGetPopupButtons } from "@/hooks/use-get-popup-buttons"
 import { useZoomToFeature } from "@/hooks/use-zoom-to-feature"
@@ -91,38 +92,17 @@ const PaginatedFeatureList = memo(({
     const start = safePage * POPUP_PAGE_SIZE
     const end = Math.min(start + POPUP_PAGE_SIZE, total)
     const slice = useMemo(() => layer.features.slice(start, end), [layer.features, start, end])
-    const showPager = total > POPUP_PAGE_SIZE
 
     return (
         <>
-            {showPager && (
-                <div className="flex items-center justify-between text-xs text-muted-foreground px-1 pb-1">
-                    <span>{start + 1}–{end} of {total}</span>
-                    <div className="flex items-center gap-1">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 w-6 p-0"
-                            disabled={safePage === 0}
-                            onClick={() => setPage(p => Math.max(0, p - 1))}
-                            aria-label="Previous page"
-                        >
-                            <ChevronLeft className="h-4 w-4" />
-                        </Button>
-                        <span>{safePage + 1}/{totalPages}</span>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 w-6 p-0"
-                            disabled={safePage >= totalPages - 1}
-                            onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
-                            aria-label="Next page"
-                        >
-                            <ChevronRight className="h-4 w-4" />
-                        </Button>
-                    </div>
-                </div>
-            )}
+            <Pager
+                page={safePage}
+                totalPages={totalPages}
+                total={total}
+                pageSize={POPUP_PAGE_SIZE}
+                onPageChange={setPage}
+                className="pb-1"
+            />
             {slice.map((feature, idx) => (
                 <FeatureCard
                     key={`${feature.id ?? start + idx}`}

--- a/src/components/ui/pager.tsx
+++ b/src/components/ui/pager.tsx
@@ -1,0 +1,56 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface PagerProps {
+    /** 0-indexed current page */
+    page: number
+    /** Total number of pages */
+    totalPages: number
+    /** Total item count, used for the "1–10 of 28" range label */
+    total: number
+    /** Items per page, used to derive the range label */
+    pageSize: number
+    onPageChange: (page: number) => void
+    className?: string
+}
+
+/**
+ * Compact range + prev/next pager for inline lists. Renders nothing when there
+ * is only one page. For full numbered link pagination, use `Pagination` instead.
+ */
+export function Pager({ page, totalPages, total, pageSize, onPageChange, className }: PagerProps) {
+    if (totalPages <= 1) return null
+    const safe = Math.min(Math.max(page, 0), totalPages - 1)
+    const start = safe * pageSize
+    const end = Math.min(start + pageSize, total)
+
+    return (
+        <div className={cn('flex items-center justify-between text-xs text-muted-foreground px-1', className)}>
+            <span>{start + 1}–{end} of {total}</span>
+            <div className="flex items-center gap-1">
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    disabled={safe === 0}
+                    onClick={() => onPageChange(Math.max(0, safe - 1))}
+                    aria-label="Previous page"
+                >
+                    <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <span>{safe + 1}/{totalPages}</span>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0"
+                    disabled={safe >= totalPages - 1}
+                    onClick={() => onPageChange(Math.min(totalPages - 1, safe + 1))}
+                    aria-label="Next page"
+                >
+                    <ChevronRight className="h-4 w-4" />
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -9,6 +9,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
+      position="top-center"
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/hooks/use-feature-query.ts
+++ b/src/hooks/use-feature-query.ts
@@ -7,10 +7,11 @@ import {
   type BoxSelectQueryParams,
   type PolygonQueryParams,
   type WfsFeature as ClickedFeature,
+  type VisibleLayersResult,
 } from '@/lib/map/wfs-service'
 
 interface UseFeatureQueryOptions {
-  onPolygonQuerySuccess?: (features: ClickedFeature[]) => void
+  onPolygonQuerySuccess?: (result: VisibleLayersResult) => void
 }
 
 /**
@@ -38,8 +39,8 @@ export function useFeatureQuery(options: UseFeatureQueryOptions = {}) {
   const polygonQuery = useMutation({
     mutationFn: queryPolygonFeatures,
     scope: { id: 'polygon-query' },
-    onSuccess: (features) => {
-      onPolygonQuerySuccess?.(features)
+    onSuccess: (result) => {
+      onPolygonQuerySuccess?.(result)
     },
   })
 

--- a/src/lib/download-utils.ts
+++ b/src/lib/download-utils.ts
@@ -1,6 +1,43 @@
 import { stringify as geojsonToWKT } from 'wellknown'
+import { zipSync, strToU8 } from 'fflate'
 
 export { geojsonToWKT }
+
+/**
+ * Build CSV string from rows + headers without triggering a download.
+ * Use when bundling multiple CSVs into a zip.
+ */
+export function buildCSV<T>(
+  data: T[],
+  headers: string[],
+  getValue: (row: T, key: string) => unknown,
+): string {
+  return [
+    headers.join(','),
+    ...data.map((row) =>
+      headers
+        .map((h) => {
+          const val = getValue(row, h)
+          if (val == null) return ''
+          const str = typeof val === 'object' ? JSON.stringify(val) : String(val)
+          if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+            return `"${str.replace(/"/g, '""')}"`
+          }
+          return str
+        })
+        .join(',')
+    ),
+  ].join('\n')
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
 
 /**
  * Download data as CSV file
@@ -11,32 +48,33 @@ export function downloadCSV<T>(
   headers: string[],
   getValue: (row: T, key: string) => unknown
 ) {
-  const csv = [
-    headers.join(','),
-    ...data.map((row) =>
-      headers
-        .map((h) => {
-          const val = getValue(row, h)
-          if (val == null) return ''
-          // Handle objects/arrays by converting to JSON to avoid [object Object]
-          const str = typeof val === 'object' ? JSON.stringify(val) : String(val)
-          // Escape quotes and wrap in quotes if contains comma/quote/newline
-          if (str.includes(',') || str.includes('"') || str.includes('\n')) {
-            return `"${str.replace(/"/g, '""')}"`
-          }
-          return str
-        })
-        .join(',')
-    ),
-  ].join('\n')
+  downloadCsvString(buildCSV(data, headers, getValue), filename)
+}
 
+/**
+ * Trigger a CSV download from a pre-built string. Use when the CSV is built
+ * elsewhere (e.g., via buildCSV when bundling into a zip but bailing on bundle).
+ */
+export function downloadCsvString(csv: string, filename: string): void {
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename.endsWith('.csv') ? filename : `${filename}.csv`
-  a.click()
-  URL.revokeObjectURL(url)
+  triggerDownload(blob, filename.endsWith('.csv') ? filename : `${filename}.csv`)
+}
+
+/**
+ * Download a set of named files bundled into a single zip.
+ * Files are entries keyed by name (e.g., 'main.csv', 'related-wells.csv').
+ */
+export function downloadZip(files: Record<string, string>, filename: string): void {
+  const entries: Record<string, Uint8Array> = {}
+  for (const [name, content] of Object.entries(files)) {
+    entries[name] = strToU8(content)
+  }
+  const zipped = zipSync(entries)
+  // Copy into a fresh ArrayBuffer to satisfy the Blob constructor's BlobPart typing
+  // (some TS configs reject Uint8Array<ArrayBufferLike> directly).
+  const buf = new Uint8Array(zipped).buffer
+  const blob = new Blob([buf], { type: 'application/zip' })
+  triggerDownload(blob, filename.endsWith('.zip') ? filename : `${filename}.zip`)
 }
 
 /**

--- a/src/lib/map/wfs-service.ts
+++ b/src/lib/map/wfs-service.ts
@@ -22,25 +22,30 @@ type Bounds = {
 // =============================================================================
 
 interface CacheEntry {
-  field: string
+  geometryField: string
+  /** First non-geometry attribute, used as sortBy for paginated WFS requests */
+  sortField: string | null
   timestamp: number
 }
 
-const geometryFieldCache = new Map<string, CacheEntry>()
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+const featureTypeCache = new Map<string, CacheEntry>()
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
 /**
- * Detect the geometry field name for a layer via DescribeFeatureType
+ * Detect geometry field + a sortable attribute via DescribeFeatureType.
+ * GeoServer requires sortBy when paginating tables/views without a PK.
  */
-async function getGeometryField(wfsUrl: string, typeName: string): Promise<string> {
+async function describeFeatureType(wfsUrl: string, typeName: string): Promise<{ geometryField: string; sortField: string | null }> {
   const cacheKey = `${wfsUrl}:${typeName}`
   const now = Date.now()
 
-  // Check cache
-  const cached = geometryFieldCache.get(cacheKey)
+  const cached = featureTypeCache.get(cacheKey)
   if (cached && (now - cached.timestamp) < CACHE_TTL_MS) {
-    return cached.field
+    return { geometryField: cached.geometryField, sortField: cached.sortField }
   }
+
+  let geometryField = 'shape'
+  let sortField: string | null = null
 
   try {
     const url = new URL(wfsUrl)
@@ -54,24 +59,26 @@ async function getGeometryField(wfsUrl: string, typeName: string): Promise<strin
     if (response.ok) {
       const data = await response.json()
       const geometryTypes = ['MultiPolygon', 'Polygon', 'MultiLineString', 'LineString', 'Point', 'MultiPoint', 'Geometry']
+      const props = data.featureTypes?.[0]?.properties || []
 
-      if (data.featureTypes?.[0]?.properties) {
-        for (const prop of data.featureTypes[0].properties) {
-          if (prop.type?.startsWith('gml:') && geometryTypes.includes(prop.localType)) {
-            geometryFieldCache.set(cacheKey, { field: prop.name, timestamp: now })
-            return prop.name
-          }
+      for (const prop of props) {
+        const isGeom = prop.type?.startsWith('gml:') && geometryTypes.includes(prop.localType)
+        if (isGeom && geometryField === 'shape') {
+          geometryField = prop.name
+        } else if (!isGeom && !sortField && prop.name) {
+          sortField = prop.name
         }
+        if (geometryField !== 'shape' && sortField) break
       }
     }
   } catch (err) {
-    console.warn('[WFS] Failed to detect geometry field:', err)
+    console.warn('[WFS] DescribeFeatureType failed:', err)
   }
 
-  // Fallback to 'shape'
-  geometryFieldCache.set(cacheKey, { field: 'shape', timestamp: now })
-  return 'shape'
+  featureTypeCache.set(cacheKey, { geometryField, sortField, timestamp: now })
+  return { geometryField, sortField }
 }
+
 
 /**
  * Convert GeoJSON Polygon to WKT with SRID prefix.
@@ -105,6 +112,8 @@ export interface WfsQueryOptions {
   count?: number
   /** Starting index for pagination */
   startIndex?: number
+  /** Sort attribute (required for stable startIndex pagination on GeoServer tables w/o PK) */
+  sortBy?: string
 }
 
 /**
@@ -122,6 +131,7 @@ function buildWfsUrl(options: WfsQueryOptions): string {
     crs = 'EPSG:4326',
     count,
     startIndex,
+    sortBy,
   } = options
 
   const url = new URL(wfsUrl)
@@ -158,6 +168,7 @@ function buildWfsUrl(options: WfsQueryOptions): string {
   // WFS 1.1.0 uses maxFeatures instead of count
   if (count) url.searchParams.set('maxFeatures', String(count))
   if (startIndex) url.searchParams.set('startIndex', String(startIndex))
+  if (sortBy) url.searchParams.set('sortBy', `${sortBy} A`)
 
   return url.toString()
 }
@@ -198,19 +209,26 @@ export interface QueryOptions {
   maxFeatures?: number
 }
 
+export interface WfsQueryResult {
+  features: Feature[]
+  /** True when paginated query stopped at maxFeatures with more available */
+  truncated: boolean
+}
+
 export async function queryWfs(
   options: WfsQueryOptions,
   queryOptions: QueryOptions = {}
-): Promise<Feature[]> {
+): Promise<WfsQueryResult> {
   const { paginate = false, pageSize = 50, maxFeatures = 10000 } = queryOptions
 
   if (!paginate) {
-    return fetchWfsPage({ ...options, count: options.count || pageSize })
+    const features = await fetchWfsPage({ ...options, count: options.count || pageSize })
+    return { features, truncated: false }
   }
 
-  // Paginated query
   const allFeatures: Feature[] = []
   let startIndex = 0
+  let truncated = false
 
   while (allFeatures.length < maxFeatures) {
     const features = await fetchWfsPage({
@@ -223,9 +241,15 @@ export async function queryWfs(
 
     if (features.length < pageSize) break
     startIndex += pageSize
+
+    if (allFeatures.length >= maxFeatures) {
+      // Hit cap; last page was full so likely more available server-side
+      truncated = true
+      break
+    }
   }
 
-  return allFeatures
+  return { features: allFeatures.slice(0, maxFeatures), truncated }
 }
 
 // =============================================================================
@@ -255,6 +279,12 @@ export interface BoxSelectQueryParams {
   layerFilters?: Record<string, string>
 }
 
+export interface VisibleLayersResult {
+  features: WfsFeature[]
+  /** True if any layer hit its maxFeatures cap */
+  truncated: boolean
+}
+
 /**
  * Query visible layers within bounds, returning simplified features
  * Uses parallel individual queries with INTERSECTS for accuracy
@@ -265,11 +295,9 @@ async function queryVisibleLayers(
   wmsUrl: string,
   options: QueryOptions = {},
   layerFilters?: Record<string, string>
-): Promise<WfsFeature[]> {
-  // Build list of all sublayers to query, with per-layer WFS URL
+): Promise<VisibleLayersResult> {
   const queries: Array<{ typeName: string; layerTitle: string; wfsUrl: string; attributeFilter?: string }> = []
   for (const layer of visibleLayers) {
-    // Use layer's own URL when present, fall back to global wmsUrl
     const layerWfsUrl = (layer.url || wmsUrl).replace(/\/wms\/?$/, '/wfs')
     const dynamicFilter = layerFilters?.[layer.title]
     const staticFilter = layer.customLayerParameters?.cql_filter
@@ -284,35 +312,41 @@ async function queryVisibleLayers(
     }
   }
 
-  if (queries.length === 0) return []
+  if (queries.length === 0) return { features: [], truncated: false }
 
-  // Query all layers in parallel
   const results = await Promise.all(
     queries.map(async ({ typeName, layerTitle, wfsUrl: layerWfsUrl, attributeFilter }) => {
       try {
-        const geometryField = await getGeometryField(layerWfsUrl, typeName)
-        const features = await queryWfs({
+        const { geometryField, sortField } = await describeFeatureType(layerWfsUrl, typeName)
+        const { features, truncated } = await queryWfs({
           wfsUrl: layerWfsUrl,
           typeName,
           geometryField,
           spatialFilter,
           attributeFilter,
+          sortBy: options.paginate ? (sortField ?? undefined) : undefined,
         }, options)
 
-        return features.map(f => ({
-          id: f.id || f.properties?.ogc_fid || 0,
-          properties: (f.properties || {}) as Record<string, unknown>,
-          geometry: f.geometry,
-          layerTitle,
-        }))
+        return {
+          features: features.map(f => ({
+            id: f.id || f.properties?.ogc_fid || 0,
+            properties: (f.properties || {}) as Record<string, unknown>,
+            geometry: f.geometry,
+            layerTitle,
+          })),
+          truncated,
+        }
       } catch (err) {
         console.warn(`[WFS] Failed to query layer ${typeName}:`, err)
-        return []
+        return { features: [] as WfsFeature[], truncated: false }
       }
     })
   )
 
-  return results.flat()
+  return {
+    features: results.flatMap(r => r.features),
+    truncated: results.some(r => r.truncated),
+  }
 }
 
 /**
@@ -336,13 +370,14 @@ export async function queryWFSFeatures(params: ClickQueryParams): Promise<WfsFea
     ]],
   }
 
-  return queryVisibleLayers(visibleLayers, clickPolygon, wmsUrl, { pageSize: 50 }, layerFilters)
+  const { features } = await queryVisibleLayers(visibleLayers, clickPolygon, wmsUrl, { pageSize: 50 }, layerFilters)
+  return features
 }
 
 /**
  * Query features in box select area with pagination
  */
-export async function queryBoxSelectFeatures(params: BoxSelectQueryParams): Promise<WfsFeature[]> {
+export async function queryBoxSelectFeatures(params: BoxSelectQueryParams): Promise<VisibleLayersResult> {
   const { visibleLayers, mapInstance, containerRect, boxSize, pageSize, wmsUrl, layerFilters } = params
 
   const centerX = containerRect.width / 2
@@ -369,7 +404,7 @@ export interface PolygonQueryParams {
   layerFilters?: Record<string, string>
 }
 
-export async function queryPolygonFeatures(params: PolygonQueryParams): Promise<WfsFeature[]> {
-  const { polygon, visibleLayers, wmsUrl, pageSize = 100, layerFilters } = params
+export async function queryPolygonFeatures(params: PolygonQueryParams): Promise<VisibleLayersResult> {
+  const { polygon, visibleLayers, wmsUrl, pageSize = 1000, layerFilters } = params
   return queryVisibleLayers(visibleLayers, polygon, wmsUrl, { paginate: true, pageSize }, layerFilters)
 }

--- a/src/lib/map/wfs-service.ts
+++ b/src/lib/map/wfs-service.ts
@@ -197,15 +197,21 @@ async function fetchWfsPage(options: WfsQueryOptions): Promise<Feature[]> {
   }
 }
 
+// Pagination defaults — also surface to callers that want to tune.
+export const DEFAULT_WFS_PAGE_SIZE = 50
+export const DEFAULT_WFS_MAX_FEATURES = 10000
+const CLICK_PAGE_SIZE = 50
+const POLYGON_PAGE_SIZE = 1000
+
 /**
  * Query WFS with optional pagination
  */
 export interface QueryOptions {
   /** Enable pagination for large result sets */
   paginate?: boolean
-  /** Page size (default: 50) */
+  /** Page size */
   pageSize?: number
-  /** Max total features (default: 10000) */
+  /** Max total features */
   maxFeatures?: number
 }
 
@@ -219,7 +225,7 @@ export async function queryWfs(
   options: WfsQueryOptions,
   queryOptions: QueryOptions = {}
 ): Promise<WfsQueryResult> {
-  const { paginate = false, pageSize = 50, maxFeatures = 10000 } = queryOptions
+  const { paginate = false, pageSize = DEFAULT_WFS_PAGE_SIZE, maxFeatures = DEFAULT_WFS_MAX_FEATURES } = queryOptions
 
   if (!paginate) {
     const features = await fetchWfsPage({ ...options, count: options.count || pageSize })
@@ -370,7 +376,7 @@ export async function queryWFSFeatures(params: ClickQueryParams): Promise<WfsFea
     ]],
   }
 
-  const { features } = await queryVisibleLayers(visibleLayers, clickPolygon, wmsUrl, { pageSize: 50 }, layerFilters)
+  const { features } = await queryVisibleLayers(visibleLayers, clickPolygon, wmsUrl, { pageSize: CLICK_PAGE_SIZE }, layerFilters)
   return features
 }
 
@@ -405,6 +411,6 @@ export interface PolygonQueryParams {
 }
 
 export async function queryPolygonFeatures(params: PolygonQueryParams): Promise<VisibleLayersResult> {
-  const { polygon, visibleLayers, wmsUrl, pageSize = 1000, layerFilters } = params
+  const { polygon, visibleLayers, wmsUrl, pageSize = POLYGON_PAGE_SIZE, layerFilters } = params
   return queryVisibleLayers(visibleLayers, polygon, wmsUrl, { paginate: true, pageSize }, layerFilters)
 }

--- a/src/routes/_map/hazards/-index.tsx
+++ b/src/routes/_map/hazards/-index.tsx
@@ -71,6 +71,7 @@ export default function Map() {
             <Layout.Body>
               <GenericMapContainer
                 onClearSearch={() => searchRef.current?.clear()}
+                disableExport
               />
             </Layout.Body>
 


### PR DESCRIPTION
Export now emits every feature property, not just popupFields.

- Configured columns keep declared order + labels + formatting
- Extra raw keys appended alphabetically
- Column visibility is UI-only; hiding no longer drops from export
- Custom (type=`custom`) fields skipped (derived, not real properties)
- Row scope still follows filter/selection