### PR TITLE
feat(common): add COG raster layer type with pixel sample popup and legend range override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "geohaz-v2",
       "version": "1.0.0-beta.2",
       "dependencies": {
+        "@geomatico/maplibre-cog-protocol": "^0.8.0",
         "@maplibre/maplibre-gl-style-spec": "^24.3.1",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -2083,6 +2084,33 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@geomatico/maplibre-cog-protocol": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@geomatico/maplibre-cog-protocol/-/maplibre-cog-protocol-0.8.0.tgz",
+      "integrity": "sha512-q5Pg7pOp/fRB/UrAUEZ4AEF/B68XwvxMg0YRk0z+UwwHfOKQThkY7u91Kusx2AwIme6QOURFK6Fvw39ooj68RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/sphericalmercator": "^1.2.0",
+        "d3-scale": "^4.0.2",
+        "geotiff": "^2.1.3",
+        "quick-lru": "^7.1.0"
+      },
+      "peerDependencies": {
+        "maplibre-gl": "^4.5.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@geomatico/maplibre-cog-protocol/node_modules/quick-lru": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-7.3.0.tgz",
+      "integrity": "sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.9.15",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
@@ -2344,6 +2372,17 @@
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
       "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
       "license": "ISC"
+    },
+    "node_modules/@mapbox/sphericalmercator": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.2.0.tgz",
+      "integrity": "sha512-ZTOuuwGuMOJN+HEmG/68bSEw15HHaMWmQ5gdTsWdWsjDe56K1kGvLOK6bOSC8gWgIvEO0w6un/2Gvv1q5hJSkQ==",
+      "bin": {
+        "bbox": "bin/bbox.js",
+        "to4326": "bin/to4326.js",
+        "to900913": "bin/to900913.js",
+        "xyz": "bin/xyz.js"
+      }
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "2.0.7",
@@ -2956,6 +2995,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -8010,6 +8055,24 @@
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-geo": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
@@ -8017,6 +8080,82 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "1"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/dargs": {
@@ -9456,6 +9595,37 @@
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "license": "ISC"
     },
+    "node_modules/geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -10034,6 +10204,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/into-stream": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
@@ -10572,6 +10751,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -14673,6 +14858,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -18416,6 +18607,12 @@
       "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
       "license": "Apache-2.0"
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
@@ -18576,6 +18773,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -18657,6 +18860,12 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@geomatico/maplibre-cog-protocol": "^0.8.0",
     "@maplibre/maplibre-gl-style-spec": "^24.3.1",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/src/components/maps/cog-legend.tsx
+++ b/src/components/maps/cog-legend.tsx
@@ -9,6 +9,7 @@ export function CogLegend({ layer }: { layer: COGLayerProps }) {
     const range = useCogRange(layer)
 
     const svg = useMemo(() => {
+        if (!range) return null
         const [min, max] = range
         const n = layer.colorStops.length
         // Synthesize a GeoServer-shaped Symbolizer so we reuse createRasterSymbol's gradient + labels.
@@ -28,5 +29,6 @@ export function CogLegend({ layer }: { layer: COGLayerProps }) {
         return createRasterSymbol(symbolizers, { unit: layer.legendUnit, range })
     }, [layer.colorStops, layer.legendUnit, range])
 
+    if (!svg) return null
     return <span className="block px-0.5 py-1" ref={mountDomNode(svg)} />
 }

--- a/src/components/maps/cog-legend.tsx
+++ b/src/components/maps/cog-legend.tsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { createRasterSymbol } from '@/lib/legend/symbolizers/raster'
+import { mountDomNode } from '@/lib/legend/mount-dom-node'
+import { useCogRange } from '@/hooks/use-cog-metadata'
+import type { COGLayerProps } from '@/lib/types/mapping-types'
+import type { Symbolizer } from '@/lib/types/geoserver-types'
+
+export function CogLegend({ layer }: { layer: COGLayerProps }) {
+    const range = useCogRange(layer)
+
+    const svg = useMemo(() => {
+        const [min, max] = range
+        const n = layer.colorStops.length
+        // Synthesize a GeoServer-shaped Symbolizer so we reuse createRasterSymbol's gradient + labels.
+        const symbolizers: Symbolizer[] = [{
+            Raster: {
+                colormap: {
+                    type: 'ramp',
+                    entries: layer.colorStops.map((color, i) => ({
+                        color,
+                        quantity: String(min + ((max - min) * i) / (n - 1)),
+                        opacity: '1',
+                        label: '',
+                    })),
+                },
+            },
+        }]
+        return createRasterSymbol(symbolizers, { unit: layer.legendUnit, range })
+    }, [layer.colorStops, layer.legendUnit, range])
+
+    return <span className="block px-0.5 py-1" ref={mountDomNode(svg)} />
+}

--- a/src/components/maps/cog-pixel-highlight.tsx
+++ b/src/components/maps/cog-pixel-highlight.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react'
+import { Source, Layer } from 'react-map-gl/maplibre'
+import { useCogMetadata, computeCogPixelPolygon } from '@/hooks/use-cog-metadata'
+import { HIGHLIGHT_COLORS } from '@/lib/map/cog/setup'
+import type { COGLayerProps } from '@/lib/types/mapping-types'
+import type { FeatureCollection, Polygon } from 'geojson'
+
+/**
+ * Highlights the actual COG pixel cell containing the click point.
+ * Snaps to the COG's native grid (using resolution + origin from TIFF metadata)
+ * so the user sees what was sampled, not just where they clicked.
+ */
+export function CogPixelHighlight({
+    layer, clickPoint,
+}: { layer: COGLayerProps; clickPoint: { lng: number; lat: number } | null }) {
+    const { data: metadata } = useCogMetadata(layer.cogUrl)
+
+    const cellGeoJson = useMemo<FeatureCollection<Polygon> | null>(() => {
+        if (!clickPoint || !metadata) return null
+        const polygon = computeCogPixelPolygon(clickPoint, metadata)
+        if (!polygon) return null
+        return { type: 'FeatureCollection', features: [{ type: 'Feature', geometry: polygon, properties: {} }] }
+    }, [clickPoint, metadata])
+
+    if (!cellGeoJson) return null
+
+    const sourceId = `cog-pixel-${layer.title}`
+    return (
+        <Source id={sourceId} type="geojson" data={cellGeoJson}>
+            <Layer id={`${sourceId}-fill`} type="fill" paint={{ 'fill-color': HIGHLIGHT_COLORS.cog, 'fill-opacity': 0.25 }} />
+            <Layer id={`${sourceId}-line`} type="line" paint={{ 'line-color': HIGHLIGHT_COLORS.cog, 'line-width': 2 }} />
+        </Source>
+    )
+}

--- a/src/components/maps/controls/export-control.ts
+++ b/src/components/maps/controls/export-control.ts
@@ -28,6 +28,11 @@ export interface LegendItem {
         yTicks: string[];
         noData?: { color: string; opacity: number; label: string };
     };
+    /** Full-width raster colorbar (e.g. COG layers). svgHeight is the SVG's intrinsic height in px. */
+    raster?: {
+        svgHtml: string;
+        svgHeight: number;
+    };
 }
 
 export interface MapBounds {
@@ -619,6 +624,7 @@ export class ExportControl implements maplibregl.IControl {
 
         const hasBivariate = legendData.some(l => l.bivariate);
         const bivariateCellSize = 30 * scale;
+        const rasterBottomGap = 4 * scale;
 
         // Calculate total height needed
         let totalHeight = padding * 2;
@@ -628,6 +634,8 @@ export class ExportControl implements maplibregl.IControl {
                 const bvRows = layer.bivariate.colors.length;
                 // axis label + grid + tick labels + optional nodata
                 totalHeight += 14 * scale + bvRows * bivariateCellSize + 14 * scale + (layer.bivariate.noData ? 16 * scale : 0);
+            } else if (layer.raster) {
+                totalHeight += layer.raster.svgHeight * scale + rasterBottomGap;
             } else {
                 totalHeight += layer.symbols.length * rowHeight;
             }
@@ -637,8 +645,9 @@ export class ExportControl implements maplibregl.IControl {
         const maxHeight = canvasHeight - margin - 60 * scale - 100 * scale;
         const constrainedHeight = Math.min(totalHeight, maxHeight);
 
-        // Position in bottom-left, above scale bar — wider panel when bivariate content is present
-        const maxWidth = (hasBivariate ? 260 : 200) * scale;
+        // Position in bottom-left, above scale bar — wider panel for bivariate / raster colorbar content
+        const hasRaster = legendData.some(l => l.raster);
+        const maxWidth = (hasBivariate ? 260 : hasRaster ? 240 : 200) * scale;
         const x = margin;
         const y = canvasHeight - margin - constrainedHeight - 60 * scale;
 
@@ -673,6 +682,17 @@ export class ExportControl implements maplibregl.IControl {
 
             if (layer.bivariate) {
                 currentY += this.drawBivariateLegend(ctx, x + padding, currentY, maxWidth - padding * 2, scale, layer.bivariate);
+            } else if (layer.raster) {
+                const barW = maxWidth - padding * 2;
+                const barH = layer.raster.svgHeight * scale;
+                try {
+                    const img = await this.svgToImage(layer.raster.svgHtml, barW, barH);
+                    ctx.drawImage(img, x + padding, currentY, barW, barH);
+                } catch {
+                    ctx.fillStyle = '#ccc';
+                    ctx.fillRect(x + padding, currentY, barW, barH);
+                }
+                currentY += barH + rasterBottomGap;
             } else {
                 // Symbols
                 ctx.font = `${10 * scale}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
@@ -853,7 +873,11 @@ export class ExportControl implements maplibregl.IControl {
         let totalHeight = padding * 2;
         for (const layer of legendData) {
             totalHeight += titleHeight + layerGap;
-            totalHeight += layer.symbols.length * rowHeight;
+            if (layer.raster) {
+                totalHeight += layer.raster.svgHeight * scale + 4 * scale;
+            } else {
+                totalHeight += layer.symbols.length * rowHeight;
+            }
         }
 
         const canvas = document.createElement('canvas');
@@ -877,21 +901,34 @@ export class ExportControl implements maplibregl.IControl {
             ctx.fillText(layer.layerTitle, padding, currentY, maxWidth - padding * 2);
             currentY += titleHeight;
 
-            // Symbols
-            ctx.font = `${12 * scale}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
-            for (const symbol of layer.symbols) {
+            if (layer.raster) {
+                const barW = maxWidth - padding * 2;
+                const barH = layer.raster.svgHeight * scale;
                 try {
-                    const img = await this.svgToImage(symbol.svgHtml, symbolSize, symbolSize);
-                    ctx.drawImage(img, padding, currentY, symbolSize, rowHeight - 4 * scale);
+                    const img = await this.svgToImage(layer.raster.svgHtml, barW, barH);
+                    ctx.drawImage(img, padding, currentY, barW, barH);
                 } catch {
                     ctx.fillStyle = '#ccc';
-                    ctx.fillRect(padding, currentY + 2 * scale, symbolSize, rowHeight - 4 * scale);
+                    ctx.fillRect(padding, currentY, barW, barH);
                 }
+                currentY += barH + 4 * scale;
+            } else {
+                // Symbols
+                ctx.font = `${12 * scale}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+                for (const symbol of layer.symbols) {
+                    try {
+                        const img = await this.svgToImage(symbol.svgHtml, symbolSize, symbolSize);
+                        ctx.drawImage(img, padding, currentY, symbolSize, rowHeight - 4 * scale);
+                    } catch {
+                        ctx.fillStyle = '#ccc';
+                        ctx.fillRect(padding, currentY + 2 * scale, symbolSize, rowHeight - 4 * scale);
+                    }
 
-                ctx.fillStyle = '#333';
-                ctx.textBaseline = 'middle';
-                ctx.fillText(symbol.label, padding + symbolSize + 8 * scale, currentY + rowHeight / 2, maxWidth - padding * 2 - symbolSize - 12 * scale);
-                currentY += rowHeight;
+                    ctx.fillStyle = '#333';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillText(symbol.label, padding + symbolSize + 8 * scale, currentY + rowHeight / 2, maxWidth - padding * 2 - symbolSize - 12 * scale);
+                    currentY += rowHeight;
+                }
             }
 
             currentY += layerGap;

--- a/src/components/maps/data-map.tsx
+++ b/src/components/maps/data-map.tsx
@@ -13,11 +13,14 @@ import {
 import { BASEMAP_STYLES, DEFAULT_BASEMAP } from '@/lib/basemaps'
 import { BoxSelectOverlay, ViewModeControl, MapToolsControl } from './controls'
 import { HighlightLayers, SpatialFilterLayer, ClickBufferLayer } from './layers'
-import { flattenVisibleDataLayers, isWMSLayer, isWFSLayer, isArcGISMapServerLayer, buildWmsTileUrl, buildArcGisExportUrl, getWmsLayerName } from '@/lib/map/layer-utils'
-import type { WMSLayerProps, WFSLayerProps, ArcGISMapServerLayerProps } from '@/lib/types/mapping-types'
+import { flattenVisibleDataLayers, isWMSLayer, isWFSLayer, isArcGISMapServerLayer, isCOGLayer, buildWmsTileUrl, buildArcGisExportUrl, getWmsLayerName } from '@/lib/map/layer-utils'
+import type { WMSLayerProps, WFSLayerProps, ArcGISMapServerLayerProps, COGLayerProps } from '@/lib/types/mapping-types'
 import type maplibregl from 'maplibre-gl'
 import type { FeatureCollection } from 'geojson'
 
+import { useCogRange } from '@/hooks/use-cog-metadata'
+import { CogPixelHighlight } from '@/components/maps/cog-pixel-highlight'
+import { buildCogProtocolUrl } from '@/lib/map/cog/setup'
 import { calculateBboxFromGeometry } from '@/lib/map/geometry-utils'
 import { getBboxCenter } from '@/lib/map/conversion-utils'
 import { useTerraDraw } from '@/hooks/use-terra-draw'
@@ -31,13 +34,31 @@ import { MapContextMenu, type ContextMenuCoords } from './map-context-menu'
 // Re-export types for consumers
 export type { DrawMode, SpatialFilter, HighlightFeature, ClickedFeature, DataMapProps } from './types'
 
-type DataLayer = WMSLayerProps | WFSLayerProps | ArcGISMapServerLayerProps
+type DataLayer = WMSLayerProps | WFSLayerProps | ArcGISMapServerLayerProps | COGLayerProps
 
 // MapLibre layer id used for z-order lookups. Keep prefixes stable — popup/query code greps for them.
 function getLayerId(layer: DataLayer): string {
   if (isWMSLayer(layer)) return `wms-layer-${layer.title}`
   if (isWFSLayer(layer)) return `${getWfsSourceId(layer)}-circle`
+  if (isCOGLayer(layer)) return `cog-layer-${layer.title}`
   return `arcgis-layer-${layer.title}`
+}
+
+function CogLayerSource({ layer, beforeId }: { layer: COGLayerProps; beforeId: string | undefined }) {
+  // Dynamic stretch from COG-embedded stats (gdal_edit -stats); STAC URL is fallback.
+  const range = useCogRange(layer)
+  const tileUrl = buildCogProtocolUrl(layer, range)
+  return (
+    <Source id={`cog-${layer.title}`} type="raster" url={tileUrl} tileSize={256}>
+      <Layer
+        id={`cog-layer-${layer.title}`}
+        beforeId={beforeId}
+        type="raster"
+        paint={{ 'raster-opacity': layer.opacity ?? 0.9 }}
+        metadata={{ title: layer.title, cogUrl: layer.cogUrl }}
+      />
+    </Source>
+  )
 }
 
 function WmsLayerSource({
@@ -204,6 +225,18 @@ export default function DataMap({
   const visibleLayers = useMemo(() => flattenVisibleDataLayers(layers), [layers])
   const visibleWmsLayers = useMemo(() => visibleLayers.filter(isWMSLayer), [visibleLayers])
   const visibleWfsLayers = useMemo(() => visibleLayers.filter(isWFSLayer), [visibleLayers])
+  const visibleCogLayers = useMemo(() => visibleLayers.filter(isCOGLayer), [visibleLayers])
+  // Vector buffer box is meaningful only when a vector layer is the click target; raster sampling alone uses the pixel highlight.
+  const hasVectorClickTarget = useMemo(() => visibleWmsLayers.length > 0 || visibleWfsLayers.length > 0, [visibleWmsLayers, visibleWfsLayers])
+  // Any clickable layer (WMS / WFS / COG) gates the click handler + URL-state restore.
+  const hasClickableLayers = useMemo(
+    () => visibleWmsLayers.length > 0 || visibleWfsLayers.length > 0 || visibleCogLayers.length > 0,
+    [visibleWmsLayers, visibleWfsLayers, visibleCogLayers]
+  )
+  const cogClickPoint = useMemo(
+    () => clickBufferBounds ? getBboxCenter(clickBufferBounds) : null,
+    [clickBufferBounds]
+  )
 
   // Fetch WFS layer data using TanStack Query (automatic caching, retries, deduplication)
   const { data: wfsLayerData } = useWfsLayerData(visibleWfsLayers)
@@ -411,7 +444,7 @@ export default function DataMap({
       justFinishedDrawingRef.current = false
       return
     }
-    if (!onFeatureClick || (visibleWmsLayers.length === 0 && visibleWfsLayers.length === 0)) return
+    if (!onFeatureClick || !hasClickableLayers) return
 
     const map = mapRef.current?.getMap()
     if (!map) return
@@ -426,7 +459,7 @@ export default function DataMap({
 
     const isAdditive = isAdditiveMode || (e.originalEvent?.shiftKey ?? false)
     queryAtPoint(map, e.point, clickTolerance, isAdditive, { extractBbox: true, clearOnEmpty: true })
-  }, [onFeatureClick, visibleWmsLayers, visibleWfsLayers, clickTolerance, isAdditiveMode, clickQuery, boxSelectMode, activeDrawShape, onClickBufferChange, onFeatureBboxChange, justFinishedDrawingRef, wmsUrl, spatialFilter, onSpatialFilterChange, layerFilters])
+  }, [onFeatureClick, hasClickableLayers, clickTolerance, isAdditiveMode, clickQuery, boxSelectMode, activeDrawShape, onClickBufferChange, onFeatureBboxChange, justFinishedDrawingRef, wmsUrl, spatialFilter, onSpatialFilterChange, layerFilters])
 
   // Handle map move end - track zoom only (box select now uses click-to-confirm)
   const handleMoveEnd = useCallback(() => {
@@ -497,8 +530,7 @@ export default function DataMap({
       onMapReady?.(map)
 
       // Restore query from URL if clickBufferBounds exists
-      const hasLayers = visibleWmsLayers.length > 0 || visibleWfsLayers.length > 0
-      if (!hasRestoredRef.current && clickBufferBounds && onFeatureClick && hasLayers) {
+      if (!hasRestoredRef.current && clickBufferBounds && onFeatureClick && hasClickableLayers) {
         hasRestoredRef.current = true
 
         const center = getBboxCenter(clickBufferBounds)
@@ -512,7 +544,7 @@ export default function DataMap({
         queryAtPoint(map, centerPoint, tolerance || clickTolerance, false)
       }
     }
-  }, [onMapReady, clickBufferBounds, onFeatureClick, visibleWmsLayers, visibleWfsLayers, clickTolerance, clickQuery, wmsUrl, layerFilters, onClickBufferChange])
+  }, [onMapReady, clickBufferBounds, onFeatureClick, hasClickableLayers, clickTolerance, clickQuery, wmsUrl, layerFilters, onClickBufferChange])
 
   // Combine loading states
   const showLoading = isLoading || queryLoading
@@ -550,7 +582,7 @@ export default function DataMap({
 
   const handleQueryHere = useCallback((coords: { lng: number; lat: number }) => {
     const map = mapRef.current?.getMap()
-    if (!map || !onFeatureClick || (visibleWmsLayers.length === 0 && visibleWfsLayers.length === 0)) return
+    if (!map || !onFeatureClick || !hasClickableLayers) return
 
     const point = map.project([coords.lng, coords.lat])
 
@@ -560,7 +592,7 @@ export default function DataMap({
     onClickBufferChange?.({ sw: [sw.lng, sw.lat], ne: [ne.lng, ne.lat] })
 
     queryAtPoint(map, point, clickTolerance, false)
-  }, [visibleWmsLayers, visibleWfsLayers, clickTolerance, clickQuery, wmsUrl, onFeatureClick, onClickBufferChange, layerFilters])
+  }, [hasClickableLayers, clickTolerance, clickQuery, wmsUrl, onFeatureClick, onClickBufferChange, layerFilters])
 
   const handleZoomIn = useCallback((coords: { lng: number; lat: number }) => {
     const map = mapRef.current?.getMap()
@@ -664,6 +696,9 @@ export default function DataMap({
           if (isArcGISMapServerLayer(layer)) {
             return <ArcGisLayerSource key={layer.title} layer={layer} beforeId={beforeId} />
           }
+          if (isCOGLayer(layer)) {
+            return <CogLayerSource key={layer.title} layer={layer} beforeId={beforeId} />
+          }
           return null
         })}
 
@@ -673,8 +708,13 @@ export default function DataMap({
         {/* Spatial filter visualization */}
         <SpatialFilterLayer filter={spatialFilter} />
 
-        {/* Click buffer visualization */}
-        {clickBufferBounds && <ClickBufferLayer bounds={clickBufferBounds} />}
+        {/* Click buffer visualization — vector click tolerance area; suppressed when only raster active */}
+        {clickBufferBounds && hasVectorClickTarget && <ClickBufferLayer bounds={clickBufferBounds} />}
+
+        {/* Pixel cell highlight per visible COG layer — shows actual sampled pixel */}
+        {visibleCogLayers.map(layer => (
+          <CogPixelHighlight key={`pixel-${layer.title}`} layer={layer} clickPoint={cogClickPoint} />
+        ))}
 
         {/* Frozen box select bounds visualization */}
         {boxSelectBounds && <ClickBufferLayer bounds={boxSelectBounds} />}

--- a/src/components/maps/data-map.tsx
+++ b/src/components/maps/data-map.tsx
@@ -48,6 +48,7 @@ function getLayerId(layer: DataLayer): string {
 function CogLayerSource({ layer, beforeId }: { layer: COGLayerProps; beforeId: string | undefined }) {
   // Dynamic stretch from COG-embedded stats (gdal_edit -stats); STAC URL is fallback.
   const range = useCogRange(layer)
+  if (!range) return null
   const tileUrl = buildCogProtocolUrl(layer, range)
   return (
     <Source id={`cog-${layer.title}`} type="raster" url={tileUrl} tileSize={256}>

--- a/src/components/maps/generic-map-container.tsx
+++ b/src/components/maps/generic-map-container.tsx
@@ -25,9 +25,11 @@ import type { LegendItem } from '@/components/maps/controls'
 import { useFeatureSelection } from '@/hooks/use-feature-selection'
 import { usePopupData } from '@/hooks/use-popup-data'
 import { getBboxCenter } from '@/lib/map/conversion-utils'
-import type { LayerProps, WMSLayerProps } from '@/lib/types/mapping-types'
+import type { LayerProps, WMSLayerProps, COGLayerProps } from '@/lib/types/mapping-types'
 import { createSVGSymbol } from '@/lib/legend/symbol-generator'
-import type { Legend } from '@/lib/types/geoserver-types'
+import { createRasterSymbol } from '@/lib/legend/symbolizers/raster'
+import { loadCogMetadata, deriveRange } from '@/hooks/use-cog-metadata'
+import type { Legend, Symbolizer } from '@/lib/types/geoserver-types'
 
 interface MapBounds {
   west: number
@@ -82,7 +84,20 @@ async function fetchLegendDataForVisibleLayers(
     return visible
   }
 
+  const getVisibleCogLayers = (layerArray: LayerProps[]): COGLayerProps[] => {
+    const visible: COGLayerProps[] = []
+    for (const layer of layerArray) {
+      if (layer.type === 'group' && 'layers' in layer) {
+        visible.push(...getVisibleCogLayers(layer.layers || []))
+      } else if (layer.type === 'cog' && layer.visible) {
+        visible.push(layer as COGLayerProps)
+      }
+    }
+    return visible
+  }
+
   const visibleLayers = getVisibleWmsLayers(layers)
+  const visibleCogLayers = getVisibleCogLayers(layers)
 
   // Fetch legend for each visible layer
   for (const layer of visibleLayers) {
@@ -198,6 +213,43 @@ async function fetchLegendDataForVisibleLayers(
       }
     } catch (e) {
       console.warn(`Failed to fetch legend for ${layer.layerName}:`, e)
+    }
+  }
+
+  // COG raster colorbars — fetch embedded stats / STAC stats, build a horizontal ramp
+  for (const cogLayer of visibleCogLayers) {
+    try {
+      const meta = await loadCogMetadata(cogLayer.cogUrl, cogLayer.stacUrl)
+      if (!meta) continue
+      const range = deriveRange(meta, cogLayer.stretchMode ?? 'minmax')
+      const n = cogLayer.colorStops.length
+      const [rmin, rmax] = range
+      const symbolizers: Symbolizer[] = [{
+        Raster: {
+          colormap: {
+            type: 'ramp',
+            entries: cogLayer.colorStops.map((color, i) => ({
+              color,
+              quantity: String(rmin + ((rmax - rmin) * i) / (n - 1)),
+              opacity: '1',
+              label: '',
+            })),
+          },
+        },
+      }]
+      const svg = createRasterSymbol(symbolizers, { unit: cogLayer.legendUnit, range })
+      const svgHeight = parseFloat(svg.getAttribute('height') ?? '40') || 40
+      // Drop the `width="100%"` attribute — svgToImage rasterizes the SVG standalone, so a percentage
+      // width has no parent to resolve against. Without an explicit width the colorbar collapses.
+      svg.setAttribute('width', '240')
+      svg.setAttribute('preserveAspectRatio', 'none')
+      results.push({
+        layerTitle: cogLayer.title,
+        symbols: [],
+        raster: { svgHtml: svg.outerHTML, svgHeight },
+      })
+    } catch (e) {
+      console.warn(`Failed to build legend for COG layer ${cogLayer.title}:`, e)
     }
   }
 

--- a/src/components/maps/generic-map-container.tsx
+++ b/src/components/maps/generic-map-container.tsx
@@ -561,6 +561,7 @@ export default function GenericMapContainer({
               width={panelState.sheetWidth}
               onWidthChange={(width) => setPanelState(prev => ({ ...prev, sheetWidth: width }))}
               isOpen={panelState.isSheetOpen}
+              clickPoint={clickPoint}
             />
           </div>
         )}
@@ -584,6 +585,7 @@ export default function GenericMapContainer({
               onOpenChange={handleSheetOpenChange}
               onHighlightChange={handleHighlightChange}
               isOpen={panelState.isSheetOpen}
+              clickPoint={clickPoint}
             />
           </div>
         )}

--- a/src/components/maps/layer-controls.tsx
+++ b/src/components/maps/layer-controls.tsx
@@ -24,7 +24,6 @@ interface LayerControlsProps {
     bivariateLegend?: { xLabel: string; yLabel: string };
     arcgisUrl?: string;
     legendUnit?: string;
-    legendRange?: [number, number];
     /** GeoParquet URL for client-side export. When set, download dropdown is enabled. */
     downloadParquetUrl?: string;
     /** When true, hide format-conversion dropdown and offer only a direct parquet download. Used for apps that require unmodified source data. */
@@ -45,7 +44,6 @@ const LayerControls: React.FC<LayerControlsProps> = ({
     bivariateLegend,
     arcgisUrl,
     legendUnit,
-    legendRange,
     downloadParquetUrl,
     disableExport = false,
 }) => {
@@ -172,7 +170,6 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                     bivariateLegend={bivariateLegend}
                     arcgisUrl={arcgisUrl}
                     legendUnit={legendUnit}
-                    legendRange={legendRange}
                 />
             </div>
         </div>

--- a/src/components/maps/layer-controls.tsx
+++ b/src/components/maps/layer-controls.tsx
@@ -23,6 +23,7 @@ interface LayerControlsProps {
     bivariateLegend?: { xLabel: string; yLabel: string };
     arcgisUrl?: string;
     legendUnit?: string;
+    legendRange?: [number, number];
 }
 
 const LayerControls: React.FC<LayerControlsProps> = ({
@@ -39,6 +40,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
     bivariateLegend,
     arcgisUrl,
     legendUnit,
+    legendRange,
 }) => {
     // Sync activeTab with openLegend prop, but let the user toggle freely afterwards
     const [prevOpenLegend, setPrevOpenLegend] = useState(openLegend);
@@ -159,6 +161,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                     bivariateLegend={bivariateLegend}
                     arcgisUrl={arcgisUrl}
                     legendUnit={legendUnit}
+                    legendRange={legendRange}
                 />
             </div>
         </div>

--- a/src/components/maps/layers/filter-layers.tsx
+++ b/src/components/maps/layers/filter-layers.tsx
@@ -62,16 +62,10 @@ export function ClickBufferLayer({ bounds }: ClickBufferLayerProps) {
       }}
     >
       <Layer
-        id="click-buffer-fill"
-        type="fill"
-        source="click-buffer-source"
-        paint={{ 'fill-color': HIGHLIGHT_COLORS.vector, 'fill-opacity': 0.2 }}
-      />
-      <Layer
         id="click-buffer-outline"
         type="line"
         source="click-buffer-source"
-        paint={{ 'line-color': HIGHLIGHT_COLORS.vector, 'line-width': 2, 'line-dasharray': [3, 2] }}
+        paint={{ 'line-color': HIGHLIGHT_COLORS.vector, 'line-width': 1.5, 'line-dasharray': [3, 2], 'line-opacity': 0.7 }}
       />
     </Source>
   )

--- a/src/components/maps/layers/filter-layers.tsx
+++ b/src/components/maps/layers/filter-layers.tsx
@@ -1,4 +1,5 @@
 import { Source, Layer } from 'react-map-gl/maplibre'
+import { HIGHLIGHT_COLORS } from '@/lib/map/cog/setup'
 import type { SpatialFilter, BoundsBox } from '../types'
 
 interface SpatialFilterLayerProps {
@@ -64,13 +65,13 @@ export function ClickBufferLayer({ bounds }: ClickBufferLayerProps) {
         id="click-buffer-fill"
         type="fill"
         source="click-buffer-source"
-        paint={{ 'fill-color': '#00ff00', 'fill-opacity': 0.2 }}
+        paint={{ 'fill-color': HIGHLIGHT_COLORS.vector, 'fill-opacity': 0.2 }}
       />
       <Layer
         id="click-buffer-outline"
         type="line"
         source="click-buffer-source"
-        paint={{ 'line-color': '#00ff00', 'line-width': 2 }}
+        paint={{ 'line-color': HIGHLIGHT_COLORS.vector, 'line-width': 2, 'line-dasharray': [3, 2] }}
       />
     </Source>
   )

--- a/src/components/maps/legend-accordion.tsx
+++ b/src/components/maps/legend-accordion.tsx
@@ -12,7 +12,6 @@ interface LegendAccordionProps {
     bivariateLegend?: { xLabel: string; yLabel: string };
     arcgisUrl?: string;
     legendUnit?: string;
-    legendRange?: [number, number];
 }
 
 function LegendItem({ item }: { item: PreviewItem }) {
@@ -36,9 +35,9 @@ function LegendItem({ item }: { item: PreviewItem }) {
     );
 }
 
-const LegendAccordion = ({ url, isOpen, layerName, customLegend, bivariateLegend, arcgisUrl, legendUnit, legendRange }: LegendAccordionProps) => {
+const LegendAccordion = ({ url, isOpen, layerName, customLegend, bivariateLegend, arcgisUrl, legendUnit }: LegendAccordionProps) => {
     const skipFetch = !!customLegend || !!bivariateLegend || !!arcgisUrl;
-    const { preview, isLoading, error } = useLegendPreview(url, layerName ?? undefined, skipFetch, legendUnit, legendRange);
+    const { preview, isLoading, error } = useLegendPreview(url, layerName ?? undefined, skipFetch, legendUnit);
     const { data: arcgisLegendItems, isLoading: arcgisLoading, error: arcgisError } = useArcGisLegend(arcgisUrl);
     // Use empty string instead of undefined to keep accordion controlled
     const accordionValue = isOpen ? "legend-accordion" : "";

--- a/src/components/maps/legend-accordion.tsx
+++ b/src/components/maps/legend-accordion.tsx
@@ -2,6 +2,7 @@ import { Accordion, AccordionContent, AccordionItem } from '@/components/ui/acco
 import { BivariateLegend } from '@/components/maps/bivariate-legend';
 import useLegendPreview, { type PreviewItem } from '@/hooks/use-legend-preview';
 import { useArcGisLegend } from '@/hooks/use-arcgis-legend';
+import { mountDomNode } from '@/lib/legend/mount-dom-node';
 
 interface LegendAccordionProps {
     url: string;
@@ -12,13 +13,6 @@ interface LegendAccordionProps {
     arcgisUrl?: string;
     legendUnit?: string;
     legendRange?: [number, number];
-}
-
-/** Callback ref that mounts a DOM node as the host's only child. Avoids dangerouslySetInnerHTML. */
-function mountDomNode(node: Node) {
-    return (host: HTMLElement | null) => {
-        if (host) host.replaceChildren(node.cloneNode(true));
-    };
 }
 
 function LegendItem({ item }: { item: PreviewItem }) {

--- a/src/components/maps/legend-accordion.tsx
+++ b/src/components/maps/legend-accordion.tsx
@@ -11,6 +11,7 @@ interface LegendAccordionProps {
     bivariateLegend?: { xLabel: string; yLabel: string };
     arcgisUrl?: string;
     legendUnit?: string;
+    legendRange?: [number, number];
 }
 
 /** Callback ref that mounts a DOM node as the host's only child. Avoids dangerouslySetInnerHTML. */
@@ -41,9 +42,9 @@ function LegendItem({ item }: { item: PreviewItem }) {
     );
 }
 
-const LegendAccordion = ({ url, isOpen, layerName, customLegend, bivariateLegend, arcgisUrl, legendUnit }: LegendAccordionProps) => {
+const LegendAccordion = ({ url, isOpen, layerName, customLegend, bivariateLegend, arcgisUrl, legendUnit, legendRange }: LegendAccordionProps) => {
     const skipFetch = !!customLegend || !!bivariateLegend || !!arcgisUrl;
-    const { preview, isLoading, error } = useLegendPreview(url, layerName ?? undefined, skipFetch, legendUnit);
+    const { preview, isLoading, error } = useLegendPreview(url, layerName ?? undefined, skipFetch, legendUnit, legendRange);
     const { data: arcgisLegendItems, isLoading: arcgisLoading, error: arcgisError } = useArcGisLegend(arcgisUrl);
     // Use empty string instead of undefined to keep accordion controlled
     const accordionValue = isOpen ? "legend-accordion" : "";

--- a/src/components/maps/popups/popup-content-with-pagination.tsx
+++ b/src/components/maps/popups/popup-content-with-pagination.tsx
@@ -4,6 +4,8 @@ import { Shrink } from "lucide-react"
 import { PopupContentDisplay } from "@/components/maps/popups/popup-content-display"
 import { useGetPopupButtons } from "@/hooks/use-get-popup-buttons"
 import { useZoomToFeature } from "@/hooks/use-zoom-to-feature"
+import { loadCogMetadata, computeCogPixelPolygon } from "@/hooks/use-cog-metadata"
+import { HIGHLIGHT_COLORS } from "@/lib/map/cog/setup"
 import type { HighlightFeature } from "@/components/maps/types"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip"
@@ -33,6 +35,7 @@ PopupButtons.displayName = 'PopupButtons';
 interface PopupContentWithPaginationProps {
     layerContent: LayerContentProps[]
     onHighlightChange?: (features: HighlightFeature[]) => void
+    clickPoint?: { lng: number; lat: number } | null
 }
 
 const FeatureCard = memo(({
@@ -69,8 +72,16 @@ const FeatureCard = memo(({
 });
 FeatureCard.displayName = 'FeatureCard';
 
-// Raster-only card for layers with no vector features but with raster data
-const RasterOnlyCard = memo(({ layer }: { layer: LayerContentProps }) => {
+// Raster-only card for layers with no vector features but with raster data.
+// COG layers get a "Zoom to Pixel" button — snaps the click to the COG's grid and zooms to that cell.
+const RasterOnlyCard = memo(({
+    layer, clickPoint, onZoomToPixel,
+}: {
+    layer: LayerContentProps
+    clickPoint?: { lng: number; lat: number } | null
+    onZoomToPixel?: (layer: LayerContentProps, clickPoint: { lng: number; lat: number }) => void
+}) => {
+    const showZoomButton = layer.sourceKind === 'cog' && clickPoint && onZoomToPixel
     return (
         <div className="space-y-2 p-3 rounded-lg border border-border bg-card shadow-sm">
             <PopupContentDisplay
@@ -78,13 +89,36 @@ const RasterOnlyCard = memo(({ layer }: { layer: LayerContentProps }) => {
                 feature={undefined}
                 layout="stacked"
             />
+            {showZoomButton && (
+                <Button variant="ghost" onClick={() => onZoomToPixel(layer, clickPoint)} className="flex gap-x-2">
+                    <Shrink className="h-5 w-5" />
+                    <span className="hidden md:flex">Zoom to Pixel</span>
+                    <span className="md:hidden">Zoom</span>
+                </Button>
+            )}
         </div>
     )
 });
 RasterOnlyCard.displayName = 'RasterOnlyCard';
 
-const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: PopupContentWithPaginationProps) => {
+const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange, clickPoint }: PopupContentWithPaginationProps) => {
     const { zoomTo } = useZoomToFeature({ onHighlightChange })
+
+    const handleZoomToPixel = useCallback(async (layer: LayerContentProps, point: { lng: number; lat: number }) => {
+        const cogUrl = layer.rasterSource?.url
+        if (!cogUrl) return
+        const metadata = await loadCogMetadata(cogUrl)
+        if (!metadata) return
+        const polygon = computeCogPixelPolygon(point, metadata)
+        if (!polygon) return
+        zoomTo({
+            type: 'Feature',
+            id: `${layer.layerTitle}-pixel`,
+            geometry: polygon,
+            properties: {},
+            namespace: layer.layerTitle,
+        }, 'EPSG:4326', { maxZoom: 16 })
+    }, [zoomTo])
     const buttons = useGetPopupButtons()
     // -1 = "All", 0+ = specific layer index
     const [selectedLayerIndex, setSelectedLayerIndex] = useState(-1)
@@ -236,8 +270,16 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
 
                         return (
                             <div key={`${layer.groupLayerTitle}-${layer.layerTitle}-${layerIdx}`}>
-                                {/* Layer header */}
-                                <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 px-1">
+                                {/* Layer header — yellow swatch only on COG items, matching the on-map pixel highlight. */}
+                                <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2 px-1 flex items-center gap-2">
+                                    {layer.sourceKind === 'cog' && (
+                                        <span
+                                            aria-hidden
+                                            title="Sampled COG pixel"
+                                            className="inline-block h-2.5 w-2.5 rounded-sm border border-black/30"
+                                            style={{ backgroundColor: HIGHLIGHT_COLORS.cog }}
+                                        />
+                                    )}
                                     {layer.layerTitle || layer.groupLayerTitle}
                                 </div>
                                 {/* Features or raster-only content */}
@@ -254,7 +296,7 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                                             />
                                         ))
                                     ) : hasRaster ? (
-                                        <RasterOnlyCard layer={layer} />
+                                        <RasterOnlyCard layer={layer} clickPoint={clickPoint} onZoomToPixel={handleZoomToPixel} />
                                     ) : null}
                                 </div>
                             </div>
@@ -275,7 +317,7 @@ const PopupContentWithPaginationInner = ({ layerContent, onHighlightChange }: Po
                                 />
                             ))
                         ) : hasRasterData(selectedLayer) ? (
-                            <RasterOnlyCard layer={selectedLayer} />
+                            <RasterOnlyCard layer={selectedLayer} clickPoint={clickPoint} onZoomToPixel={handleZoomToPixel} />
                         ) : null}
                     </div>
                 ) : null}

--- a/src/components/maps/popups/popup-sheet.tsx
+++ b/src/components/maps/popups/popup-sheet.tsx
@@ -22,6 +22,8 @@ interface PopupSheetProps {
     onWidthChange?: (width: number) => void;
     /** Controlled open state from parent */
     isOpen?: boolean;
+    /** Click point (WGS84) — used by raster popup cards to snap to COG pixel grid for zoom-to. */
+    clickPoint?: { lng: number; lat: number } | null;
 }
 
 export interface PopupSheetRef {
@@ -43,6 +45,7 @@ const PopupSheet = forwardRef<PopupSheetRef, PopupSheetProps>(({
     width = DEFAULT_WIDTH,
     onWidthChange,
     isOpen: controlledOpen,
+    clickPoint,
 }, ref) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
     const floatingCloseRef = useRef<HTMLDivElement>(null);
@@ -187,6 +190,7 @@ const PopupSheet = forwardRef<PopupSheetRef, PopupSheetProps>(({
                                 key={contentKey}
                                 layerContent={popupContent}
                                 onHighlightChange={onHighlightChange}
+                                clickPoint={clickPoint}
                             />
                         </div>
                     </div>

--- a/src/components/maps/popups/types.ts
+++ b/src/components/maps/popups/types.ts
@@ -35,6 +35,8 @@ export interface LayerContentProps {
     colorCodingMode?: ColorCodingMode
     customLayerParameters?: Record<string, string> | null
     rasterSource?: ProcessedRasterSource
+    /** 'cog' = client-side pixel sample (yellow); 'wms-raster' or 'vector' use the buffer (green). */
+    sourceKind?: 'cog' | 'wms-raster' | 'vector'
     visible: boolean
     queryable?: boolean
     schema?: string

--- a/src/hooks/__tests__/use-cog-metadata.test.ts
+++ b/src/hooks/__tests__/use-cog-metadata.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { deriveRange, computeCogPixelPolygon, type CogMetadata } from '../use-cog-metadata'
+
+const baseStats: CogMetadata = {
+    minimum: -100,
+    maximum: 200,
+    mean: 50,
+    stddev: 25,
+}
+
+describe('deriveRange', () => {
+    it('minmax returns the raw [min, max]', () => {
+        expect(deriveRange(baseStats, 'minmax')).toEqual([-100, 200])
+    })
+
+    it('sigma returns mean ± 2σ', () => {
+        expect(deriveRange(baseStats, 'sigma')).toEqual([0, 100])
+    })
+})
+
+describe('computeCogPixelPolygon', () => {
+    // 1°×1° pixels, origin at (0, 0) upper-left. Pure WGS84 → no projection math.
+    const grid: CogMetadata = {
+        ...baseStats,
+        pixelSize: [1, 1],
+        origin: [0, 0],
+        epsg: 4326,
+    }
+
+    it('returns null when pixelSize is missing', () => {
+        const noPx: CogMetadata = { ...baseStats, origin: [0, 0], epsg: 4326 }
+        expect(computeCogPixelPolygon({ lng: 0, lat: 0 }, noPx)).toBeNull()
+    })
+
+    it('returns null when origin is missing', () => {
+        const noOrigin: CogMetadata = { ...baseStats, pixelSize: [1, 1], epsg: 4326 }
+        expect(computeCogPixelPolygon({ lng: 0, lat: 0 }, noOrigin)).toBeNull()
+    })
+
+    it('snaps a click to the containing pixel cell', () => {
+        // click at (2.5, -3.5) → col 2, row 3 → cell lng [2, 3], lat [-4, -3]
+        const poly = computeCogPixelPolygon({ lng: 2.5, lat: -3.5 }, grid)
+        expect(poly).not.toBeNull()
+        expect(poly!.type).toBe('Polygon')
+
+        const ring = poly!.coordinates[0]
+        expect(ring).toHaveLength(5)
+        // ll, lr, ur, ul, ll (closed)
+        expect(ring[0]).toEqual([2, -4])
+        expect(ring[1]).toEqual([3, -4])
+        expect(ring[2]).toEqual([3, -3])
+        expect(ring[3]).toEqual([2, -3])
+        expect(ring[4]).toEqual(ring[0])
+    })
+})

--- a/src/hooks/use-cog-metadata.tsx
+++ b/src/hooks/use-cog-metadata.tsx
@@ -39,10 +39,11 @@ export function useCogMetadata(cogUrl?: string, stacFallbackUrl?: string) {
     })
 }
 
-/** Resolves a COG layer's render range — dynamic from metadata when stretchMode set, else static fallback. */
-export function useCogRange(layer: COGLayerProps): [number, number] {
-    const { data } = useCogMetadata(layer.stretchMode ? layer.cogUrl : undefined, layer.stacUrl)
-    return (layer.stretchMode && data) ? deriveRange(data, layer.stretchMode) : layer.range
+/** Resolves a COG layer's render range from embedded stats / STAC. Returns undefined while loading or on fetch failure. */
+export function useCogRange(layer: COGLayerProps): [number, number] | undefined {
+    const { data } = useCogMetadata(layer.cogUrl, layer.stacUrl)
+    if (!data) return undefined
+    return deriveRange(data, layer.stretchMode ?? 'minmax')
 }
 
 // Module-level cache so repeated fromUrl(cogUrl) calls share a parsed GeoTIFF instance

--- a/src/hooks/use-cog-metadata.tsx
+++ b/src/hooks/use-cog-metadata.tsx
@@ -1,0 +1,146 @@
+import { useQuery } from '@tanstack/react-query'
+import { fromUrl, GeoTIFF } from 'geotiff'
+import type { Polygon } from 'geojson'
+import type { COGLayerProps } from '@/lib/types/mapping-types'
+import { convertCoordinate } from '@/lib/map/conversion-utils'
+import { queryKeys } from '@/lib/query-keys'
+
+export interface CogMetadata {
+    minimum: number
+    maximum: number
+    mean: number
+    stddev: number
+    /** [pixelW, pixelH] in COG's native CRS units (positive). undefined if not readable. */
+    pixelSize?: [number, number]
+    /** [x, y] of upper-left pixel origin in COG's native CRS. undefined if not readable. */
+    origin?: [number, number]
+    /** EPSG code of COG's native CRS (e.g. 3857). undefined if not readable. */
+    epsg?: number
+}
+
+const STATIC_QUERY_OPTS = {
+    staleTime: 1000 * 60 * 60,    // 1h — COG file is immutable during a session
+    gcTime: 1000 * 60 * 60,       // keep in cache as long as it's fresh
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    retry: 1,
+} as const
+
+/**
+ * Reads pixel stats + grid info embedded in the COG via `gdal_edit -stats` (TIFF GDAL_METADATA tags).
+ * Single source of truth — no STAC drift. Falls back to STAC URL if COG has no embedded stats.
+ */
+export function useCogMetadata(cogUrl?: string, stacFallbackUrl?: string) {
+    return useQuery<CogMetadata | null>({
+        queryKey: queryKeys.cog.metadata(cogUrl, stacFallbackUrl),
+        enabled: !!cogUrl,
+        ...STATIC_QUERY_OPTS,
+        queryFn: () => loadCogMetadata(cogUrl!, stacFallbackUrl),
+    })
+}
+
+/** Resolves a COG layer's render range — dynamic from metadata when stretchMode set, else static fallback. */
+export function useCogRange(layer: COGLayerProps): [number, number] {
+    const { data } = useCogMetadata(layer.stretchMode ? layer.cogUrl : undefined, layer.stacUrl)
+    return (layer.stretchMode && data) ? deriveRange(data, layer.stretchMode) : layer.range
+}
+
+// Module-level cache so repeated fromUrl(cogUrl) calls share a parsed GeoTIFF instance
+// (header range read happens once per URL across hook + non-hook callers).
+const tiffCache = new Map<string, Promise<GeoTIFF>>()
+function getTiff(cogUrl: string): Promise<GeoTIFF> {
+    let p = tiffCache.get(cogUrl)
+    if (!p) {
+        p = fromUrl(cogUrl).catch(err => { tiffCache.delete(cogUrl); throw err })
+        tiffCache.set(cogUrl, p)
+    }
+    return p
+}
+
+/** One-shot fetch of COG metadata. Exported so non-hook callers (e.g. popup zoom handler) can use it. */
+export async function loadCogMetadata(cogUrl: string, stacFallbackUrl?: string): Promise<CogMetadata | null> {
+    const fromCog = await readCogMetadata(cogUrl)
+    if (fromCog) return fromCog
+    if (stacFallbackUrl) return readStacStats(stacFallbackUrl)
+    return null
+}
+
+async function readCogMetadata(cogUrl: string): Promise<CogMetadata | null> {
+    try {
+        const tiff = await getTiff(cogUrl)
+        const image = await tiff.getImage(0)
+        const md = image.getGDALMetadata(0) as Record<string, string> | null
+        if (!md) return null
+        const min = parseFloat(md.STATISTICS_MINIMUM)
+        const max = parseFloat(md.STATISTICS_MAXIMUM)
+        const mean = parseFloat(md.STATISTICS_MEAN)
+        const stddev = parseFloat(md.STATISTICS_STDDEV)
+        if ([min, max, mean, stddev].some(v => !Number.isFinite(v))) return null
+
+        // Grid info — used to snap click to pixel cell for highlighting
+        let pixelSize: [number, number] | undefined
+        let origin: [number, number] | undefined
+        let epsg: number | undefined
+        try {
+            const [px, py] = image.getResolution()
+            const [ox, oy] = image.getOrigin()
+            pixelSize = [Math.abs(px), Math.abs(py)]
+            origin = [ox, oy]
+            const code = image.getGeoKeys()?.ProjectedCSTypeGeoKey ?? image.getGeoKeys()?.GeographicTypeGeoKey
+            if (typeof code === 'number') epsg = code
+        } catch { /* metadata optional */ }
+
+        return { minimum: min, maximum: max, mean, stddev, pixelSize, origin, epsg }
+    } catch {
+        return null
+    }
+}
+
+interface StacItem {
+    assets?: Record<string, { 'raster:bands'?: Array<{ statistics?: Partial<CogMetadata> }> }>
+}
+
+async function readStacStats(stacUrl: string): Promise<CogMetadata | null> {
+    const res = await fetch(stacUrl)
+    if (!res.ok) return null
+    const item: StacItem = await res.json()
+    const asset = item.assets ? Object.values(item.assets)[0] : undefined
+    const s = asset?.['raster:bands']?.[0]?.statistics
+    if (!s || s.minimum === undefined || s.maximum === undefined ||
+        s.mean === undefined || s.stddev === undefined) return null
+    return { minimum: s.minimum, maximum: s.maximum, mean: s.mean, stddev: s.stddev }
+}
+
+export function deriveRange(stats: CogMetadata, mode: 'minmax' | 'sigma'): [number, number] {
+    if (mode === 'sigma') return [stats.mean - 2 * stats.stddev, stats.mean + 2 * stats.stddev]
+    return [stats.minimum, stats.maximum]
+}
+
+/**
+ * Snap a click point to the COG pixel grid and return the cell as a WGS84 polygon.
+ * Returns null if metadata lacks pixelSize/origin.
+ */
+export function computeCogPixelPolygon(
+    clickPoint: { lng: number; lat: number },
+    metadata: CogMetadata,
+): Polygon | null {
+    if (!metadata.pixelSize || !metadata.origin) return null
+    const cogEpsg = `EPSG:${metadata.epsg ?? 3857}`
+    const [pxW, pxH] = metadata.pixelSize
+    const [originX, originY] = metadata.origin
+
+    const [cx, cy] = convertCoordinate([clickPoint.lng, clickPoint.lat], 'EPSG:4326', cogEpsg)
+    const col = Math.floor((cx - originX) / pxW)
+    const row = Math.floor((originY - cy) / pxH)
+    const minX = originX + col * pxW
+    const maxX = minX + pxW
+    const maxY = originY - row * pxH
+    const minY = maxY - pxH
+
+    const ll = convertCoordinate([minX, minY], cogEpsg, 'EPSG:4326')
+    const lr = convertCoordinate([maxX, minY], cogEpsg, 'EPSG:4326')
+    const ur = convertCoordinate([maxX, maxY], cogEpsg, 'EPSG:4326')
+    const ul = convertCoordinate([minX, maxY], cogEpsg, 'EPSG:4326')
+
+    return { type: 'Polygon', coordinates: [[ll, lr, ur, ul, ll]] }
+}

--- a/src/hooks/use-custom-layerlist.tsx
+++ b/src/hooks/use-custom-layerlist.tsx
@@ -6,7 +6,8 @@ import { useLayerItemState } from '@/hooks/use-layer-item-state';
 import { LayerProps } from '@/lib/types/mapping-types';
 import { useMap } from '@/hooks/use-map';
 import { findLayerByTitle } from '@/lib/map/utils';
-import { isWMSLayer, isWFSLayer, isPMTilesLayer, isArcGISMapServerLayer } from '@/lib/map/layer-utils';
+import { isWMSLayer, isWFSLayer, isPMTilesLayer, isArcGISMapServerLayer, isCOGLayer } from '@/lib/map/layer-utils';
+import { CogLegend } from '@/components/maps/cog-legend';
 import { useLayerExtent, UseLayerExtentOptions } from '@/hooks/use-layer-extent';
 import { useFetchLayerDescriptions } from '@/hooks/use-fetch-layer-descriptions';
 import { useSidebar } from '@/hooks/use-sidebar';
@@ -271,7 +272,7 @@ const LayerAccordionItem = ({ layerConfig, isTopLevel, parentGroupTitle }: Layer
                             url={extentOptions.type === 'wms' ? extentOptions.wmsUrl || '' : ''}
                             openLegend={isUserExpanded}
                             layerName={extentOptions.type === 'wms' ? extentOptions.layerName : null}
-                            customLegend={layerConfig.customLegend}
+                            customLegend={isCOGLayer(layerConfig) ? <CogLegend layer={layerConfig} /> : layerConfig.customLegend}
                             bivariateLegend={layerConfig.bivariateLegend}
                             arcgisUrl={extentOptions.type === 'arcgis' ? extentOptions.mapServerUrl : undefined}
                             legendUnit={isWMSLayer(layerConfig) ? layerConfig.legendUnit : undefined}

--- a/src/hooks/use-custom-layerlist.tsx
+++ b/src/hooks/use-custom-layerlist.tsx
@@ -275,6 +275,7 @@ const LayerAccordionItem = ({ layerConfig, isTopLevel, parentGroupTitle }: Layer
                             bivariateLegend={layerConfig.bivariateLegend}
                             arcgisUrl={extentOptions.type === 'arcgis' ? extentOptions.mapServerUrl : undefined}
                             legendUnit={isWMSLayer(layerConfig) ? layerConfig.legendUnit : undefined}
+                            legendRange={isWMSLayer(layerConfig) ? layerConfig.legendRange : undefined}
                         />
                     </AccordionContent>
                 </AccordionItem>

--- a/src/hooks/use-custom-layerlist.tsx
+++ b/src/hooks/use-custom-layerlist.tsx
@@ -287,7 +287,6 @@ const LayerAccordionItem = ({ layerConfig, isTopLevel, parentGroupTitle, disable
                             bivariateLegend={layerConfig.bivariateLegend}
                             arcgisUrl={extentOptions.type === 'arcgis' ? extentOptions.mapServerUrl : undefined}
                             legendUnit={isWMSLayer(layerConfig) ? layerConfig.legendUnit : undefined}
-                            legendRange={isWMSLayer(layerConfig) ? layerConfig.legendRange : undefined}
                             downloadParquetUrl={layerConfig.downloadParquetUrl}
                             disableExport={disableExport}
                         />

--- a/src/hooks/use-legend-preview.tsx
+++ b/src/hooks/use-legend-preview.tsx
@@ -34,7 +34,7 @@ export type PreviewItem = {
 };
 
 /** Fetches GeoServer GetLegendGraphic JSON and converts each rule into a preview item. */
-const useLegendPreview = (url: string, layerName?: string, skip?: boolean, legendUnit?: string, legendRange?: [number, number]) => {
+const useLegendPreview = (url: string, layerName?: string, skip?: boolean, legendUnit?: string) => {
     const fetchLegendData = async (): Promise<PreviewItem[]> => {
         if (!url || !layerName) {
             return [];
@@ -67,7 +67,7 @@ const useLegendPreview = (url: string, layerName?: string, skip?: boolean, legen
             // Raster: bypass RendererFactory (would crush the bar to a 32×22 swatch).
             const rasterRule = findRasterRule(rules);
             if (rasterRule) {
-                const html = createRasterSymbol(rasterRule.symbolizers, { unit: legendUnit, range: legendRange });
+                const html = createRasterSymbol(rasterRule.symbolizers, { unit: legendUnit });
                 return [{ html }];
             }
 

--- a/src/hooks/use-legend-preview.tsx
+++ b/src/hooks/use-legend-preview.tsx
@@ -34,7 +34,7 @@ export type PreviewItem = {
 };
 
 /** Fetches GeoServer GetLegendGraphic JSON and converts each rule into a preview item. */
-const useLegendPreview = (url: string, layerName?: string, skip?: boolean, legendUnit?: string) => {
+const useLegendPreview = (url: string, layerName?: string, skip?: boolean, legendUnit?: string, legendRange?: [number, number]) => {
     const fetchLegendData = async (): Promise<PreviewItem[]> => {
         if (!url || !layerName) {
             return [];
@@ -67,7 +67,7 @@ const useLegendPreview = (url: string, layerName?: string, skip?: boolean, legen
             // Raster: bypass RendererFactory (would crush the bar to a 32×22 swatch).
             const rasterRule = findRasterRule(rules);
             if (rasterRule) {
-                const html = createRasterSymbol(rasterRule.symbolizers, { unit: legendUnit });
+                const html = createRasterSymbol(rasterRule.symbolizers, { unit: legendUnit, range: legendRange });
                 return [{ html }];
             }
 

--- a/src/hooks/use-popup-data.ts
+++ b/src/hooks/use-popup-data.ts
@@ -16,7 +16,10 @@ import type { LayerContentProps, ExtendedFeature } from '@/components/maps/popup
 import type { GeoServerGeoJSON } from '@/lib/types/geoserver-types'
 import { convertCoordinate } from '@/lib/map/conversion-utils'
 import { createPointBufferBbox } from '@/lib/map/utils'
-import { findLayerByTitle, flattenWmsLayers } from '@/lib/map/layer-utils'
+import { findLayerByTitle, flattenWmsLayers, flattenVisibleLayers, isCOGLayer } from '@/lib/map/layer-utils'
+import { locationValues } from '@geomatico/maplibre-cog-protocol'
+import { queryKeys } from '@/lib/query-keys'
+import type { COGLayerProps } from '@/lib/types/mapping-types'
 
 interface UsePopupDataOptions {
   /** Vector features from WFS query */
@@ -123,6 +126,49 @@ function getLayersWithRasterSource(layers: LayerProps[]): Map<string, RasterSour
   return result
 }
 
+/** Synthesize a RasterSource shape from a COG layer so it flows through the same popup pipeline. */
+function cogLayerToRasterSource(layer: COGLayerProps): RasterSource {
+  const unit = layer.legendUnit ?? ''
+  return {
+    url: layer.cogUrl,
+    layerName: layer.title,
+    valueField: 'value',
+    valueLabel: layer.popupValueLabel ?? 'Value',
+    transform: (n: number) => `${Math.round(n * 100) / 100}${unit ? ` ${unit}` : ''}`,
+  }
+}
+
+function getCogLayersForPopup(layers: LayerProps[]): Map<string, { layer: COGLayerProps; rasterSource: RasterSource }> {
+  const result = new Map<string, { layer: COGLayerProps; rasterSource: RasterSource }>()
+  for (const cog of flattenVisibleLayers(layers, isCOGLayer)) {
+    if (cog.title) result.set(cog.title, { layer: cog, rasterSource: cogLayerToRasterSource(cog) })
+  }
+  return result
+}
+
+/** Sample COG pixel value at click point via geotiff.js (range-read, no server). */
+async function fetchCogValue(
+  cogUrl: string,
+  point: { lng: number; lat: number },
+  valueField: string,
+): Promise<GeoServerGeoJSON | null> {
+  try {
+    const values = await locationValues(cogUrl, { latitude: point.lat, longitude: point.lng })
+    const v = values?.[0]
+    if (v === undefined || !Number.isFinite(v)) return null
+    return {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        geometry: { type: 'Point', coordinates: [point.lng, point.lat] },
+        properties: { [valueField]: v },
+      }],
+    } as GeoServerGeoJSON
+  } catch {
+    return null
+  }
+}
+
 /**
  * Hook that prepares popup data from WFS results and fetches raster values
  */
@@ -146,28 +192,36 @@ export function usePopupData({
     return grouped
   }, [vectorFeatures])
 
-  // Get all layers with rasterSource config
+  // Get all layers with rasterSource config (WMS) and visible COG layers (sampled client-side)
   const layersWithRaster = useMemo(() => getLayersWithRasterSource(layersConfig), [layersConfig])
+  const cogLayers = useMemo(() => getCogLayersForPopup(layersConfig), [layersConfig])
 
-  // Determine which layers need raster fetching
-  // Include layers that have rasterSource, regardless of whether they have vector features
-  const rasterQueries = useMemo((): RasterQueryConfig[] => {
+  // Determine which layers need raster fetching. Tagged 'wms' or 'cog' to dispatch query path.
+  const rasterQueries = useMemo((): Array<RasterQueryConfig & { kind: 'wms' | 'cog' }> => {
     if (!clickPoint) return []
 
-    const queries: RasterQueryConfig[] = []
+    const queries: Array<RasterQueryConfig & { kind: 'wms' | 'cog' }> = []
     for (const [layerTitle, rasterSource] of layersWithRaster) {
-      queries.push({ layerTitle, rasterSource })
+      queries.push({ layerTitle, rasterSource, kind: 'wms' })
+    }
+    for (const [layerTitle, { rasterSource }] of cogLayers) {
+      queries.push({ layerTitle, rasterSource, kind: 'cog' })
     }
     return queries
-  }, [clickPoint, layersWithRaster])
+  }, [clickPoint, layersWithRaster, cogLayers])
 
-  // Fetch raster values for all layers in parallel
+  // Fetch raster values for all layers in parallel.
+  // COG values use queryKeys.cog.value() — coords are rounded so near-duplicate clicks share cache.
   const rasterResults = useQueries({
-    queries: rasterQueries.map(({ layerTitle, rasterSource }) => ({
-      queryKey: ['rasterValue', rasterSource.layerName, clickPoint?.lng, clickPoint?.lat],
+    queries: rasterQueries.map(({ layerTitle, rasterSource, kind }) => ({
+      queryKey: kind === 'cog'
+        ? queryKeys.cog.value(rasterSource.layerName, clickPoint?.lng ?? 0, clickPoint?.lat ?? 0)
+        : ['rasterValue', rasterSource.layerName, clickPoint?.lng, clickPoint?.lat] as const,
       queryFn: async () => {
         if (!clickPoint) return null
-        const data = await fetchRasterValue(rasterSource, clickPoint, clickBbox)
+        const data = kind === 'cog'
+          ? await fetchCogValue(rasterSource.url, clickPoint, rasterSource.valueField)
+          : await fetchRasterValue(rasterSource, clickPoint, clickBbox)
         return { layerTitle, rasterSource, data }
       },
       enabled: !!clickPoint,
@@ -219,6 +273,10 @@ export function usePopupData({
       // Skip if no features AND no raster data
       if (features.length === 0 && !processedRasterSource) continue
 
+      const sourceKind: LayerContentProps['sourceKind'] = layer && isCOGLayer(layer)
+        ? 'cog'
+        : (processedRasterSource ? 'wms-raster' : 'vector')
+
       result.push({
         groupLayerTitle: title,
         layerTitle: title,
@@ -231,6 +289,7 @@ export function usePopupData({
         colorCodingMap: sublayerConfig?.colorCodingMap,
         colorCodingMode: sublayerConfig?.colorCodingMode,
         rasterSource: processedRasterSource,
+        sourceKind,
         maxZoomLevel: layer?.maxZoomLevel,
         features: features.map((f): ExtendedFeature => ({
           type: 'Feature',

--- a/src/lib/legend/mount-dom-node.ts
+++ b/src/lib/legend/mount-dom-node.ts
@@ -1,0 +1,9 @@
+/**
+ * React callback ref that mounts a foreign DOM node (e.g. an SVG built imperatively)
+ * as the host element's only child. Avoids `dangerouslySetInnerHTML`.
+ */
+export function mountDomNode(node: Node) {
+    return (host: HTMLElement | null) => {
+        if (host) host.replaceChildren(node.cloneNode(true))
+    }
+}

--- a/src/lib/legend/symbolizers/raster.ts
+++ b/src/lib/legend/symbolizers/raster.ts
@@ -1,4 +1,5 @@
 import type { Symbolizer, RasterColormapEntry } from '@/lib/types/geoserver-types'
+import { formatToSigFigs } from '@/lib/utils'
 
 export interface RasterSymbolOptions {
     /** Setting this enables min/max labels on the bar. Omit for a label-less colorbar. */
@@ -24,8 +25,7 @@ const SVG_HEIGHT_BARE = 16
 let gradientCounter = 0
 
 function formatQuantity(n: number): string {
-    const rounded = Math.round(n)
-    return Math.abs(rounded) >= 1000 ? rounded.toLocaleString() : String(rounded)
+    return formatToSigFigs(n, 3)
 }
 
 function isVisibleEntry(e: RasterColormapEntry): boolean {

--- a/src/lib/legend/symbolizers/raster.ts
+++ b/src/lib/legend/symbolizers/raster.ts
@@ -24,7 +24,8 @@ const SVG_HEIGHT_BARE = 16
 let gradientCounter = 0
 
 function formatQuantity(n: number): string {
-    return Math.abs(n) >= 1000 ? n.toLocaleString() : String(n)
+    const rounded = Math.round(n)
+    return Math.abs(rounded) >= 1000 ? rounded.toLocaleString() : String(rounded)
 }
 
 function isVisibleEntry(e: RasterColormapEntry): boolean {

--- a/src/lib/legend/symbolizers/raster.ts
+++ b/src/lib/legend/symbolizers/raster.ts
@@ -3,6 +3,8 @@ import type { Symbolizer, RasterColormapEntry } from '@/lib/types/geoserver-type
 export interface RasterSymbolOptions {
     /** Setting this enables min/max labels on the bar. Omit for a label-less colorbar. */
     unit?: string
+    /** Override derived min/max from SLD stops. Use when SLD stops don't match true data extent. */
+    range?: [number, number]
 }
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
@@ -74,8 +76,10 @@ export function createRasterSymbol(symbolizers: Symbolizer[], opts?: RasterSymbo
     if (colormap?.type === 'values') return svg
     if (stops.length === 0) return svg
 
-    const min = Math.min(...stops.map(s => s.value))
-    const max = Math.max(...stops.map(s => s.value))
+    const [min, max] = opts?.range ?? [
+        Math.min(...stops.map(s => s.value)),
+        Math.max(...stops.map(s => s.value)),
+    ]
     const range = max - min || 1
 
     const gradientId = `raster-gradient-${++gradientCounter}`

--- a/src/lib/map/__tests__/layer-utils.test.ts
+++ b/src/lib/map/__tests__/layer-utils.test.ts
@@ -5,6 +5,7 @@ import {
   isPMTilesLayer,
   isGroupLayer,
   isArcGISMapServerLayer,
+  isCOGLayer,
   flattenVisibleLayers,
   flattenWmsLayers,
   flattenWfsLayers,
@@ -17,6 +18,7 @@ import type {
   PMTilesLayerProps,
   GroupLayerProps,
   ArcGISMapServerLayerProps,
+  COGLayerProps,
 } from '@/lib/types/mapping-types'
 
 // ── Fixtures ─────────────────────────────────────────────────────────
@@ -52,6 +54,15 @@ const arcgisLayer: ArcGISMapServerLayerProps = {
   visible: true,
 }
 
+const cogLayer: COGLayerProps = {
+  type: 'cog',
+  title: 'COG Layer',
+  cogUrl: 'https://example.com/raster.tif',
+  colorStops: ['#000', '#fff'],
+  range: [0, 100],
+  visible: true,
+}
+
 const hiddenWms: WMSLayerProps = { ...wmsLayer, title: 'Hidden WMS', visible: false }
 const hiddenArcgis: ArcGISMapServerLayerProps = { ...arcgisLayer, title: 'Hidden ArcGIS', visible: false }
 
@@ -64,13 +75,14 @@ const group: GroupLayerProps = {
 // ── Type guards ──────────────────────────────────────────────────────
 
 describe('type guards', () => {
-  const layers: LayerProps[] = [wmsLayer, wfsLayer, pmtilesLayer, arcgisLayer, group]
+  const layers: LayerProps[] = [wmsLayer, wfsLayer, pmtilesLayer, arcgisLayer, cogLayer, group]
 
   it.each([
     ['isWMSLayer', isWMSLayer, 'WMS Layer'],
     ['isWFSLayer', isWFSLayer, 'WFS Layer'],
     ['isPMTilesLayer', isPMTilesLayer, 'PMTiles Layer'],
     ['isArcGISMapServerLayer', isArcGISMapServerLayer, 'ArcGIS Layer'],
+    ['isCOGLayer', isCOGLayer, 'COG Layer'],
     ['isGroupLayer', isGroupLayer, 'Group'],
   ])('%s matches only its own type', (_name, guard, expectedTitle) => {
     const matches = layers.filter(guard)

--- a/src/lib/map/__tests__/layer-utils.test.ts
+++ b/src/lib/map/__tests__/layer-utils.test.ts
@@ -59,7 +59,6 @@ const cogLayer: COGLayerProps = {
   title: 'COG Layer',
   cogUrl: 'https://example.com/raster.tif',
   colorStops: ['#000', '#fff'],
-  range: [0, 100],
   visible: true,
 }
 

--- a/src/lib/map/cog/setup.ts
+++ b/src/lib/map/cog/setup.ts
@@ -27,8 +27,8 @@ export function buildCogProtocolUrl(layer: COGLayerProps, range: [number, number
 
 /** Highlight colors used to visually link map shapes (buffer / pixel) with popup item swatches. */
 export const HIGHLIGHT_COLORS = {
-    /** COG pixel cell highlight (yellow). */
-    cog: '#ffeb3b',
-    /** Vector click buffer (green). */
-    vector: '#00ff00',
+    /** COG pixel cell highlight (amber) — emphasised because it marks the actual sampled data cell. */
+    cog: '#fbbf24',
+    /** Vector click buffer outline (neutral) — secondary, just shows the search radius. */
+    vector: '#525252',
 } as const;

--- a/src/lib/map/cog/setup.ts
+++ b/src/lib/map/cog/setup.ts
@@ -1,0 +1,34 @@
+import maplibregl from 'maplibre-gl';
+import { cogProtocol } from '@geomatico/maplibre-cog-protocol';
+import type { COGLayerProps } from '@/lib/types/mapping-types';
+
+let protocolAdded = false;
+
+/** Register cog:// protocol once per app lifecycle. */
+export function setupCOGProtocol(): void {
+    if (protocolAdded) return;
+    maplibregl.addProtocol('cog', cogProtocol);
+    protocolAdded = true;
+}
+
+/**
+ * Build a `cog://` source URL with the lib's color hash spec.
+ * Hash format: `#color:[hex,...],min,max,modifiers`
+ * Modifiers: `c` = continuous interpolation, `-` = reverse colormap.
+ */
+export function buildCogProtocolUrl(layer: COGLayerProps, range: [number, number]): string {
+    const colorsJson = JSON.stringify(layer.colorStops);
+    const continuous = layer.continuous === false ? '' : 'c';
+    const reverse = layer.reverse ? '-' : '';
+    const modifiers = `${continuous}${reverse}`;
+    const tail = modifiers ? `,${modifiers}` : '';
+    return `cog://${layer.cogUrl}#color:${colorsJson},${range[0]},${range[1]}${tail}`;
+}
+
+/** Highlight colors used to visually link map shapes (buffer / pixel) with popup item swatches. */
+export const HIGHLIGHT_COLORS = {
+    /** COG pixel cell highlight (yellow). */
+    cog: '#ffeb3b',
+    /** Vector click buffer (green). */
+    vector: '#00ff00',
+} as const;

--- a/src/lib/map/factory/maplibre.ts
+++ b/src/lib/map/factory/maplibre.ts
@@ -319,6 +319,7 @@ export class MapLibreMapFactory implements MapFactory {
     } else if (layerConfig.type === 'wfs') {
       await this.addWFSLayer(map, layerConfig as WFSLayerProps);
     }
+    // Note: 'cog' layers render via <CogLayerSource> in data-map.tsx (react-map-gl path)
   }
 
   private async addWMSLayer(map: maplibregl.Map, layerConfig: WMSLayerProps): Promise<void> {
@@ -522,6 +523,7 @@ export class MapLibreMapFactory implements MapFactory {
       }
     }
   }
+
   /**
    * Fetch GeoJSON from a WFS service and add as vector layer
    * Uses queryRenderedFeatures for click detection (respects symbol bounds)

--- a/src/lib/map/layer-utils.ts
+++ b/src/lib/map/layer-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Layer type guards, traversal, and URL parsing utilities
  */
-import type { LayerProps, WMSLayerProps, WFSLayerProps, PMTilesLayerProps, GroupLayerProps, ArcGISMapServerLayerProps } from '@/lib/types/mapping-types'
+import type { LayerProps, WMSLayerProps, WFSLayerProps, PMTilesLayerProps, COGLayerProps, GroupLayerProps, ArcGISMapServerLayerProps } from '@/lib/types/mapping-types'
 
 // ── Type guards ──────────────────────────────────────────────────────
 
@@ -13,6 +13,9 @@ export const isWFSLayer = (layer: LayerProps): layer is WFSLayerProps =>
 
 export const isPMTilesLayer = (layer: LayerProps): layer is PMTilesLayerProps =>
   layer.type === 'pmtiles'
+
+export const isCOGLayer = (layer: LayerProps): layer is COGLayerProps =>
+  layer.type === 'cog'
 
 export const isGroupLayer = (layer: LayerProps): layer is GroupLayerProps =>
   layer.type === 'group'
@@ -50,8 +53,8 @@ export const flattenWfsLayers = (layers: LayerProps[]) =>
 export const flattenArcGisLayers = (layers: LayerProps[]) =>
   flattenVisibleLayers(layers, isArcGISMapServerLayer)
 
-export const isDataLayer = (layer: LayerProps): layer is WMSLayerProps | WFSLayerProps | ArcGISMapServerLayerProps =>
-  isWMSLayer(layer) || isWFSLayer(layer) || isArcGISMapServerLayer(layer)
+export const isDataLayer = (layer: LayerProps): layer is WMSLayerProps | WFSLayerProps | ArcGISMapServerLayerProps | COGLayerProps =>
+  isWMSLayer(layer) || isWFSLayer(layer) || isArcGISMapServerLayer(layer) || isCOGLayer(layer)
 
 export const flattenVisibleDataLayers = (layers: LayerProps[]) =>
   flattenVisibleLayers(layers, isDataLayer)

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -74,6 +74,16 @@ export const queryKeys = {
     formations: () => [...queryKeys.carbonStorage.all, 'formations'] as const,
   },
 
+  // COG (Cloud Optimized GeoTIFF) queries — pixel metadata + sampled values
+  cog: {
+    all: ['cog'] as const,
+    metadata: (cogUrl?: string, stacUrl?: string) =>
+      [...queryKeys.cog.all, 'metadata', cogUrl, stacUrl] as const,
+    /** lng/lat are rounded to 5 decimals (~1m) so near-duplicate clicks share the cache. */
+    value: (layerName: string, lng: number, lat: number) =>
+      [...queryKeys.cog.all, 'value', layerName, Math.round(lng * 1e5) / 1e5, Math.round(lat * 1e5) / 1e5] as const,
+  },
+
   // Hazards queries
   hazards: {
     all: ['hazards'] as const,

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -124,8 +124,6 @@ export interface WMSLayerProps extends BaseLayerProps {
     crs?: string; // EPSG code (e.g., 'EPSG:26912', 'EPSG:3857') for WMS GetFeatureInfo requests
     /** Set to enable min/max labels on the raster colorbar legend. Omit to render the bar without labels. */
     legendUnit?: string;
-    /** Override derived min/max from SLD stops when they don't match the true data extent. */
-    legendRange?: [number, number];
 }
 
 export interface ArcGISMapServerLayerProps extends BaseLayerProps {
@@ -150,7 +148,7 @@ export interface COGLayerProps extends BaseLayerProps {
     continuous?: boolean;
     /** Reverse color order. */
     reverse?: boolean;
-    /** Unit for legend labels (e.g. 'mGal'). Reuses legendRange path. */
+    /** Unit for legend labels (e.g. 'mGal'). */
     legendUnit?: string;
     /** Human-readable label for the sampled pixel value in popups (e.g. 'Gravity Anomaly'). */
     popupValueLabel?: string;

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -122,6 +122,8 @@ export interface WMSLayerProps extends BaseLayerProps {
     crs?: string; // EPSG code (e.g., 'EPSG:26912', 'EPSG:3857') for WMS GetFeatureInfo requests
     /** Set to enable min/max labels on the raster colorbar legend. Omit to render the bar without labels. */
     legendUnit?: string;
+    /** Override derived min/max from SLD stops when they don't match the true data extent. */
+    legendRange?: [number, number];
 }
 
 export interface ArcGISMapServerLayerProps extends BaseLayerProps {

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -103,7 +103,7 @@ export type ExtendedSublayerProperties = {
 
 
 interface BaseLayerProps {
-    type: 'feature' | 'tile' | 'map-image' | 'geojson' | 'imagery' | 'wms' | 'group' | 'pmtiles' | 'wfs';
+    type: 'feature' | 'tile' | 'map-image' | 'geojson' | 'imagery' | 'wms' | 'group' | 'pmtiles' | 'cog' | 'wfs';
     title: string;
     url?: string;
     visible?: boolean;
@@ -130,6 +130,28 @@ export interface ArcGISMapServerLayerProps extends BaseLayerProps {
     type: 'map-image';
     /** Base ArcGIS MapServer URL (e.g., .../MapServer — no /export, no /0) */
     url: string;
+}
+
+export interface COGLayerProps extends BaseLayerProps {
+    type: 'cog';
+    /** HTTP(S) URL to the COG file. */
+    cogUrl: string;
+    /** Optional STAC item URL. Used as fallback if COG has no embedded stats (gdal_edit -stats). */
+    stacUrl?: string;
+    /** Dynamic stretch from COG-embedded stats (or STAC fallback). 'minmax' = [min, max]. 'sigma' = mean ± 2σ. */
+    stretchMode?: 'minmax' | 'sigma';
+    /** Viridis-like hex color stops, low → high. */
+    colorStops: string[];
+    /** Stretch range [min, max] mapped to colorStops [0, 1]. Used as fallback when no stacUrl/stretchMode. */
+    range: [number, number];
+    /** Linear interpolation between stops; false = stepped. */
+    continuous?: boolean;
+    /** Reverse color order. */
+    reverse?: boolean;
+    /** Unit for legend labels (e.g. 'mGal'). Reuses legendRange path. */
+    legendUnit?: string;
+    /** Human-readable label for the sampled pixel value in popups (e.g. 'Gravity Anomaly'). */
+    popupValueLabel?: string;
 }
 
 export interface PMTilesLayerProps extends BaseLayerProps {
@@ -199,7 +221,7 @@ export interface GroupLayerProps extends BaseLayerProps {
 }
 
 
-export type LayerProps = WMSLayerProps | PMTilesLayerProps | WFSLayerProps | GroupLayerProps | ArcGISMapServerLayerProps | BaseLayerProps;
+export type LayerProps = WMSLayerProps | PMTilesLayerProps | COGLayerProps | WFSLayerProps | GroupLayerProps | ArcGISMapServerLayerProps | BaseLayerProps;
 
 export type MapImageLayerRenderer = {
     type: 'map-image-renderer';

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -142,8 +142,6 @@ export interface COGLayerProps extends BaseLayerProps {
     stretchMode?: 'minmax' | 'sigma';
     /** Viridis-like hex color stops, low → high. */
     colorStops: string[];
-    /** Stretch range [min, max] mapped to colorStops [0, 1]. Used as fallback when no stacUrl/stretchMode. */
-    range: [number, number];
     /** Linear interpolation between stops; false = stepped. */
     continuous?: boolean;
     /** Reverse color order. */

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -31,6 +31,14 @@ const numericFormatters: Record<string, (n: number) => string> = {
   percent: (n) => n.toLocaleString('en-US', { style: 'percent', minimumFractionDigits: 1 }),
 };
 
+/** Round to N significant figures and stringify without scientific notation (1234 → "1,230", 12.34 → "12.3"). */
+export function formatToSigFigs(n: number, sigFigs: number): string {
+  if (!Number.isFinite(n)) return String(n);
+  if (n === 0) return '0';
+  const rounded = Number(n.toPrecision(sigFigs));
+  return Math.abs(rounded) >= 1000 ? rounded.toLocaleString('en-US') : String(rounded);
+}
+
 export function formatNumeric(value: unknown, format?: string): string {
   if (value === null || value === undefined || value === '') return '';
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,12 +8,14 @@ import { RouterProvider, createRouter } from '@tanstack/react-router'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import proj4 from 'proj4'
 import { setupPMTilesProtocol } from '@/lib/map/pmtiles/setup'
+import { setupCOGProtocol } from '@/lib/map/cog/setup'
 
 // Import the generated route tree
 import { routeTree } from './routeTree.gen'
 
 // Initialize PMTiles protocol (runs once at app start)
 setupPMTilesProtocol()
+setupCOGProtocol()
 
 proj4.defs("EPSG:26912", "+proj=utm +zone=12 +ellps=GRS80 +datum=NAD83 +units=m +no_defs");
 // defs for 3857

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -1,5 +1,5 @@
 import { ENERGY_MINERALS_WORKSPACE, HAZARDS_WORKSPACE, MAPPING_WORKSPACE, PROD_GEOSERVER_URL } from "@/lib/constants";
-import { ArcGISMapServerLayerProps, LayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
+import { ArcGISMapServerLayerProps, COGLayerProps, LayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
 import { GeoJsonProperties } from "geojson";
 import { toTitleCase, toSentenceCase } from "@/lib/utils";
 
@@ -749,9 +749,9 @@ const geothermalSpringsJoinsConfig: WMSLayerProps = {
     ],
 };
 
-// CGBA Gravity Anomalies — continuous raster served via WMS.
+// CGBA Gravity Anomalies — WMS (legacy, GeoServer-backed). Kept side-by-side with COG for comparison.
 const cgbaRasterLayerName = 'enmin_geophysics_gravanomalyraster_current';
-const cgbaBouguerRasterTitle = 'Complete Bouguer Gravity Anomaly';
+const cgbaBouguerRasterTitle = 'Complete Bouguer Gravity Anomaly (WMS)';
 const cgbaBouguerRasterConfig: WMSLayerProps = {
     type: 'wms',
     url: `${PROD_GEOSERVER_URL}/wms`,
@@ -760,16 +760,13 @@ const cgbaBouguerRasterConfig: WMSLayerProps = {
     opacity: 0.9,
     crs: 'EPSG:26912',
     legendUnit: 'mGal',
-    // SLD stops are -310/-81 but WCS DescribeCoverage reports true extent -283/-107. Remove after COG migration.
     legendRange: [-283, -107],
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${cgbaRasterLayerName}`,
             popupEnabled: false,
             queryable: true,
-            popupFields: {
-                // empty in favor of using the rasterSource for popup values
-            },
+            popupFields: {},
             rasterSource: {
                 url: `${PROD_GEOSERVER_URL}/wms`,
                 headers: {
@@ -785,6 +782,22 @@ const cgbaBouguerRasterConfig: WMSLayerProps = {
     ],
 };
 
+// CGBA Gravity Anomalies — COG via CDN. Stretch derived dynamically from STAC raster:bands stats.
+const cgbaBouguerCOGConfig: COGLayerProps = {
+    type: 'cog',
+    title: 'Complete Bouguer Gravity Anomaly (COG)',
+    visible: false,
+    opacity: 0.9,
+    cogUrl: 'https://maps-assets.geology.utah.gov/geophysics/cbgaras-cog.tif',
+    stacUrl: 'https://maps-assets.geology.utah.gov/geophysics/cbgaras.stac.json',
+    stretchMode: 'minmax',
+    colorStops: ['#440154', '#31688e', '#35b779', '#c8e020', '#fde725'],
+    range: [-310, -85], // fallback if STAC fetch fails
+    continuous: true,
+    legendUnit: 'mGal',
+    popupValueLabel: 'Gravity Anomaly',
+};
+
 const geophysicalDataConfig: LayerProps = {
     type: 'group',
     title: 'Geophysical Data',
@@ -795,6 +808,7 @@ const geophysicalDataConfig: LayerProps = {
         gravityStationsLayerConfig,
         pacesLegacyLayerConfig,
         cgbaBouguerRasterConfig,
+        cgbaBouguerCOGConfig,
     ]
 }
 

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -769,43 +769,10 @@ const geothermalSpringsJoinsConfig: WMSLayerProps = {
     ],
 };
 
-// CGBA Gravity Anomalies — WMS (legacy, GeoServer-backed). Kept side-by-side with COG for comparison.
-const cgbaRasterLayerName = 'enmin_geophysics_gravanomalyraster_current';
-const cgbaBouguerRasterTitle = 'Complete Bouguer Gravity Anomaly (WMS)';
-const cgbaBouguerRasterConfig: WMSLayerProps = {
-    type: 'wms',
-    url: `${PROD_GEOSERVER_URL}/wms`,
-    title: cgbaBouguerRasterTitle,
-    visible: false,
-    opacity: 0.9,
-    crs: 'EPSG:26912',
-    legendUnit: 'mGal',
-    legendRange: [-283, -107],
-    sublayers: [
-        {
-            name: `${ENERGY_MINERALS_WORKSPACE}:${cgbaRasterLayerName}`,
-            popupEnabled: false,
-            queryable: true,
-            popupFields: {},
-            rasterSource: {
-                url: `${PROD_GEOSERVER_URL}/wms`,
-                headers: {
-                    "Accept": "application/json",
-                    "Cache-Control": "no-cache",
-                },
-                layerName: `${ENERGY_MINERALS_WORKSPACE}:${cgbaRasterLayerName}`,
-                valueField: "GRAY_INDEX",
-                valueLabel: "Gravity Anomaly",
-                transform: (value: number) => `${value} mGal`,
-            },
-        },
-    ],
-};
-
 // CGBA Gravity Anomalies — COG via CDN. Stretch derived dynamically from STAC raster:bands stats.
 const cgbaBouguerCOGConfig: COGLayerProps = {
     type: 'cog',
-    title: 'Complete Bouguer Gravity Anomaly (COG)',
+    title: 'Complete Bouguer Gravity Anomaly',
     visible: false,
     opacity: 0.9,
     cogUrl: 'https://maps-assets.geology.utah.gov/geophysics/cbgaras-cog.tif',
@@ -827,7 +794,6 @@ const geophysicalDataConfig: LayerProps = {
         geothermalTEMLayerConfig,
         gravityStationsLayerConfig,
         pacesLegacyLayerConfig,
-        cgbaBouguerRasterConfig,
         cgbaBouguerCOGConfig,
     ]
 }

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -759,6 +759,9 @@ const cgbaBouguerRasterConfig: WMSLayerProps = {
     visible: false,
     opacity: 0.9,
     crs: 'EPSG:26912',
+    legendUnit: 'mGal',
+    // SLD stops are -310/-81 but WCS DescribeCoverage reports true extent -283/-107. Remove after COG migration.
+    legendRange: [-283, -107],
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${cgbaRasterLayerName}`,

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -779,7 +779,6 @@ const cgbaBouguerCOGConfig: COGLayerProps = {
     stacUrl: 'https://maps-assets.geology.utah.gov/geophysics/cbgaras.stac.json',
     stretchMode: 'minmax',
     colorStops: ['#440154', '#31688e', '#35b779', '#c8e020', '#fde725'],
-    range: [-310, -85], // fallback if STAC fetch fails
     continuous: true,
     legendUnit: 'mGal',
     popupValueLabel: 'Gravity Anomaly',


### PR DESCRIPTION
COG raster type via maplibre-cog-protocol + click-to-sample popup. Adds legendRange override for raster colorbars where SLD stops don't match data extent.