### PR TITLE
feat(common): add download tracking via gtm dataLayer

### DIFF
--- a/src/components/maps/parquet-download-menu.tsx
+++ b/src/components/maps/parquet-download-menu.tsx
@@ -26,6 +26,16 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
     const download = useMutation({
         mutationFn: async (format: ExportFormat) => {
             const { exportParquet, safeFilename } = await import('@/lib/duckdb-export');
+
+            // Track download event in Google Tag Manager dataLayer
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+                event: 'dataset_download',
+                layer_title: layerTitle,
+                format,
+                parquet_url: parquetUrl,
+            });
+
             await exportParquet({
                 parquetUrl,
                 filename: safeFilename(layerTitle),

--- a/src/components/maps/parquet-download-menu.tsx
+++ b/src/components/maps/parquet-download-menu.tsx
@@ -26,16 +26,6 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
     const download = useMutation({
         mutationFn: async (format: ExportFormat) => {
             const { exportParquet, safeFilename } = await import('@/lib/duckdb-export');
-
-            // Track download event in Google Tag Manager dataLayer
-            window.dataLayer = window.dataLayer || [];
-            window.dataLayer.push({
-                event: 'dataset_download',
-                layer_title: layerTitle,
-                format,
-                parquet_url: parquetUrl,
-            });
-
             await exportParquet({
                 parquetUrl,
                 filename: safeFilename(layerTitle),
@@ -46,6 +36,16 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
                         // Let mutation onError handle display; no-op here
                     }
                 },
+            });
+        },
+        onSuccess: (_data, format) => {
+            // Track completed download in Google Tag Manager dataLayer
+            window.dataLayer = window.dataLayer || [];
+            window.dataLayer.push({
+                event: 'dataset_download',
+                layer_title: layerTitle,
+                format,
+                parquet_url: parquetUrl,
             });
         },
         onError: (err) => {

--- a/src/components/maps/parquet-download-menu.tsx
+++ b/src/components/maps/parquet-download-menu.tsx
@@ -45,7 +45,9 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
                 event: 'dataset_download',
                 layer_title: layerTitle,
                 format,
-                parquet_url: parquetUrl,
+                has_geometry: schema?.hasGeometry ?? false,
+                column_count: schema?.columns.length ?? 0,
+                row_count: schema?.rowCount ?? 0,
             });
         },
         onError: (err) => {

--- a/src/hooks/use-parquet-schema.ts
+++ b/src/hooks/use-parquet-schema.ts
@@ -9,6 +9,7 @@ export interface ParquetSchema {
     columns: string[];
     geometryColumn: string | null;
     hasGeometry: boolean;
+    rowCount: number;
 }
 
 const fetchSchema = async (url: string): Promise<ParquetSchema> => {
@@ -18,7 +19,9 @@ const fetchSchema = async (url: string): Promise<ParquetSchema> => {
     // schema[0] is the root group; actual columns start at index 1.
     const columns = metadata.schema.slice(1).map(s => s.name);
     const geometryColumn = GEOM_CANDIDATES.find(c => columns.includes(c)) ?? null;
-    return { columns, geometryColumn, hasGeometry: !!geometryColumn };
+    // metadata.num_rows is a bigint; coerce for plain JSON/analytics use.
+    const rowCount = Number(metadata.num_rows);
+    return { columns, geometryColumn, hasGeometry: !!geometryColumn, rowCount };
 };
 
 /** Probe a parquet URL's schema once, cache forever. Runs on mount when url is set. */

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+    dataLayer?: Record<string, unknown>[];
+}


### PR DESCRIPTION
This PR adds a type-safe Google Tag Manager (GTM) dataLayer tracking event when a user successfully completes a layer dataset download. The event fires in the mutation's `onSuccess` callback, so only completed downloads are tracked — failed or aborted exports are not counted. The event is pushed cleanly to `window.dataLayer` and can be captured inside GTM to route download metrics directly to GA4 with no brittle DOM scraping required.

### Event payload (`dataset_download`)

| Field | Description |
| --- | --- |
| `layer_title` | Title of the downloaded layer |
| `format` | Export format chosen (e.g. GeoJSON, CSV) |
| `has_geometry` | Whether the layer has a geometry column |
| `column_count` | Number of columns in the parquet schema |
| `row_count` | Number of rows in the dataset |

`has_geometry`, `column_count` and `row_count` come from the parquet footer already read on mount by `useParquetSchema` — no extra fetch or full download. `row_count` is surfaced from the footer's `num_rows` (coerced from bigint).

### Notes

- The GTM container loads on all environments (including dynamically spun-up preview URLs), so the `dataset_download` trigger should be scoped in GTM to the production hostname to avoid polluting prod GA4 with preview traffic.
- `has_geometry`, `column_count` and `row_count` need registering as custom dimensions in GA4 admin to appear in reports.