### PR TITLE
feat(common): popup header restyle and conditional sitla View Report link

### DIFF
--- a/src/components/maps/popups/popup-content-display.tsx
+++ b/src/components/maps/popups/popup-content-display.tsx
@@ -207,7 +207,7 @@ function CollapsibleSection({ label, children }: { label: string; children: Reac
         <div className="flex flex-col space-y-2">
             <button
                 onClick={() => setIsOpen(o => !o)}
-                className="flex items-center gap-1 font-bold text-primary hover:text-primary/80 hover:bg-muted/50 rounded px-1 -ml-1 transition-colors w-full"
+                className="flex items-center gap-1 font-bold text-foreground hover:text-foreground/80 hover:bg-muted/50 rounded px-1 -ml-1 transition-colors w-full"
             >
                 {isOpen ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />}
                 <span className="underline">{label}</span>

--- a/src/components/maps/popups/popup-content-display.tsx
+++ b/src/components/maps/popups/popup-content-display.tsx
@@ -7,7 +7,7 @@ import type { LayerContentProps } from "@/components/maps/popups/types";
 import { Link } from "@/components/ui/link";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { formatNumeric } from "@/lib/utils";
-import { memo, useMemo, useState, ReactNode } from "react";
+import { memo, useMemo, useState, useId, ReactNode } from "react";
 import {
     FieldConfig,
     StringPopupFieldConfig,
@@ -203,21 +203,29 @@ export function buildGalleryImages(
 
 function CollapsibleSection({ label, count, children }: { label: string; count?: number; children: ReactNode }) {
     const [isOpen, setIsOpen] = useState(false);
+    const contentId = useId();
     return (
         <div className="flex flex-col space-y-2">
             <button
                 onClick={() => setIsOpen(o => !o)}
-                className="flex items-center gap-1 font-bold text-foreground hover:text-foreground/80 hover:bg-muted/50 rounded px-1 -ml-1 transition-colors w-full"
+                aria-expanded={isOpen}
+                aria-controls={contentId}
+                className="flex items-center gap-1 font-bold text-foreground hover:text-foreground/80 hover:bg-muted/50 rounded px-1 -ml-1 transition-colors w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-                {isOpen ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />}
+                {isOpen
+                    ? <ChevronDown aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+                    : <ChevronRight aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />}
                 <span className="underline">{label}</span>
                 {count !== undefined && (
-                    <span className="ml-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground no-underline">
+                    <span
+                        aria-label={`${count} item${count === 1 ? '' : 's'}`}
+                        className="ml-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground no-underline"
+                    >
                         {count}
                     </span>
                 )}
             </button>
-            {isOpen && children}
+            {isOpen && <div id={contentId}>{children}</div>}
         </div>
     );
 }

--- a/src/components/maps/popups/popup-content-display.tsx
+++ b/src/components/maps/popups/popup-content-display.tsx
@@ -201,7 +201,7 @@ export function buildGalleryImages(
     return [...fromImageFields, ...fromRelatedTables]
 }
 
-function CollapsibleSection({ label, children }: { label: string; children: ReactNode }) {
+function CollapsibleSection({ label, count, children }: { label: string; count?: number; children: ReactNode }) {
     const [isOpen, setIsOpen] = useState(false);
     return (
         <div className="flex flex-col space-y-2">
@@ -211,6 +211,11 @@ function CollapsibleSection({ label, children }: { label: string; children: Reac
             >
                 {isOpen ? <ChevronDown className="h-3.5 w-3.5 shrink-0" /> : <ChevronRight className="h-3.5 w-3.5 shrink-0" />}
                 <span className="underline">{label}</span>
+                {count !== undefined && (
+                    <span className="ml-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground no-underline">
+                        {count}
+                    </span>
+                )}
             </button>
             {isOpen && children}
         </div>
@@ -384,7 +389,7 @@ const PopupContentDisplayInner = ({ feature, layout, layer, bulkRelatedData }: P
         if (useTableFormat) {
             const headers = table.displayFields!.map(df => df.label || df.field);
             relatedContent = (
-                <CollapsibleSection key={`related-${table.fieldLabel}-${tableIndex}`} label={sectionLabel}>
+                <CollapsibleSection key={`related-${table.fieldLabel}-${tableIndex}`} label={sectionLabel} count={groupedValues.length}>
                     <Table>
                         <TableHeader>
                             <TableRow>
@@ -409,7 +414,7 @@ const PopupContentDisplayInner = ({ feature, layout, layer, bulkRelatedData }: P
             );
         } else {
             relatedContent = (
-                <CollapsibleSection key={`related-${table.fieldLabel}-${tableIndex}`} label={sectionLabel}>
+                <CollapsibleSection key={`related-${table.fieldLabel}-${tableIndex}`} label={sectionLabel} count={groupedValues.length}>
                     {groupedValues.map((group, groupIdx) => (
                         <div key={`group-${groupIdx}`} className="flex flex-col">
                             {group.map((valueItem, valueIdx) => (

--- a/src/components/maps/popups/popup-content-display.tsx
+++ b/src/components/maps/popups/popup-content-display.tsx
@@ -266,8 +266,8 @@ const PopupContentDisplayInner = ({ feature, layout, layer, bulkRelatedData }: P
         return (
             <div className="space-y-4">
                 <div className="flex flex-col">
-                    <p className="font-bold underline text-primary">{rasterSource.valueLabel}</p>
-                    <p className="break-words">{displayValue}</p>
+                    <p className="font-bold underline text-foreground">{rasterSource.valueLabel}</p>
+                    <p className="break-words text-foreground/80">{displayValue}</p>
                 </div>
             </div>
         );
@@ -348,8 +348,8 @@ const PopupContentDisplayInner = ({ feature, layout, layer, bulkRelatedData }: P
         ) : label;
         const content = (
             <div key={`feature-item-${label}-${index}`} className="flex flex-col">
-                <p className="font-bold underline text-primary">{labelContent}</p>
-                <div className="break-words">
+                <p className="font-bold underline text-foreground">{labelContent}</p>
+                <div className="break-words text-foreground/80">
                     {hasColorStyling ? (
                         <span className={colorStyle.className} style={colorStyle.style}>
                             {renderFieldContent(finalDisplayValue, fieldKey, properties, linkFields, urlPattern)}

--- a/src/components/maps/popups/popup-content-with-pagination.tsx
+++ b/src/components/maps/popups/popup-content-with-pagination.tsx
@@ -286,8 +286,8 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                         return (
                             <div key={`${layer.groupLayerTitle}-${layer.layerTitle}-${layerIdx}`}>
                                 {/* Layer header */}
-                                <div className="text-base font-bold text-primary uppercase tracking-wide mb-2 px-1">
-                                    Layer: {layer.layerTitle || layer.groupLayerTitle}
+                                <div className="text-base text-primary mb-2 px-1">
+                                    <span className="font-bold uppercase tracking-wide">Layer:</span> <span className="capitalize">{layer.layerTitle || layer.groupLayerTitle}</span>
                                 </div>
                                 {/* Features or raster-only content */}
                                 <div className="space-y-2">

--- a/src/components/maps/popups/popup-content-with-pagination.tsx
+++ b/src/components/maps/popups/popup-content-with-pagination.tsx
@@ -286,8 +286,8 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                         return (
                             <div key={`${layer.groupLayerTitle}-${layer.layerTitle}-${layerIdx}`}>
                                 {/* Layer header */}
-                                <div className="text-base text-primary mb-2 px-1">
-                                    <span className="font-bold uppercase tracking-wide">Layer:</span> <span className="capitalize">{layer.layerTitle || layer.groupLayerTitle}</span>
+                                <div className="text-base font-bold text-primary mb-2 px-1">
+                                    <span className="uppercase tracking-wide">Layer:</span> <span className="capitalize">{layer.layerTitle || layer.groupLayerTitle}</span>
                                 </div>
                                 {/* Features or raster-only content */}
                                 <div className="space-y-2">

--- a/src/components/maps/popups/popup-content-with-pagination.tsx
+++ b/src/components/maps/popups/popup-content-with-pagination.tsx
@@ -286,8 +286,8 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                         return (
                             <div key={`${layer.groupLayerTitle}-${layer.layerTitle}-${layerIdx}`}>
                                 {/* Layer header */}
-                                <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 px-1">
-                                    {layer.layerTitle || layer.groupLayerTitle}
+                                <div className="text-base font-bold text-primary uppercase tracking-wide mb-2 px-1">
+                                    Layer: {layer.layerTitle || layer.groupLayerTitle}
                                 </div>
                                 {/* Features or raster-only content */}
                                 <div className="space-y-2">

--- a/src/routes/_map/carbonstorage/-data/layers/layers.tsx
+++ b/src/routes/_map/carbonstorage/-data/layers/layers.tsx
@@ -715,7 +715,16 @@ const sitlaReportsWMSConfig: WMSLayerProps = {
                     }
                 },
                 'Description': { field: 'description', type: 'string' },
-                'Report': { field: 'linktoreport', type: 'string', transform: () => 'Coming Soon' },
+                'Report': { field: 'linktoreport', type: 'string' },
+            },
+            linkFields: {
+                'linktoreport': {
+                    transform: (value: unknown) => {
+                        const str = String(value ?? '');
+                        if (!str || !str.startsWith('http')) return [];
+                        return [{ label: 'View Report', href: str }];
+                    },
+                },
             },
             colorCodingMap: {
                 'ranking': (value: string | number) => {


### PR DESCRIPTION
## Summary
- Layer header in popup now reads `LAYER: <name>` in orange, bold, larger size
- Field labels: white, bold, underlined (theme-aware via `text-foreground`, no longer orange)
- Field values: 80% white (`text-foreground/80`) for subtle hierarchy without zebra striping
- Sitla Reports layer now has a View Report link if there is a report attached to the polygon