### PR TITLE
refactor(common): replace fast-xml-parser with native DOMParser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
         "dompurify": "^3.1.6",
         "driver.js": "^1.4.0",
         "embla-carousel-react": "^8.3.0",
-        "fast-xml-parser": "^5.3.7",
         "fflate": "^0.8.2",
         "firebase": "^12.3.0",
         "hyparquet": "^1.25.6",
@@ -9454,24 +9453,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
-      "integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -17473,18 +17454,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "dompurify": "^3.1.6",
     "driver.js": "^1.4.0",
     "embla-carousel-react": "^8.3.0",
-    "fast-xml-parser": "^5.3.7",
     "fflate": "^0.8.2",
     "firebase": "^12.3.0",
     "hyparquet": "^1.25.6",

--- a/src/hooks/__tests__/use-layer-extent.test.ts
+++ b/src/hooks/__tests__/use-layer-extent.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { parseCapabilitiesExtent } from '../use-layer-extent'
+
+const wrap = (layers: string) => `<?xml version="1.0" encoding="UTF-8"?>
+<WMS_Capabilities version="1.3.0" xmlns="http://www.opengis.net/wms">
+  <Capability>
+    <Layer>
+      <Title>Root</Title>
+      ${layers}
+    </Layer>
+  </Capability>
+</WMS_Capabilities>`
+
+describe('parseCapabilitiesExtent', () => {
+    it('prefers CRS:84 (lon/lat order, no swap)', () => {
+        const xml = wrap(`
+            <Layer>
+                <Name>ns:roads</Name>
+                <BoundingBox CRS="CRS:84" minx="-114" miny="37" maxx="-109" maxy="42"/>
+                <BoundingBox CRS="EPSG:4326" minx="37" miny="-114" maxx="42" maxy="-109"/>
+            </Layer>`)
+        expect(parseCapabilitiesExtent(xml, 'ns:roads')).toEqual([-114, 37, -109, 42])
+    })
+
+    it('falls back to EPSG:4326 and swaps lat/lon axis order', () => {
+        const xml = wrap(`
+            <Layer>
+                <Name>ns:roads</Name>
+                <BoundingBox CRS="EPSG:4326" minx="37" miny="-114" maxx="42" maxy="-109"/>
+            </Layer>`)
+        // EPSG:4326 in 1.3.0 is lat/lon -> swapped to [lon, lat, lon, lat]
+        expect(parseCapabilitiesExtent(xml, 'ns:roads')).toEqual([-114, 37, -109, 42])
+    })
+
+    it('falls back to EX_GeographicBoundingBox', () => {
+        const xml = wrap(`
+            <Layer>
+                <Name>ns:roads</Name>
+                <EX_GeographicBoundingBox>
+                    <westBoundLongitude>-114</westBoundLongitude>
+                    <southBoundLatitude>37</southBoundLatitude>
+                    <eastBoundLongitude>-109</eastBoundLongitude>
+                    <northBoundLatitude>42</northBoundLatitude>
+                </EX_GeographicBoundingBox>
+            </Layer>`)
+        expect(parseCapabilitiesExtent(xml, 'ns:roads')).toEqual([-114, 37, -109, 42])
+    })
+
+    it('finds a deeply nested layer by name', () => {
+        const xml = wrap(`
+            <Layer>
+                <Name>group</Name>
+                <Layer>
+                    <Name>ns:roads</Name>
+                    <BoundingBox CRS="CRS:84" minx="-114" miny="37" maxx="-109" maxy="42"/>
+                </Layer>
+            </Layer>`)
+        expect(parseCapabilitiesExtent(xml, 'ns:roads')).toEqual([-114, 37, -109, 42])
+    })
+
+    it('returns null when layer name is absent', () => {
+        const xml = wrap(`
+            <Layer>
+                <Name>ns:other</Name>
+                <BoundingBox CRS="CRS:84" minx="-114" miny="37" maxx="-109" maxy="42"/>
+            </Layer>`)
+        expect(parseCapabilitiesExtent(xml, 'ns:roads')).toBeNull()
+    })
+
+    it('returns null for malformed XML', () => {
+        expect(parseCapabilitiesExtent('<not-closed', 'ns:roads')).toBeNull()
+    })
+})

--- a/src/hooks/use-layer-extent.ts
+++ b/src/hooks/use-layer-extent.ts
@@ -1,105 +1,77 @@
 import { useQuery } from "@tanstack/react-query";
-import { XMLParser } from "fast-xml-parser";
 import { PMTiles } from "pmtiles";
 import { queryKeys } from '@/lib/query-keys';
 import { convertBbox } from '@/lib/map/conversion-utils';
 
 export type BoundingBox = [number, number, number, number]; // [minLng, minLat, maxLng, maxLat]
 
-interface WMSLayer {
-    Name?: string;
-    Layer?: WMSLayer | WMSLayer[];
-    BoundingBox?: WMSBoundingBox | WMSBoundingBox[];
-    EX_GeographicBoundingBox?: {
-        westBoundLongitude: string;
-        southBoundLatitude: string;
-        eastBoundLongitude: string;
-        northBoundLatitude: string;
-    };
-}
+const directChildren = (el: Element, name: string): Element[] =>
+    Array.from(el.children).filter((child) => child.localName === name);
 
-interface WMSBoundingBox {
-    '@_CRS'?: string;
-    '@_minx': string;
-    '@_miny': string;
-    '@_maxx': string;
-    '@_maxy': string;
-}
+const directChildText = (el: Element, name: string): string | null =>
+    directChildren(el, name)[0]?.textContent?.trim() ?? null;
 
-// Create parser once at module level to avoid recreation on every parse
-const xmlParser = new XMLParser({
-    ignoreAttributes: false,
-    attributeNamePrefix: '@_'
-});
-
-const parseCapabilitiesExtent = (xml: string, targetLayerName: string): BoundingBox | null => {
+export const parseCapabilitiesExtent = (xml: string, targetLayerName: string): BoundingBox | null => {
     try {
-        const parsed = xmlParser.parse(xml);
-        const capability = parsed.WMS_Capabilities?.Capability ||
-            parsed.WMT_MS_Capabilities?.Capability;
+        const doc = new DOMParser().parseFromString(xml, 'application/xml');
+        if (doc.querySelector('parsererror')) {
+            console.error('Error parsing GetCapabilities response: malformed XML');
+            return null;
+        }
 
-        if (!capability?.Layer) return null;
+        // Root is WMS_Capabilities (1.3.0) or WMT_MS_Capabilities (1.1.1)
+        const capability = directChildren(doc.documentElement, 'Capability')[0];
+        const rootLayer = capability && directChildren(capability, 'Layer')[0];
+        if (!rootLayer) return null;
 
-        // Helper function to find layer by name
-        const findLayerByName = (layer: WMSLayer, name: string): WMSLayer | null => {
-            if (layer.Name === name) return layer;
-            if (layer.Layer) {
-                if (Array.isArray(layer.Layer)) {
-                    for (const sublayer of layer.Layer) {
-                        const found = findLayerByName(sublayer, name);
-                        if (found) return found;
-                    }
-                } else {
-                    return findLayerByName(layer.Layer, name);
-                }
+        const findLayerByName = (layer: Element, name: string): Element | null => {
+            if (directChildText(layer, 'Name') === name) return layer;
+            for (const sublayer of directChildren(layer, 'Layer')) {
+                const found = findLayerByName(sublayer, name);
+                if (found) return found;
             }
             return null;
         };
 
-        const targetLayer = findLayerByName(capability.Layer, targetLayerName);
-
+        const targetLayer = findLayerByName(rootLayer, targetLayerName);
         if (!targetLayer) return null;
 
         // Try WMS 1.3.0 BoundingBox
         // IMPORTANT: Prefer CRS:84 over EPSG:4326 because WMS 1.3.0 uses lat/lon axis order
         // for EPSG:4326, while CRS:84 always uses lon/lat order
-        if (targetLayer.BoundingBox) {
-            const boxes = Array.isArray(targetLayer.BoundingBox)
-                ? targetLayer.BoundingBox
-                : [targetLayer.BoundingBox];
+        const boxes = directChildren(targetLayer, 'BoundingBox');
 
-            // First try CRS:84 (always lon/lat order)
-            const crs84Box = boxes.find((box: WMSBoundingBox) => box['@_CRS'] === 'CRS:84');
-            if (crs84Box) {
-                return [
-                    parseFloat(crs84Box['@_minx']),
-                    parseFloat(crs84Box['@_miny']),
-                    parseFloat(crs84Box['@_maxx']),
-                    parseFloat(crs84Box['@_maxy'])
-                ];
-            }
+        // First try CRS:84 (always lon/lat order)
+        const crs84Box = boxes.find((box) => box.getAttribute('CRS') === 'CRS:84');
+        if (crs84Box) {
+            return [
+                parseFloat(crs84Box.getAttribute('minx')!),
+                parseFloat(crs84Box.getAttribute('miny')!),
+                parseFloat(crs84Box.getAttribute('maxx')!),
+                parseFloat(crs84Box.getAttribute('maxy')!)
+            ];
+        }
 
-            // Fall back to EPSG:4326 but swap axes (WMS 1.3.0 uses lat/lon for 4326)
-            const epsg4326Box = boxes.find((box: WMSBoundingBox) => box['@_CRS'] === 'EPSG:4326');
-            if (epsg4326Box) {
-                // minx/maxx are lat, miny/maxy are lon in WMS 1.3.0 EPSG:4326
-                return [
-                    parseFloat(epsg4326Box['@_miny']), // lon
-                    parseFloat(epsg4326Box['@_minx']), // lat
-                    parseFloat(epsg4326Box['@_maxy']), // lon
-                    parseFloat(epsg4326Box['@_maxx'])  // lat
-                ];
-            }
+        // Fall back to EPSG:4326 but swap axes (WMS 1.3.0 uses lat/lon for 4326)
+        const epsg4326Box = boxes.find((box) => box.getAttribute('CRS') === 'EPSG:4326');
+        if (epsg4326Box) {
+            // minx/maxx are lat, miny/maxy are lon in WMS 1.3.0 EPSG:4326
+            return [
+                parseFloat(epsg4326Box.getAttribute('miny')!), // lon
+                parseFloat(epsg4326Box.getAttribute('minx')!), // lat
+                parseFloat(epsg4326Box.getAttribute('maxy')!), // lon
+                parseFloat(epsg4326Box.getAttribute('maxx')!)  // lat
+            ];
         }
 
         // Try WMS 1.3.0 EX_GeographicBoundingBox
-        if (targetLayer.EX_GeographicBoundingBox) {
-            const bbox = targetLayer.EX_GeographicBoundingBox;
+        const exBox = directChildren(targetLayer, 'EX_GeographicBoundingBox')[0];
+        if (exBox) {
             return [
-                parseFloat(bbox.westBoundLongitude),
-                parseFloat(bbox.southBoundLatitude),
-                parseFloat(bbox.eastBoundLongitude),
-                parseFloat(bbox.northBoundLatitude)
+                parseFloat(directChildText(exBox, 'westBoundLongitude')!),
+                parseFloat(directChildText(exBox, 'southBoundLatitude')!),
+                parseFloat(directChildText(exBox, 'eastBoundLongitude')!),
+                parseFloat(directChildText(exBox, 'northBoundLatitude')!)
             ];
         }
 


### PR DESCRIPTION
- Parse WMS GetCapabilities with native DOMParser instead of fast-xml-parser.
- Remove fast-xml-parser dependency, clearing one high-severity advisory.
- Add unit tests for WMS extent parsing.