### PR TITLE
feat: consume EPSG:4326 from canonical storage; degree-based AOI validation

### DIFF
--- a/src/lib/map/__tests__/conversion-utils.test.ts
+++ b/src/lib/map/__tests__/conversion-utils.test.ts
@@ -351,9 +351,11 @@ describe('serializePolygonForUrl', () => {
     consoleSpy.mockRestore();
   });
 
-  it('defaults to EPSG:3857 when crs is missing', () => {
+  it('defaults to EPSG:4326 when crs is missing', () => {
+    // Default is now WGS84 (canonical storage projection); input ring is assumed
+    // already in 4326, so serialization is the identity transform.
     const polygon: PolygonGeometry = {
-      rings: [[[-12367126, 4871080]]]
+      rings: [[[-111.09, 40.76]]]
     };
     const result = serializePolygonForUrl(polygon);
 
@@ -361,12 +363,14 @@ describe('serializePolygonForUrl', () => {
     if (result) {
       const parsed = JSON.parse(result);
       expect(parsed.rings[0][0][0]).toBeCloseTo(-111.09, 1);
+      expect(parsed.rings[0][0][1]).toBeCloseTo(40.76, 1);
     }
   });
 });
 
 describe('deserializePolygonFromUrl', () => {
-  it('deserializes WGS84 polygon to Web Mercator', () => {
+  it('deserializes WGS84 polygon as WGS84 (identity)', () => {
+    // URL is WGS84; AOI is stored in WGS84 internally — no reprojection.
     const serialized = JSON.stringify({
       rings: [[[-111.09, 40.76], [-111.08, 40.75], [-111.09, 40.76]]]
     });
@@ -374,9 +378,9 @@ describe('deserializePolygonFromUrl', () => {
 
     expect(result).not.toBeNull();
     if (result) {
-      expect(result.crs).toBe('EPSG:3857');
-      expect(result.rings[0][0][0]).toBeCloseTo(-12366482, -1);
-      expect(result.rings[0][0][1]).toBeCloseTo(4977006, -1);
+      expect(result.crs).toBe('EPSG:4326');
+      expect(result.rings[0][0][0]).toBeCloseTo(-111.09, 2);
+      expect(result.rings[0][0][1]).toBeCloseTo(40.76, 2);
     }
   });
 
@@ -388,7 +392,7 @@ describe('deserializePolygonFromUrl', () => {
 
     expect(result).not.toBeNull();
     if (result) {
-      expect(result.crs).toBe('EPSG:3857');
+      expect(result.crs).toBe('EPSG:4326');
     }
   });
 

--- a/src/lib/map/conversion-utils.ts
+++ b/src/lib/map/conversion-utils.ts
@@ -277,7 +277,7 @@ export function serializePolygonForUrl(polygon: PolygonGeometry | null): string 
         }
 
         const rings = polygon.rings;
-        const sourceCRS = polygon.crs || 'EPSG:3857'; // Default to Web Mercator
+        const sourceCRS = polygon.crs || 'EPSG:4326'; // Default to WGS84 (canonical storage projection)
 
         // Convert to WGS84 if needed for human-readable coordinates in URL
         let wgs84Rings = rings;
@@ -307,11 +307,11 @@ export function serializePolygonForUrl(polygon: PolygonGeometry | null): string 
 
 /**
  * Deserialize polygon from URL query parameter
- * Reconstructs polygon from compact WGS84 format
- * Converts coordinates back to Web Mercator (EPSG:3857)
+ * URL coordinates are in WGS84 (EPSG:4326); AOI is stored internally in WGS84 too,
+ * so no reprojection is needed.
  * Expects format: { "rings": [[[lng, lat], [lng, lat], ...]] }
- * - Coordinates are in WGS84 [longitude, latitude] order (human-readable)
- * - Returns PolygonGeometry in Web Mercator (EPSG:3857)
+ * - Coordinates are in WGS84 [longitude, latitude] order (GeoJSON-standard)
+ * - Returns PolygonGeometry in WGS84 (EPSG:4326)
  */
 export function deserializePolygonFromUrl(serialized: string): PolygonGeometry | null {
     try {
@@ -323,18 +323,9 @@ export function deserializePolygonFromUrl(serialized: string): PolygonGeometry |
             return null;
         }
 
-        // Convert from WGS84 back to Web Mercator
-        const webMercatorRings = compact.rings.map((ring: number[][]) =>
-            ring.map(([lng, lat]: number[]) => {
-                const [x, y] = convertCoordinate([lng, lat], 'EPSG:4326', 'EPSG:3857');
-                return [x, y];
-            })
-        );
-
-        // Return polygon geometry with EPSG code
         return {
-            rings: webMercatorRings, // rings: [[[x, y], [x, y], ...]] in Web Mercator
-            crs: 'EPSG:3857' // Web Mercator
+            rings: compact.rings, // rings: [[[lng, lat], [lng, lat], ...]] in WGS84
+            crs: 'EPSG:4326'
         };
     } catch (error) {
         console.error('Error deserializing polygon:', error);

--- a/src/lib/map/wfs-service.ts
+++ b/src/lib/map/wfs-service.ts
@@ -83,8 +83,8 @@ async function describeFeatureType(wfsUrl: string, typeName: string): Promise<{ 
 /**
  * Convert GeoJSON Polygon to WKT with SRID prefix.
  * CQL INTERSECTS evaluates in the layer's native CRS, so we must declare
- * our polygon's CRS explicitly. Without this, layers stored in EPSG:3857
- * silently return 0 results when queried with EPSG:4326 coordinates.
+ * our polygon's CRS explicitly. Without this, layers stored in a CRS other
+ * than EPSG:4326 silently return 0 results when queried with our coordinates.
  */
 function polygonToWkt(polygon: Polygon): string {
   const ring = polygon.coordinates[0]

--- a/src/routes/_map/carbonstorage/-data/layers/layers.tsx
+++ b/src/routes/_map/carbonstorage/-data/layers/layers.tsx
@@ -14,7 +14,7 @@ const georegionsWMSConfig: WMSLayerProps = {
     title: georegionsWMSTitle,
     visible: true,
     opacity: 0.3,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     downloadParquetUrl: parquetUrl("enmin_ccus_georegions"),
     sublayers: [
         {
@@ -55,7 +55,7 @@ const oilGasFieldsWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: oilGasFieldsWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${oilGasFieldsLayerName}`,
@@ -80,7 +80,7 @@ const pipelinesWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: pipelinesWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${pipelinesLayerName}`,
@@ -180,7 +180,7 @@ const riversWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: riversWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${GEN_GIS_WORKSPACE}:${riversLayerName}`,
@@ -202,7 +202,7 @@ const roadsWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: roadsWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${roadsLayerName}`,
@@ -802,7 +802,7 @@ const ccusProjectsWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: ccusProjectsWMSTitle,
     visible: true,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     downloadParquetUrl: parquetUrl("ccus_projects"),
     sublayers: [
         {
@@ -862,7 +862,7 @@ const geochemWellSitesWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: geochemWellSitesWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     downloadParquetUrl: parquetUrl("enmin_ccus_geochemistry"),
     sublayers: [
         {
@@ -1132,7 +1132,7 @@ const utCountiesConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: 'Utah Counties',
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [{
         name: `${ENERGY_MINERALS_WORKSPACE}:enmin_ut_counties_current`,
         popupEnabled: false,
@@ -1146,7 +1146,7 @@ const utTownshipRangesConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: 'Utah Township & Ranges',
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     visibleZoomRange: [11, 22],
     sublayers: [{
         name: `${ENERGY_MINERALS_WORKSPACE}:enmin_plss_townshiprange_current`,

--- a/src/routes/_map/hazards/-components/sidebar/report-generator.tsx
+++ b/src/routes/_map/hazards/-components/sidebar/report-generator.tsx
@@ -9,7 +9,6 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { Link } from "@/components/ui/link";
-import proj4 from 'proj4';
 import turfArea from '@turf/area';
 import { polygon as turfPolygon } from '@turf/helpers';
 import { serializePolygonForUrl, PolygonGeometry } from '@/lib/map/conversion-utils';
@@ -23,13 +22,15 @@ type DialogType = 'areaTooLarge' | 'confirmation' | null;
 const SQ_METERS_PER_SQ_MILE = 2589988.11;
 const SQ_METERS_PER_SQ_KM = 1_000_000;
 
-/** Geodesic area from a Web Mercator polygon via @turf/area */
+// AOI extent limits in WGS84 degrees, sized to approximately 12 km × 18 km at Utah latitudes (~40°N).
+// Latitude degrees are uniform; longitude degrees vary ~3% across Utah, so the longitude limit
+// is approximate. 1° latitude ≈ 111,320 m everywhere; 1° longitude ≈ 85,300 m at 40°N.
+const MAX_AOI_LAT_EXTENT_DEG = 0.108;  // ≈12 km
+const MAX_AOI_LON_EXTENT_DEG = 0.211;  // ≈18 km at 40°N
+
+/** Geodesic area from a WGS84 polygon via @turf/area */
 function formatAoiArea(aoi: PolygonGeometry): string {
-    // Convert rings from Web Mercator to WGS84 for turf
-    const wgs84Rings = aoi.rings.map(ring =>
-        ring.map(([x, y]) => proj4('EPSG:3857', 'EPSG:4326', [x, y]))
-    );
-    const sqM = turfArea(turfPolygon(wgs84Rings));
+    const sqM = turfArea(turfPolygon(aoi.rings));
     const sqMi = (sqM / SQ_METERS_PER_SQ_MILE).toFixed(1);
     const sqKm = (sqM / SQ_METERS_PER_SQ_KM).toFixed(1);
 
@@ -62,42 +63,31 @@ function ReportGenerator() {
 
     // Handle draw completion from the shared TerraDraw instance
     const handleDrawComplete = (polygon: Polygon) => {
-        // Convert from WGS84 (GeoJSON) to Web Mercator for area check
+        // TerraDraw provides coordinates in WGS84 (GeoJSON spec)
         const rings = polygon.coordinates;
-        const mercatorRings: number[][][] = [];
 
+        // Calculate extent in WGS84 degrees directly
+        const allLng: number[] = [];
+        const allLat: number[] = [];
         for (const ring of rings) {
-            const mercatorRing: number[][] = [];
             for (const coord of ring) {
-                const [x, y] = proj4('EPSG:4326', 'EPSG:3857', [coord[0], coord[1]]);
-                mercatorRing.push([x, y]);
-            }
-            mercatorRings.push(mercatorRing);
-        }
-
-        // Calculate extent from Web Mercator coordinates
-        const allX: number[] = [];
-        const allY: number[] = [];
-        for (const ring of mercatorRings) {
-            for (const coord of ring) {
-                allX.push(coord[0]);
-                allY.push(coord[1]);
+                allLng.push(coord[0]);
+                allLat.push(coord[1]);
             }
         }
 
-        const minX = Math.min(...allX);
-        const maxX = Math.max(...allX);
-        const minY = Math.min(...allY);
-        const maxY = Math.max(...allY);
+        const minLng = Math.min(...allLng);
+        const maxLng = Math.max(...allLng);
+        const minLat = Math.min(...allLat);
+        const maxLat = Math.max(...allLat);
 
-        const areaWidth = maxX - minX;
-        const areaHeight = maxY - minY;
+        const areaWidth = maxLng - minLng;   // degrees longitude
+        const areaHeight = maxLat - minLat;  // degrees latitude
 
-        // Check if area is within limits (12000m x 18000m)
-        if (areaHeight < 12000 && areaWidth < 18000) {
+        if (areaHeight < MAX_AOI_LAT_EXTENT_DEG && areaWidth < MAX_AOI_LON_EXTENT_DEG) {
             const aoi: PolygonGeometry = {
-                rings: mercatorRings,
-                crs: 'EPSG:3857' // Web Mercator
+                rings,
+                crs: 'EPSG:4326'
             };
             setPendingAoi(aoi);
             setActiveDialog('confirmation');
@@ -186,26 +176,23 @@ function ReportGenerator() {
         const sw = bounds.getSouthWest();
         const ne = bounds.getNorthEast();
 
-        // Convert to Web Mercator for area calculation
-        const [swX, swY] = proj4('EPSG:4326', 'EPSG:3857', [sw.lng, sw.lat]);
-        const [neX, neY] = proj4('EPSG:4326', 'EPSG:3857', [ne.lng, ne.lat]);
+        // Area calculation in WGS84 degrees
+        const areaWidth = Math.abs(ne.lng - sw.lng);
+        const areaHeight = Math.abs(ne.lat - sw.lat);
 
-        const areaWidth = Math.abs(neX - swX);
-        const areaHeight = Math.abs(neY - swY);
-
-        if (areaHeight < 12000 && areaWidth < 18000) {
-            // Create polygon from bounds (in Web Mercator)
+        if (areaHeight < MAX_AOI_LAT_EXTENT_DEG && areaWidth < MAX_AOI_LON_EXTENT_DEG) {
+            // CCW winding per GeoJSON RFC 7946 (exterior ring)
             const rings = [[
-                [neX, neY],
-                [neX, swY],
-                [swX, swY],
-                [swX, neY],
-                [neX, neY]
+                [sw.lng, sw.lat],
+                [ne.lng, sw.lat],
+                [ne.lng, ne.lat],
+                [sw.lng, ne.lat],
+                [sw.lng, sw.lat],
             ]];
 
             const aoi: PolygonGeometry = {
-                rings: [rings[0]],
-                crs: 'EPSG:3857' // Web Mercator
+                rings,
+                crs: 'EPSG:4326'
             };
             handleNavigate(aoi);
         } else {
@@ -264,17 +251,14 @@ function ReportGenerator() {
         const sw = bounds.getSouthWest();
         const ne = bounds.getNorthEast();
 
-        // Convert to Web Mercator for area calculation
-        const [swX, swY] = proj4('EPSG:4326', 'EPSG:3857', [sw.lng, sw.lat]);
-        const [neX, neY] = proj4('EPSG:4326', 'EPSG:3857', [ne.lng, ne.lat]);
+        // Area calculation in WGS84 degrees
+        const areaWidth = Math.abs(ne.lng - sw.lng);
+        const areaHeight = Math.abs(ne.lat - sw.lat);
 
-        const areaWidth = Math.abs(neX - swX);
-        const areaHeight = Math.abs(neY - swY);
-
-        // Calculate scale factor needed to fit within limits (12000m x 18000m)
-        // Add a small buffer (0.95) to ensure we're comfortably within limits
-        const scaleX = (18000 * 0.95) / areaWidth;
-        const scaleY = (12000 * 0.95) / areaHeight;
+        // Calculate scale factor needed to fit within MAX_AOI extent.
+        // Add a small buffer (0.95) to ensure we're comfortably within limits.
+        const scaleX = (MAX_AOI_LON_EXTENT_DEG * 0.95) / areaWidth;
+        const scaleY = (MAX_AOI_LAT_EXTENT_DEG * 0.95) / areaHeight;
         const scaleFactor = Math.min(scaleX, scaleY);
 
         // Calculate zoom delta (each zoom level is 2x)

--- a/src/routes/_map/hazards/-components/sidebar/report-generator.tsx
+++ b/src/routes/_map/hazards/-components/sidebar/report-generator.tsx
@@ -22,11 +22,13 @@ type DialogType = 'areaTooLarge' | 'confirmation' | null;
 const SQ_METERS_PER_SQ_MILE = 2589988.11;
 const SQ_METERS_PER_SQ_KM = 1_000_000;
 
-// AOI extent limits in WGS84 degrees, sized to approximately 12 km × 18 km at Utah latitudes (~40°N).
-// Latitude degrees are uniform; longitude degrees vary ~3% across Utah, so the longitude limit
-// is approximate. 1° latitude ≈ 111,320 m everywhere; 1° longitude ≈ 85,300 m at 40°N.
-const MAX_AOI_LAT_EXTENT_DEG = 0.108;  // ≈12 km
-const MAX_AOI_LON_EXTENT_DEG = 0.211;  // ≈18 km at 40°N
+// AOI extent limits in WGS84 degrees. Calibrated to preserve the pre-migration cap: the old check
+// compared Web Mercator unit deltas against 12000/18000, which (with ~1.305× Mercator inflation at
+// 40°N) capped the true ground extent at ≈9.2 km lat × 13.8 km lon. These degree values reproduce
+// that same true extent at 40°N. Longitude degrees vary ~4% across Utah latitudes (approximate).
+// 1° latitude ≈ 111,320 m everywhere; 1° longitude ≈ 85,300 m at 40°N.
+const MAX_AOI_LAT_EXTENT_DEG = 0.0826;  // ≈9.2 km
+const MAX_AOI_LON_EXTENT_DEG = 0.162;   // ≈13.8 km at 40°N
 
 /** Geodesic area from a WGS84 polygon via @turf/area */
 function formatAoiArea(aoi: PolygonGeometry): string {

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -106,7 +106,7 @@ const utCountiesConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: 'Utah Counties',
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     downloadParquetUrl: parquetUrl("enmin_ut_counties"),
     sublayers: [{
         name: `${ENERGY_MINERALS_WORKSPACE}:enmin_ut_counties_current`,
@@ -121,7 +121,7 @@ const utTownshipRangesConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: 'Utah Township & Ranges',
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     visibleZoomRange: [11, 22],
     downloadParquetUrl: parquetUrl("enmin_plss_townshiprange"),
     sublayers: [{
@@ -139,7 +139,7 @@ const oilGasFieldsWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: oilGasFieldsWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${oilGasFieldsLayerName}`,
@@ -164,7 +164,7 @@ const basinsWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: basinsWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     downloadParquetUrl: parquetUrl("enmin_ucrc_basins"),
     sublayers: [
         {
@@ -187,7 +187,7 @@ const nonpetrolWellsConfig: WMSLayerProps = {
   url: `${PROD_GEOSERVER_URL}/wms`,
   title: nonpetrolWellsTitle,
   visible: false,
-  crs: 'EPSG:3857',
+  crs: 'EPSG:4326',
   sublayers: [
     {
       name: `${ENERGY_MINERALS_WORKSPACE}:${nonpetrolWellsLayerName}`,
@@ -317,7 +317,7 @@ const metalMiningDistrictsConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: metalMiningDistrictsTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${metalMiningDistrictsLayerName}`,
@@ -370,7 +370,7 @@ const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${MAPPING_WORKSPACE}:${seamlessGeolunitsLayerName}`,
@@ -391,7 +391,7 @@ const pipelinesWMSConfig: WMSLayerProps = {
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: pipelinesWMSTitle,
     visible: false,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     sublayers: [
         {
             name: `${ENERGY_MINERALS_WORKSPACE}:${pipelinesLayerName}`,

--- a/src/routes/_map/subsurface/-index.tsx
+++ b/src/routes/_map/subsurface/-index.tsx
@@ -50,7 +50,7 @@ const searchConfig: SearchSourceConfig[] = [
     url: `${PROD_POSTGREST_URL}/enmin_ucrc_wells_current`,
     sourceName: 'UCRC Wells',
     layerName: ucrcWellsWMSTitle,
-    crs: 'EPSG:3857',
+    crs: 'EPSG:4326',
     displayField: 'well_name',
     secondaryDisplayField: 'uwi',
     params: {

--- a/src/routes/_report/-data/hazard-unit-map.ts
+++ b/src/routes/_report/-data/hazard-unit-map.ts
@@ -45,9 +45,9 @@ const geometryFieldOverrides: Record<string, string> = {
 };
 
 // Native CRS per layer (default is EPSG:26912, override where different)
-// TODO: All layers will eventually migrate to EPSG:3857
+// TODO: All layers will eventually migrate to EPSG:4326
 const crsOverrides: Record<string, string> = {
-    [quaternaryFaultsHazardCode]: 'EPSG:3857',
+    [quaternaryFaultsHazardCode]: 'EPSG:4326',
 };
 
 /**
@@ -62,7 +62,7 @@ export function getGeometryField(hazardCode: string): string {
 /**
  * Get the native CRS for a hazard code
  * @param hazardCode - The hazard code (e.g., 'QFF', 'LQS')
- * @returns The EPSG code (e.g., 'EPSG:26912', 'EPSG:3857')
+ * @returns The EPSG code (e.g., 'EPSG:26912', 'EPSG:4326')
  */
 export function getLayerCRS(hazardCode: string): string {
     return crsOverrides[hazardCode] || 'EPSG:26912';

--- a/src/routes/_report/-utils/qff-legend-service.ts
+++ b/src/routes/_report/-utils/qff-legend-service.ts
@@ -18,7 +18,7 @@ export async function generateQFFLegendItems(polygon: string): Promise<CustomLeg
         wfsLayer: 'hazards:hazards_qfaults_current',
         wmsLayer: 'hazards:hazards_qfaults_current',
         geometryField: 'geom',
-        crs: 'EPSG:3857',
+        crs: 'EPSG:4326',
         properties: 'faultzone,faultname,sectionname,strandname,mappedscale,slipsense,faultage,sliprate,qffhazardunit',
         unitField: 'qffhazardunit',
         groupByField: 'faultzone',


### PR DESCRIPTION
## Summary

- Layer config `crs:` fields across subsurface, carbonstorage, qff-legend, hazard-unit-map, and `subsurface/-index` flipped from `'EPSG:3857'` to `'EPSG:4326'`. These drive WFS `srsName`, so GeoServer now serves features in 4326 (matching the new canonical storage).
- AOI internal CRS becomes 4326 throughout `report-generator.tsx`. Removes the proj4 round-trip that existed only to compute meter-based extent thresholds.
- Report-area validation rewritten in degrees: `MAX_AOI_LAT_EXTENT_DEG = 0.108` (≈12 km), `MAX_AOI_LON_EXTENT_DEG = 0.211` (≈18 km at 40°N). Drift across Utah latitudes (~3-4%) is acceptable per design.
- `conversion-utils.ts` `deserializePolygonFromUrl` simplified — URL is 4326, in-memory AOI is now 4326, no reprojection needed. Default fallback for unlabeled polygons also flips to 4326.

## What is *not* changed (intentional)

- **WMS render paths** (`layer-utils.ts`, `factory/maplibre.ts`, `report-map.tsx`, `map-preview.tsx`) remain at EPSG:3857. MapLibre's tile-URL template only substitutes `{bbox-epsg-3857}` — there is no `{bbox-epsg-4326}` placeholder. GeoServer reprojects from 4326 storage on the fly for the WMS rendered image, so this path keeps working after the backend migration with zero changes.
- **WMS 1.3.0 GetFeatureInfo** in `use-popup-data.ts` also remains at 3857. Switching to `CRS=EPSG:4326` in WMS 1.3.0 triggers an axis-order swap (lat,lon) — avoided here for safety. GeoServer reprojects for the feature query too.
- `src/main.tsx` proj4 def for EPSG:3857 stays — still useful for the WMS GetFeatureInfo path and for the `convertBbox` defensive heuristic.
- All test references in `src/lib/map/__tests__/conversion-utils.test.ts` to 3857↔4326 conversion stay — those test the bi-directional conversion functions, which must still support both.

The resulting bifurcation is intentional and safe:
- **Spatial-filter side** (WFS `srsName`, CQL polygon SRID, AOI internal CRS, layer config `crs:`) = 4326
- **WMS render/info side** (tile sources, GetFeatureInfo, canvas math) = 3857

## Coordinated PRs

This is one of three coordinated PRs flipping the canonical projection across the pipeline:

1. **ugs-ingest** — dbt generator template + metadata payload (`UGS-GIO/ugs-ingest` PR #162)
2. **dataELT** — all existing dbt intermediate models + docs (`UGS-GIO/dataELT` PR #411)
3. **ugs-map-viewer** (this PR) — frontend consumer

The three should be merged in the same cutover window. Do not merge alone — a 4326 frontend against a 3857 backend will silently return empty WFS results because the CQL `INTERSECTS` SRID won't match the stored geometry SRID.

## Test plan

- [ ] `npm test src/lib/map/__tests__/conversion-utils.test.ts` — 53/53 vitest pass (verified locally)
- [ ] `npm run lint` shows 107 problems (71 errors, 36 warnings) — matches master baseline, zero new errors
- [ ] `npm run build` succeeds
- [ ] Dev preview against test schema (after dataELT sibling PR lands in test schema): hazards report flow end-to-end — draw an AOI, area-limit dialog respects the new degree thresholds, generated report renders, intersecting quad names returned by WFS
- [ ] Subsurface and carbonstorage WMS layers render visibly on the main map (verifies the 3857 WMS path still works against a 4326 backend via GeoServer reprojection)
- [ ] QFF legend generation succeeds against the qfaults layer
- [ ] Old shared report URLs (URL params already in WGS84 from before the migration) still deserialize correctly into 4326 AOI