### PR TITLE
refactor(subsurface): ucrc inventory layer attribute changes

### DIFF
--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -494,6 +494,15 @@ const ucrcWellsWFSConfig: PMTilesLayerProps = {
                         return val;
                     }
                 },
+                'Kelly bushing Elevation (GL ft)': {
+                    field: 'elevation_kb',
+                    type: 'custom',
+                    transform: (properties) => {
+                        const val = properties?.['elevation_kb'];
+                        if (val === null || val === undefined || val === 0 || val === '0') return null;
+                        return val;
+                    }
+                },
                 'Latitude': { field: 'latitude', type: 'number' },
                 'Longitude': { field: 'longitude', type: 'number' },
                 'Easting (NAD83)': {

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -488,8 +488,24 @@ const ucrcWellsWFSConfig: PMTilesLayerProps = {
                 'Elevation (GL ft)': { field: 'elevation_gl', type: 'number' },
                 'Latitude': { field: 'latitude', type: 'number' },
                 'Longitude': { field: 'longitude', type: 'number' },
-                'Easting (NAD83)': { field: 'easting', type: 'number' },
-                'Northing (NAD83)': { field: 'northing', type: 'number' },
+                'Easting (NAD83)': {
+                    field: 'easting',
+                    type: 'custom',
+                    transform: (properties) => {
+                        const val = properties?.['easting'];
+                        if (val === null || val === undefined || val === 0 || val === '0') return null;
+                        return val;
+                    }
+                },
+                'Northing (NAD83)': {
+                    field: 'northing',
+                    type: 'custom',
+                    transform: (properties) => {
+                        const val = properties?.['northing'];
+                        if (val === null || val === undefined || val === 0 || val === '0') return null;
+                        return val;
+                    }
+                },
                 'Township': { field: 'township', type: 'string' },
                 'Range': { field: 'range', type: 'string' },
                 'Section': { field: 'section', type: 'string' },

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -485,7 +485,15 @@ const ucrcWellsWFSConfig: PMTilesLayerProps = {
                 'Purpose': { field: 'purpose', type: 'string' },
                 'Producing Formation': { field: 'producing_formation', type: 'string' },
                 'TD (ft)': { field: 'td_ft', type: 'number' },
-                'Elevation (GL ft)': { field: 'elevation_gl', type: 'number' },
+                'Elevation (GL ft)': {
+                    field: 'elevation_gl',
+                    type: 'custom',
+                    transform: (properties) => {
+                        const val = properties?.['elevation_gl'];
+                        if (val === null || val === undefined || val === 0 || val === '0') return null;
+                        return val;
+                    }
+                },
                 'Latitude': { field: 'latitude', type: 'number' },
                 'Longitude': { field: 'longitude', type: 'number' },
                 'Easting (NAD83)': {


### PR DESCRIPTION
changes to fields and attributes in the UCRC Inventory layer.

-Hide Easting and Northing fields if they are “0” or null

-Add Rotary Kelly Bushing field after Easting/Northing fields and if they are “0” or null, hide the field

-If Elevation field is “0” or empty, hide field

-Add public notes field and hide if empty (if not already there)