### PR TITLE
feat(common): sortable related-table columns via TanStack Table (numeric/alpha, N/A last)

### DIFF
--- a/src/components/maps/popups/popup-content-display.tsx
+++ b/src/components/maps/popups/popup-content-display.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { RelatedDataMap, EMPTY_RELATED_DATA_MAP } from "@/hooks/use-bulk-related-table";
 import { Feature, Geometry, GeoJsonProperties } from "geojson";
-import { ChevronDown, ChevronRight, ExternalLink, Info } from "lucide-react";
+import { ChevronDown, ChevronRight, ChevronUp, ChevronsUpDown, ExternalLink, Info } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LayerContentProps } from "@/components/maps/popups/types";
 import { Link } from "@/components/ui/link";
@@ -240,23 +240,96 @@ function InlineSection({ label, children }: { label?: string; children: ReactNod
     );
 }
 
-// Shared table used for both related tables and pivoted popup-fields tables. Centralizes the
-// header/cell styling so the two call sites can't drift apart. Pass `headers` to render a header
-// row; each row is an array of cell contents.
-function PopupTable({ headers, rows }: { headers?: ReactNode[]; rows: ReactNode[][] }) {
+type SortDir = 'asc' | 'desc';
+
+/**
+ * Derive a sortable key from a rendered cell. Numeric strings (incl. thousands
+ * separators / currency) → number; `N/A`/blank or React-node cells (transforms
+ * like links/photos) → null, which always sorts last. Other strings → string.
+ */
+function cellSortKey(cell: ReactNode): number | string | null {
+    if (cell == null) return null;
+    if (typeof cell === 'number') return Number.isFinite(cell) ? cell : null;
+    if (typeof cell !== 'string') return null; // React node — not sortable
+    const s = cell.trim();
+    if (s === '' || /^n\/?a$/i.test(s)) return null;
+    const stripped = s.replace(/[$,\s]/g, '');
+    if (/^[-+]?\d*\.?\d+$/.test(stripped)) {
+        const n = Number(stripped);
+        if (Number.isFinite(n)) return n;
+    }
+    return s;
+}
+
+// Shared table for related tables and pivoted popup-fields tables. Centralizes
+// header/cell styling. `sortable` makes columns of plain values clickable to
+// sort (numeric or alphabetical); N/A and node cells sort last in both orders.
+function PopupTable({ headers, rows, sortable = false }: { headers?: ReactNode[]; rows: ReactNode[][]; sortable?: boolean }) {
+    const [sort, setSort] = useState<{ col: number; dir: SortDir } | null>(null);
+
+    // A column is sortable only if every cell is a plain value (no React nodes).
+    const sortableCols = useMemo(() => {
+        if (!sortable || !headers) return [];
+        return headers.map((_, col) => rows.length > 0 && rows.every(r => {
+            const c = r[col];
+            return c == null || typeof c === 'string' || typeof c === 'number';
+        }));
+    }, [sortable, headers, rows]);
+
+    const orderedRows = useMemo(() => {
+        if (!sort) return rows;
+        const order = rows.map((_, i) => i).sort((ia, ib) => {
+            const ka = cellSortKey(rows[ia][sort.col]);
+            const kb = cellSortKey(rows[ib][sort.col]);
+            if (ka == null && kb == null) return 0;
+            if (ka == null) return 1;  // nulls/N-A always last, regardless of dir
+            if (kb == null) return -1;
+            const base = typeof ka === 'number' && typeof kb === 'number'
+                ? ka - kb
+                : String(ka).localeCompare(String(kb), undefined, { numeric: true, sensitivity: 'base' });
+            return sort.dir === 'asc' ? base : -base;
+        });
+        return order.map(i => rows[i]);
+    }, [rows, sort]);
+
+    const onHeaderClick = (col: number) => {
+        setSort(prev => {
+            if (!prev || prev.col !== col) return { col, dir: 'asc' };
+            if (prev.dir === 'asc') return { col, dir: 'desc' };
+            return null; // third click clears the sort
+        });
+    };
+
     return (
         <Table>
             {headers && (
                 <TableHeader>
                     <TableRow>
-                        {headers.map((header, idx) => (
-                            <TableHead key={idx} className="h-8 text-xs">{header}</TableHead>
-                        ))}
+                        {headers.map((header, idx) => {
+                            const canSort = sortableCols[idx];
+                            const active = sort?.col === idx;
+                            return (
+                                <TableHead key={idx} className="h-8 text-xs">
+                                    {canSort ? (
+                                        <button
+                                            type="button"
+                                            onClick={() => onHeaderClick(idx)}
+                                            className="flex items-center gap-1 hover:text-foreground"
+                                        >
+                                            {header}
+                                            {active && sort?.dir === 'asc' && <ChevronUp className="h-3 w-3" />}
+                                            {active && sort?.dir === 'desc' && <ChevronDown className="h-3 w-3" />}
+                                            {!active && <ChevronsUpDown className="h-3 w-3 opacity-40" />}
+                                        </button>
+                                    ) : header}
+                                </TableHead>
+                            );
+                        })}
                     </TableRow>
                 </TableHeader>
             )}
             <TableBody>
-                {rows.map((cells, rowIdx) => (
+                {orderedRows.map((cells, rowIdx) => (
                     <TableRow key={rowIdx}>
                         {cells.map((cell, cellIdx) => (
                             <TableCell key={cellIdx} className="py-1.5 text-xs">{cell}</TableCell>
@@ -445,6 +518,7 @@ const PopupContentDisplayInner = ({ feature, layout, layer, bulkRelatedData }: P
                 <PopupTable
                     headers={headers}
                     rows={groupedValues.map(group => group.map(valueItem => valueItem.value))}
+                    sortable
                 />
             );
         } else {

--- a/src/components/maps/popups/popup-content-display.tsx
+++ b/src/components/maps/popups/popup-content-display.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { RelatedDataMap, EMPTY_RELATED_DATA_MAP } from "@/hooks/use-bulk-related-table";
 import { Feature, Geometry, GeoJsonProperties } from "geojson";
-import { ChevronDown, ChevronRight, ChevronUp, ChevronsUpDown, ExternalLink, Info } from "lucide-react";
+import { ChevronDown, ChevronRight, ExternalLink, Info } from "lucide-react";
+import { RelatedDataTable } from "@/components/maps/popups/related-data-table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { LayerContentProps } from "@/components/maps/popups/types";
 import { Link } from "@/components/ui/link";
@@ -240,96 +241,23 @@ function InlineSection({ label, children }: { label?: string; children: ReactNod
     );
 }
 
-type SortDir = 'asc' | 'desc';
-
-/**
- * Derive a sortable key from a rendered cell. Numeric strings (incl. thousands
- * separators / currency) → number; `N/A`/blank or React-node cells (transforms
- * like links/photos) → null, which always sorts last. Other strings → string.
- */
-function cellSortKey(cell: ReactNode): number | string | null {
-    if (cell == null) return null;
-    if (typeof cell === 'number') return Number.isFinite(cell) ? cell : null;
-    if (typeof cell !== 'string') return null; // React node — not sortable
-    const s = cell.trim();
-    if (s === '' || /^n\/?a$/i.test(s)) return null;
-    const stripped = s.replace(/[$,\s]/g, '');
-    if (/^[-+]?\d*\.?\d+$/.test(stripped)) {
-        const n = Number(stripped);
-        if (Number.isFinite(n)) return n;
-    }
-    return s;
-}
-
-// Shared table for related tables and pivoted popup-fields tables. Centralizes
-// header/cell styling. `sortable` makes columns of plain values clickable to
-// sort (numeric or alphabetical); N/A and node cells sort last in both orders.
-function PopupTable({ headers, rows, sortable = false }: { headers?: ReactNode[]; rows: ReactNode[][]; sortable?: boolean }) {
-    const [sort, setSort] = useState<{ col: number; dir: SortDir } | null>(null);
-
-    // A column is sortable only if every cell is a plain value (no React nodes).
-    const sortableCols = useMemo(() => {
-        if (!sortable || !headers) return [];
-        return headers.map((_, col) => rows.length > 0 && rows.every(r => {
-            const c = r[col];
-            return c == null || typeof c === 'string' || typeof c === 'number';
-        }));
-    }, [sortable, headers, rows]);
-
-    const orderedRows = useMemo(() => {
-        if (!sort) return rows;
-        const order = rows.map((_, i) => i).sort((ia, ib) => {
-            const ka = cellSortKey(rows[ia][sort.col]);
-            const kb = cellSortKey(rows[ib][sort.col]);
-            if (ka == null && kb == null) return 0;
-            if (ka == null) return 1;  // nulls/N-A always last, regardless of dir
-            if (kb == null) return -1;
-            const base = typeof ka === 'number' && typeof kb === 'number'
-                ? ka - kb
-                : String(ka).localeCompare(String(kb), undefined, { numeric: true, sensitivity: 'base' });
-            return sort.dir === 'asc' ? base : -base;
-        });
-        return order.map(i => rows[i]);
-    }, [rows, sort]);
-
-    const onHeaderClick = (col: number) => {
-        setSort(prev => {
-            if (!prev || prev.col !== col) return { col, dir: 'asc' };
-            if (prev.dir === 'asc') return { col, dir: 'desc' };
-            return null; // third click clears the sort
-        });
-    };
-
+// Shared table used for both related tables and pivoted popup-fields tables. Centralizes the
+// header/cell styling so the two call sites can't drift apart. Pass `headers` to render a header
+// row; each row is an array of cell contents. (Sortable related tables use RelatedDataTable.)
+function PopupTable({ headers, rows }: { headers?: ReactNode[]; rows: ReactNode[][] }) {
     return (
         <Table>
             {headers && (
                 <TableHeader>
                     <TableRow>
-                        {headers.map((header, idx) => {
-                            const canSort = sortableCols[idx];
-                            const active = sort?.col === idx;
-                            return (
-                                <TableHead key={idx} className="h-8 text-xs">
-                                    {canSort ? (
-                                        <button
-                                            type="button"
-                                            onClick={() => onHeaderClick(idx)}
-                                            className="flex items-center gap-1 hover:text-foreground"
-                                        >
-                                            {header}
-                                            {active && sort?.dir === 'asc' && <ChevronUp className="h-3 w-3" />}
-                                            {active && sort?.dir === 'desc' && <ChevronDown className="h-3 w-3" />}
-                                            {!active && <ChevronsUpDown className="h-3 w-3 opacity-40" />}
-                                        </button>
-                                    ) : header}
-                                </TableHead>
-                            );
-                        })}
+                        {headers.map((header, idx) => (
+                            <TableHead key={idx} className="h-8 text-xs">{header}</TableHead>
+                        ))}
                     </TableRow>
                 </TableHeader>
             )}
             <TableBody>
-                {orderedRows.map((cells, rowIdx) => (
+                {rows.map((cells, rowIdx) => (
                     <TableRow key={rowIdx}>
                         {cells.map((cell, cellIdx) => (
                             <TableCell key={cellIdx} className="py-1.5 text-xs">{cell}</TableCell>
@@ -513,12 +441,13 @@ const PopupContentDisplayInner = ({ feature, layout, layer, bulkRelatedData }: P
         let innerContent: JSX.Element;
 
         if (useTableFormat) {
-            const headers = table.displayFields!.map(df => df.label || df.field);
+            // Sortable: raw rows + column defs (TanStack) so sorting is numeric/
+            // alphabetical on the underlying values, not the rendered cells.
             innerContent = (
-                <PopupTable
-                    headers={headers}
-                    rows={groupedValues.map(group => group.map(valueItem => valueItem.value))}
-                    sortable
+                <RelatedDataTable
+                    rows={data[tableIndex] as Record<string, unknown>[]}
+                    displayFields={table.displayFields!}
+                    initialSort={table.sortBy ? { id: table.sortBy, desc: table.sortDirection === 'desc' } : undefined}
                 />
             );
         } else {

--- a/src/components/maps/popups/related-data-table.tsx
+++ b/src/components/maps/popups/related-data-table.tsx
@@ -1,0 +1,142 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import {
+    useReactTable,
+    getCoreRowModel,
+    getSortedRowModel,
+    flexRender,
+    type ColumnDef,
+    type SortingState,
+} from '@tanstack/react-table';
+import { ChevronDown, ChevronUp, ChevronsUpDown } from 'lucide-react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatNumeric } from '@/lib/utils';
+import type { DisplayField } from '@/lib/types/mapping-types';
+
+type Row = Record<string, unknown>;
+
+/**
+ * Sort key derived from a RAW field value. Numeric values (incl. thousands
+ * separators / currency) → number; `N/A`/blank/null → undefined (pinned last via
+ * `sortUndefined`); everything else → string. Sorting on the raw value (not the
+ * rendered cell) keeps numeric order honest and N/A out of the middle.
+ */
+function sortKey(raw: unknown): number | string | undefined {
+    if (raw == null) return undefined;
+    if (typeof raw === 'number') return Number.isFinite(raw) ? raw : undefined;
+    const s = String(raw).trim();
+    if (s === '' || /^n\/?a$/i.test(s)) return undefined;
+    const stripped = s.replace(/[$,\s]/g, '');
+    if (/^[-+]?\d*\.?\d+$/.test(stripped)) {
+        const n = Number(stripped);
+        if (Number.isFinite(n)) return n;
+    }
+    return s;
+}
+
+/** Render a cell the way the popup does: format → transform → `N/A` fallback. */
+function renderCell(df: DisplayField, row: Row, allRows: Row[]): ReactNode {
+    const formatted = formatNumeric(row[df.field], df.format);
+    const final = df.transform ? df.transform(formatted, row, allRows) : formatted;
+    return final || 'N/A';
+}
+
+/**
+ * Sortable related-table (TanStack Table over raw rows). Each `displayField`
+ * becomes a column: sorting uses the raw value (numeric or alphabetical, N/A
+ * last); the cell renders via the field's format + transform. Columns whose
+ * cells are React nodes (links, photo galleries) are not sortable.
+ */
+export function RelatedDataTable({
+    rows,
+    displayFields,
+    initialSort,
+}: {
+    rows: Row[];
+    displayFields: DisplayField[];
+    /** Default sort (from the related-table config's sortBy/sortDirection). */
+    initialSort?: { id: string; desc: boolean };
+}) {
+    const [sorting, setSorting] = useState<SortingState>(initialSort ? [initialSort] : []);
+
+    // Pre-render cells once: drives both display and which columns are sortable
+    // (a column with any React-node cell can't be meaningfully sorted).
+    const rendered = useMemo(
+        () => rows.map(row => displayFields.map(df => renderCell(df, row, rows))),
+        [rows, displayFields],
+    );
+    const sortableCols = useMemo(
+        () => displayFields.map((_, ci) => rendered.every(r => {
+            const c = r[ci];
+            return c == null || typeof c === 'string' || typeof c === 'number';
+        })),
+        [rendered, displayFields],
+    );
+
+    const columns = useMemo<ColumnDef<Row>[]>(
+        () => displayFields.map((df, ci) => ({
+            id: df.field,
+            accessorFn: (row) => sortKey(row[df.field]),
+            header: df.label || df.field,
+            cell: ({ row }) => rendered[row.index][ci],
+            enableSorting: sortableCols[ci],
+            sortUndefined: 'last',
+            sortDescFirst: false, // first click = ascending for every column (TanStack defaults numbers to desc-first)
+            sortingFn: (a, b, id) => {
+                const va = a.getValue(id), vb = b.getValue(id);
+                if (typeof va === 'number' && typeof vb === 'number') return va - vb;
+                return String(va).localeCompare(String(vb), undefined, { numeric: true, sensitivity: 'base' });
+            },
+        })),
+        [displayFields, rendered, sortableCols],
+    );
+
+    const table = useReactTable({
+        data: rows,
+        columns,
+        state: { sorting },
+        onSortingChange: setSorting,
+        getCoreRowModel: getCoreRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+    });
+
+    return (
+        <Table>
+            <TableHeader>
+                {table.getHeaderGroups().map(hg => (
+                    <TableRow key={hg.id}>
+                        {hg.headers.map(header => {
+                            const sorted = header.column.getIsSorted();
+                            return (
+                                <TableHead key={header.id} className="h-8 text-xs">
+                                    {header.column.getCanSort() ? (
+                                        <button
+                                            type="button"
+                                            onClick={header.column.getToggleSortingHandler()}
+                                            className="flex items-center gap-1 hover:text-foreground"
+                                        >
+                                            {flexRender(header.column.columnDef.header, header.getContext())}
+                                            {sorted === 'asc' && <ChevronUp className="h-3 w-3" />}
+                                            {sorted === 'desc' && <ChevronDown className="h-3 w-3" />}
+                                            {!sorted && <ChevronsUpDown className="h-3 w-3 opacity-40" />}
+                                        </button>
+                                    ) : flexRender(header.column.columnDef.header, header.getContext())}
+                                </TableHead>
+                            );
+                        })}
+                    </TableRow>
+                ))}
+            </TableHeader>
+            <TableBody>
+                {table.getRowModel().rows.map(row => (
+                    <TableRow key={row.id}>
+                        {row.getVisibleCells().map(cell => (
+                            <TableCell key={cell.id} className="py-1.5 text-xs">
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </TableCell>
+                        ))}
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    );
+}

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -342,7 +342,7 @@ export interface RelatedTable {
 }
 
 
-interface DisplayField {
+export interface DisplayField {
     field: string;
     label?: string;
     /** Format numeric values: 'number' (thousands), 'currency' (USD), 'percent'. Applied before transform. */


### PR DESCRIPTION
Makes related-table columns in popups sortable (e.g. UCRC Collection → Core Boxes), built on **TanStack Table** for consistency with the repo's `data-table/` system.

New `RelatedDataTable` (`useReactTable` + sorted row model) over **raw rows + column defs** — sorting keys off the underlying values, not the rendered cells:
- Click a header to sort **ascending → descending → unsorted** (3-state); **first click is ascending** for every column.
- **Numeric** columns (Box #, Top/Bottom ft) sort by value; **string** columns alphabetically (numeric-aware, case-insensitive).
- **N/A / blank / null sorts last in both directions** (`sortUndefined: 'last'`) — the number columns mix in `N/A`.
- React-node columns (Photos, links) aren't sortable — no affordance shown.
- Honors the related-table config's `sortBy` / `sortDirection` as the default sort.

The shared `PopupTable` (key/value popup-fields pivot) is unchanged. Verified live on PRESTON NUTTER 1 (204 boxes): default box-number order, numeric asc/desc with N/A pinned last, Type alphabetical, Photos non-sortable.
