### PR TITLE
fix(common): add related-table download option to layerlist export

### DIFF
--- a/src/components/maps/layer-controls.tsx
+++ b/src/components/maps/layer-controls.tsx
@@ -9,6 +9,7 @@ import { LayerDescriptionAccordion } from '@/components/maps/layer-description-a
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/lib/query-keys';
 import { ParquetDownloadMenu } from '@/components/maps/parquet-download-menu';
+import type { RelatedTable } from '@/lib/types/mapping-types';
 
 interface LayerControlsProps {
     handleZoomToLayer: () => void;
@@ -26,6 +27,9 @@ interface LayerControlsProps {
     legendUnit?: string;
     /** GeoParquet URL for client-side export. When set, download dropdown is enabled. */
     downloadParquetUrl?: string;
+    /** Related tables configured on the layer's sublayers (e.g. formation tops, geochemistry).
+     * When non-empty, the download menu offers an "Include related data" option. */
+    relatedTables?: RelatedTable[];
     /** When true, hide format-conversion dropdown and offer only a direct parquet download. Used for apps that require unmodified source data. */
     disableExport?: boolean;
     /** Optional layer-scoped filter UI. When provided, adds a Filters toggle to the button row and a collapsible panel below. */
@@ -49,6 +53,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
     arcgisUrl,
     legendUnit,
     downloadParquetUrl,
+    relatedTables,
     disableExport = false,
     filtersContent,
     statsContent,
@@ -162,7 +167,7 @@ const LayerControls: React.FC<LayerControlsProps> = ({
                         </Toggle>
 
                         {!disableExport && downloadParquetUrl && (
-                            <ParquetDownloadMenu parquetUrl={downloadParquetUrl} layerTitle={title} />
+                            <ParquetDownloadMenu parquetUrl={downloadParquetUrl} layerTitle={title} relatedTables={relatedTables} />
                         )}
 
                         {filtersContent && (

--- a/src/components/maps/parquet-download-menu.tsx
+++ b/src/components/maps/parquet-download-menu.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
+    DropdownMenuCheckboxItem,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuLabel,
@@ -12,16 +14,22 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useParquetSchema } from '@/hooks/use-parquet-schema';
 import { EXPORT_FORMATS, availableFormats, type ExportFormat } from '@/lib/export-formats';
+import type { RelatedTable } from '@/lib/types/mapping-types';
 
 interface ParquetDownloadMenuProps {
     /** GeoParquet URL — when present, the menu renders. */
     parquetUrl: string;
     /** Used as the download filename stem */
     layerTitle: string;
+    /** Related tables configured on the layer (e.g. formation tops, geochemistry). When
+     * non-empty, adds an "Include related data" option that bundles them as a zip. */
+    relatedTables?: RelatedTable[];
 }
 
-export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parquetUrl, layerTitle }) => {
+export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parquetUrl, layerTitle, relatedTables }) => {
     const { data: schema, isLoading: schemaLoading, isError: schemaError } = useParquetSchema(parquetUrl);
+    const [includeRelated, setIncludeRelated] = useState(true);
+    const hasRelatedTables = (relatedTables?.length ?? 0) > 0;
 
     const download = useMutation({
         mutationFn: async (format: ExportFormat) => {
@@ -31,6 +39,7 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
                 filename: safeFilename(layerTitle),
                 format,
                 geometryColumn: schema?.geometryColumn ?? null,
+                relatedTables: hasRelatedTables && includeRelated ? relatedTables : undefined,
                 onProgress: (stage) => {
                     if (stage.stage === 'error') {
                         // Let mutation onError handle display; no-op here
@@ -93,6 +102,21 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
                         </DropdownMenuItem>
                     );
                 })}
+                {hasRelatedTables && (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                            Options
+                        </DropdownMenuLabel>
+                        <DropdownMenuCheckboxItem
+                            checked={includeRelated}
+                            onCheckedChange={setIncludeRelated}
+                            onSelect={(e) => e.preventDefault()}
+                        >
+                            Include related data
+                        </DropdownMenuCheckboxItem>
+                    </>
+                )}
             </DropdownMenuContent>
         </DropdownMenu>
     );

--- a/src/hooks/use-bulk-related-table.ts
+++ b/src/hooks/use-bulk-related-table.ts
@@ -2,6 +2,7 @@ import { RelatedTable } from "@/lib/types/mapping-types";
 import type { PostgRESTRow } from '@/lib/types/postgrest-types';
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from '@/lib/query-keys';
+import { fetchRelatedRows, groupRelatedRows } from '@/lib/related-table-fetch';
 
 // Map of targetValue -> array of related rows (supports multiple matches like formation tops)
 export type RelatedDataMap = Map<string, PostgRESTRow[]>;
@@ -46,82 +47,10 @@ export function useBulkRelatedTable(
                     const matchingField = config.matchingField;
                     if (!matchingField) return new Map();
                     try {
-                        let rows: PostgRESTRow[];
-
-                        if (config.fetchMode === 'parquet' && config.url) {
-                            // STAC geoparquet via duckdb-wasm. Lazy import keeps duckdb off the
-                            // initial bundle — it loads on the first popup with a parquet table.
-                            const { queryParquetByValues } = await import('@/lib/duckdb/client');
-                            rows = await queryParquetByValues({
-                                url: config.url,
-                                matchingField,
-                                values: uniqueValues,
-                                sortBy: config.sortBy,
-                                sortDirection: config.sortDirection,
-                            });
-                        } else if (config.fetchMode === 'wfs' && config.wfsTypeName && config.url) {
-                            // WFS mode: build CQL_FILTER IN query
-                            const inValues = uniqueValues.map(v => `'${v}'`).join(',');
-                            const cqlFilter = `${matchingField} IN (${inValues})`;
-                            const wfsUrl = new URL(config.url);
-                            wfsUrl.searchParams.set('service', 'WFS');
-                            wfsUrl.searchParams.set('version', '1.1.0');
-                            wfsUrl.searchParams.set('request', 'GetFeature');
-                            wfsUrl.searchParams.set('typeName', config.wfsTypeName);
-                            wfsUrl.searchParams.set('outputFormat', 'application/json');
-                            wfsUrl.searchParams.set('CQL_FILTER', cqlFilter);
-                            if (config.sortBy) {
-                                const dir = config.sortDirection === 'desc' ? ' D' : ' A';
-                                wfsUrl.searchParams.set('sortBy', `${config.sortBy}${dir}`);
-                            }
-
-                            const response = await fetch(wfsUrl.toString());
-                            if (!response.ok) {
-                                console.error(`[useBulkRelatedTable] WFS fetch failed: ${response.status}`);
-                                return new Map();
-                            }
-
-                            const geojson = await response.json();
-                            rows = (geojson.features || []).map(
-                                (f: { properties?: PostgRESTRow }) => f.properties || {}
-                            );
-                        } else if (config.url) {
-                            // PostgREST mode (default)
-                            const inValues = uniqueValues.join(',');
-                            let queryUrl = `${config.url}?${matchingField}=in.(${inValues})`;
-                            if (config.sortBy) {
-                                const dir = config.sortDirection === 'desc' ? 'desc' : 'asc';
-                                queryUrl += `&order=${config.sortBy}.${dir}`;
-                            }
-
-                            const response = await fetch(queryUrl, {
-                                headers: config.headers,
-                            });
-
-                            if (!response.ok) {
-                                console.error(`[useBulkRelatedTable] fetch failed: ${response.status}`);
-                                return new Map();
-                            }
-
-                            const data = await response.json();
-                            rows = Array.isArray(data) ? data : [data];
-                        } else {
-                            return new Map();
-                        }
-
-                        // Build a map: matchingField value -> array of rows
-                        // (supports multiple matches like formation tops per well)
-                        const map = new Map<string, PostgRESTRow[]>();
-                        for (const row of rows) {
-                            const key = String(row[matchingField] ?? '');
-                            if (key) {
-                                const existing = map.get(key) || [];
-                                existing.push(row);
-                                map.set(key, existing);
-                            }
-                        }
-
-                        return map;
+                        const rows = await fetchRelatedRows(config, uniqueValues);
+                        // Map: matchingField value -> array of rows (supports multiple
+                        // matches like formation tops per well).
+                        return groupRelatedRows(rows, matchingField);
                     } catch (err) {
                         console.error(`Error fetching bulk related table:`, err);
                         return new Map();

--- a/src/hooks/use-custom-layerlist.tsx
+++ b/src/hooks/use-custom-layerlist.tsx
@@ -145,6 +145,15 @@ const LayerAccordionItem = ({ layerConfig, isTopLevel, parentGroupTitle, disable
 
     const { refetch: fetchExtent, data: cachedExtent } = useLayerExtent(extentOptions);
 
+    // Related tables live on sublayer popup config (WMS/PMTiles). Flattened
+    // across sublayers so the download menu can bundle them all in one zip.
+    const relatedTables = useMemo(() => {
+        if (isWMSLayer(layerConfig) || isPMTilesLayer(layerConfig)) {
+            return layerConfig.sublayers?.flatMap(sub => sub.relatedTables ?? []) ?? [];
+        }
+        return [];
+    }, [layerConfig]);
+
     const currentZoom = useMapZoom();
     const visibleZoomRange = layerConfig.visibleZoomRange ?? null;
     const zoomHint = isSelected ? getZoomHint(currentZoom, visibleZoomRange) : null;
@@ -351,6 +360,7 @@ const LayerAccordionItem = ({ layerConfig, isTopLevel, parentGroupTitle, disable
                             arcgisUrl={extentOptions.type === 'arcgis' ? extentOptions.mapServerUrl : undefined}
                             legendUnit={isWMSLayer(layerConfig) ? layerConfig.legendUnit : undefined}
                             downloadParquetUrl={layerConfig.downloadParquetUrl}
+                            relatedTables={relatedTables}
                             disableExport={disableExport}
                             filtersContent={layerConfig.title ? layerExtrasRender?.(layerConfig.title) : undefined}
                             statsContent={layerConfig.title ? layerStatsRender?.(layerConfig.title) : undefined}

--- a/src/lib/duckdb-export.ts
+++ b/src/lib/duckdb-export.ts
@@ -12,7 +12,10 @@
 
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { EXPORT_FORMATS, type ExportFormat } from '@/lib/export-formats';
-import { withConnection, loadSpatial, escapeSql } from '@/lib/duckdb/client';
+import { withConnection, loadSpatial, escapeSql, queryParquetDistinctValues } from '@/lib/duckdb/client';
+import { downloadZip } from '@/lib/download-utils';
+import { fetchRelatedRowsBulk, relatedRowsToCsv } from '@/lib/related-table-fetch';
+import type { RelatedTable } from '@/lib/types/mapping-types';
 
 export type { ExportFormat } from '@/lib/export-formats';
 export { safeFilename } from '@/lib/export-formats';
@@ -29,6 +32,9 @@ export interface ExportOptions {
     format: ExportFormat;
     /** Geometry column name if present, else null — discovered via useParquetSchema */
     geometryColumn: string | null;
+    /** Related tables configured on the layer (formation tops, geochemistry, etc). When
+     * present + non-empty, `exportParquet` bundles them alongside the main file as a zip. */
+    relatedTables?: RelatedTable[];
     onProgress?: (stage: ExportStage) => void;
 }
 
@@ -133,14 +139,89 @@ const jsonReplacer = (_key: string, value: unknown) => {
         : String(value);
 };
 
+// Sanitize a related table's fieldLabel into a safe zip entry name.
+const safeEntryName = (s: string): string =>
+    s.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').toLowerCase() || 'related';
+
+// Unique `related-<name>.csv` stem per table, resolved synchronously up front so
+// two tables with the same (or empty) fieldLabel don't collide to one zip entry.
+// Deterministic and race-free — computed before the concurrent fetch below.
+const uniqueEntryNames = (relatedTables: RelatedTable[]): string[] => {
+    const used = new Set<string>();
+    return relatedTables.map((t, idx) => {
+        const base = safeEntryName(t.fieldLabel || `table-${idx + 1}`);
+        let name = base;
+        for (let n = 2; used.has(name); n++) name = `${base}-${n}`;
+        used.add(name);
+        return name;
+    });
+};
+
+/**
+ * Fetch every configured related table for the full layer (not just visible
+ * features).
+ *
+ * - parquet related assets are read whole (already scoped to the STAC item), so
+ *   we skip the distinct-key scan entirely — reading the main parquet's join
+ *   column just to feed a filter we don't use would be pure waste.
+ * - postgrest/wfs tables may be shared across datasets, so we pull the layer's
+ *   distinct join keys (once, for that table's targetField) and chunk-filter.
+ *
+ * Each table is isolated: one that errors (bad URL, CORS, server cap) is logged
+ * and skipped so the main file and the other related tables still download.
+ */
+const buildRelatedCsvFiles = async (
+    parquetUrl: string,
+    relatedTables: RelatedTable[],
+): Promise<Record<string, string>> => {
+    const files: Record<string, string> = {};
+    const entryNames = uniqueEntryNames(relatedTables);
+    await Promise.all(relatedTables.map(async (table, idx) => {
+        if (!table.matchingField) return;
+        try {
+            let values: string[] = [];
+            if (table.fetchMode !== 'parquet') {
+                if (!table.targetField) return; // STAC-backed entry not yet resolved
+                values = await queryParquetDistinctValues({ url: parquetUrl, field: table.targetField });
+                if (values.length === 0) return;
+            }
+            const rows = await fetchRelatedRowsBulk(table, values);
+            if (rows.length === 0) return;
+            files[`related-${entryNames[idx]}.csv`] = relatedRowsToCsv(rows, table);
+        } catch (err) {
+            console.error(`[exportParquet] related table '${table.fieldLabel ?? idx}' failed, skipping:`, err);
+        }
+    }));
+    return files;
+};
+
 // ── Public entrypoint ────────────────────────────────────────────────────────
 
 export const exportParquet = async (opts: ExportOptions): Promise<void> => {
     const meta = EXPORT_FORMATS[opts.format];
     try {
         const blob = await handlers[opts.format](opts);
-        opts.onProgress?.({ stage: 'writing', message: 'Saving file…' });
-        triggerDownload(blob, `${opts.filename}.${meta.extension}`);
+        const relatedTables = opts.relatedTables ?? [];
+
+        if (relatedTables.length === 0) {
+            opts.onProgress?.({ stage: 'writing', message: 'Saving file…' });
+            triggerDownload(blob, `${opts.filename}.${meta.extension}`);
+            opts.onProgress?.({ stage: 'complete', message: 'Done' });
+            return;
+        }
+
+        opts.onProgress?.({ stage: 'converting', message: 'Fetching related tables…' });
+        const relatedFiles = await buildRelatedCsvFiles(opts.parquetUrl, relatedTables);
+
+        opts.onProgress?.({ stage: 'writing', message: 'Saving files…' });
+        if (Object.keys(relatedFiles).length === 0) {
+            // No related rows matched — fall back to a single-file download rather
+            // than a zip with only the main file.
+            triggerDownload(blob, `${opts.filename}.${meta.extension}`);
+        } else {
+            const mainBytes = new Uint8Array(await blob.arrayBuffer());
+            downloadZip({ [`${opts.filename}.${meta.extension}`]: mainBytes, ...relatedFiles }, opts.filename);
+        }
         opts.onProgress?.({ stage: 'complete', message: 'Done' });
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/lib/duckdb/client.ts
+++ b/src/lib/duckdb/client.ts
@@ -120,3 +120,49 @@ export const queryParquetByValues = async (
         return result.toArray().map(r => normalizeRow(r.toJSON() as Record<string, unknown>));
     });
 };
+
+export interface ParquetAllOptions {
+    /** Remote .parquet URL (read over httpfs). */
+    url: string;
+    sortBy?: string;
+    sortDirection?: 'asc' | 'desc';
+}
+
+/**
+ * Read an entire remote geoparquet. Used by the layerlist "download whole layer +
+ * related tables" path, where every row is wanted anyway — avoids building a giant
+ * value-filtered query (which blows past URL limits for postgrest joins).
+ */
+export const queryParquetAll = async (
+    { url, sortBy, sortDirection }: ParquetAllOptions,
+): Promise<PostgRESTRow[]> => {
+    return withConnection(async (conn) => {
+        const order = sortBy
+            ? ` ORDER BY ${quoteIdent(sortBy)} ${sortDirection === 'desc' ? 'DESC' : 'ASC'}`
+            : '';
+        const result = await conn.query(
+            `SELECT * FROM read_parquet('${escapeSql(url)}')${order}`,
+        );
+        return result.toArray().map(r => normalizeRow(r.toJSON() as Record<string, unknown>));
+    });
+};
+
+/**
+ * Read the distinct non-null values of one column from a remote geoparquet.
+ * Used to seed a bulk related-table fetch (matchingField IN (...)) for a
+ * whole-layer download, where there's no already-loaded feature set to draw
+ * join keys from.
+ */
+export const queryParquetDistinctValues = async (
+    { url, field }: { url: string; field: string },
+): Promise<string[]> => {
+    return withConnection(async (conn) => {
+        const result = await conn.query(
+            `SELECT DISTINCT CAST(${quoteIdent(field)} AS VARCHAR) AS v FROM read_parquet('${escapeSql(url)}') WHERE ${quoteIdent(field)} IS NOT NULL`,
+        );
+        return result.toArray()
+            .map(r => (r.toJSON() as { v: unknown }).v)
+            .filter((v): v is string => v != null)
+            .map(String);
+    });
+};

--- a/src/lib/related-table-fetch.ts
+++ b/src/lib/related-table-fetch.ts
@@ -1,0 +1,162 @@
+/**
+ * Shared related-table fetch logic — used by the popup/table-view bulk fetch
+ * (`useBulkRelatedTable`) AND the layerlist's bulk "download related table"
+ * export, so the postgrest/wfs/parquet dispatch lives in exactly one place.
+ */
+
+import { isValidElement } from 'react';
+import type { RelatedTable, DisplayField } from '@/lib/types/mapping-types';
+import type { PostgRESTRow } from '@/lib/types/postgrest-types';
+import { buildCSV } from '@/lib/download-utils';
+import { formatNumeric } from '@/lib/utils';
+
+/**
+ * Fetch every related row whose `matchingField` is in `values`, dispatching on
+ * `fetchMode` (postgrest default, wfs, or STAC geoparquet via duckdb-wasm).
+ */
+export async function fetchRelatedRows(config: RelatedTable, values: string[]): Promise<PostgRESTRow[]> {
+    const matchingField = config.matchingField;
+    const uniqueValues = [...new Set(values.filter(Boolean))];
+    if (!matchingField || uniqueValues.length === 0) return [];
+
+    if (config.fetchMode === 'parquet' && config.url) {
+        // Lazy import keeps duckdb off the initial bundle.
+        const { queryParquetByValues } = await import('@/lib/duckdb/client');
+        return queryParquetByValues({
+            url: config.url,
+            matchingField,
+            values: uniqueValues,
+            sortBy: config.sortBy,
+            sortDirection: config.sortDirection,
+        });
+    }
+
+    if (config.fetchMode === 'wfs' && config.wfsTypeName && config.url) {
+        const inValues = uniqueValues.map(v => `'${v}'`).join(',');
+        const cqlFilter = `${matchingField} IN (${inValues})`;
+        const wfsUrl = new URL(config.url);
+        wfsUrl.searchParams.set('service', 'WFS');
+        wfsUrl.searchParams.set('version', '1.1.0');
+        wfsUrl.searchParams.set('request', 'GetFeature');
+        wfsUrl.searchParams.set('typeName', config.wfsTypeName);
+        wfsUrl.searchParams.set('outputFormat', 'application/json');
+        wfsUrl.searchParams.set('CQL_FILTER', cqlFilter);
+        if (config.sortBy) {
+            const dir = config.sortDirection === 'desc' ? ' D' : ' A';
+            wfsUrl.searchParams.set('sortBy', `${config.sortBy}${dir}`);
+        }
+
+        const response = await fetch(wfsUrl.toString());
+        if (!response.ok) {
+            console.error(`[fetchRelatedRows] WFS fetch failed: ${response.status}`);
+            return [];
+        }
+        const geojson = await response.json();
+        return (geojson.features || []).map((f: { properties?: PostgRESTRow }) => f.properties || {});
+    }
+
+    if (config.url) {
+        const inValues = uniqueValues.join(',');
+        let queryUrl = `${config.url}?${matchingField}=in.(${inValues})`;
+        if (config.sortBy) {
+            const dir = config.sortDirection === 'desc' ? 'desc' : 'asc';
+            queryUrl += `&order=${config.sortBy}.${dir}`;
+        }
+
+        const response = await fetch(queryUrl, { headers: config.headers });
+        if (!response.ok) {
+            console.error(`[fetchRelatedRows] fetch failed: ${response.status}`);
+            return [];
+        }
+        const data = await response.json();
+        return Array.isArray(data) ? data : [data];
+    }
+
+    return [];
+}
+
+/** Max join keys per postgrest/wfs request — keeps the `in.(…)`/CQL URL under
+ *  server request-line limits. A whole-layer export can have thousands of keys. */
+const RELATED_FETCH_CHUNK = 300;
+
+/**
+ * Bulk-fetch related rows for a whole-layer export, dispatching on `fetchMode`.
+ *
+ * - parquet: read the entire related asset in one shot — it's already scoped to
+ *   the STAC item, so every row belongs to this layer (no per-key filtering, no
+ *   URL to overflow).
+ * - postgrest/wfs: the table may be shared across datasets and the server caps
+ *   unfiltered responses, so we KEEP the join-key filter but split it into
+ *   chunks. One giant `in.(…thousands…)` URL is what triggers net::ERR_FAILED.
+ */
+export async function fetchRelatedRowsBulk(config: RelatedTable, values: string[]): Promise<PostgRESTRow[]> {
+    if (config.fetchMode === 'parquet' && config.url) {
+        // Lazy import keeps duckdb off the initial bundle.
+        const { queryParquetAll } = await import('@/lib/duckdb/client');
+        return queryParquetAll({
+            url: config.url,
+            sortBy: config.sortBy,
+            sortDirection: config.sortDirection,
+        });
+    }
+
+    const unique = [...new Set(values.filter(Boolean))];
+    if (!config.matchingField || unique.length === 0) return [];
+
+    const out: PostgRESTRow[] = [];
+    for (let i = 0; i < unique.length; i += RELATED_FETCH_CHUNK) {
+        out.push(...await fetchRelatedRows(config, unique.slice(i, i + RELATED_FETCH_CHUNK)));
+    }
+    return out;
+}
+
+/** Group rows by `matchingField` value — mirrors the PostgREST join semantics used by popups. */
+export function groupRelatedRows(rows: PostgRESTRow[], matchingField: string): Map<string, PostgRESTRow[]> {
+    const map = new Map<string, PostgRESTRow[]>();
+    for (const row of rows) {
+        const key = String(row[matchingField] ?? '');
+        if (!key) continue;
+        const existing = map.get(key) || [];
+        existing.push(row);
+        map.set(key, existing);
+    }
+    return map;
+}
+
+function formatDisplayValue(row: PostgRESTRow, df: DisplayField): unknown {
+    const formatted = formatNumeric(row[df.field], df.format);
+    if (!df.transform) return formatted;
+    const result = df.transform(formatted);
+    if (isValidElement(result)) {
+        const props = result.props as { to?: string; href?: string };
+        return props.to || props.href || formatted;
+    }
+    return result;
+}
+
+/**
+ * Flatten fetched related rows to a CSV string. Uses `displayFields` (label
+ * order) when configured, else dumps every raw column from the first row.
+ */
+export function relatedRowsToCsv(rows: PostgRESTRow[], table: RelatedTable): string {
+    const displayFields = table.displayFields || [];
+    if (displayFields.length === 0) {
+        const headers = Object.keys(rows[0] || {});
+        return buildCSV(rows, headers, (row, header) => row[header] ?? '');
+    }
+
+    // Prepend the join key so bulk-exported related rows can be tied back to the
+    // main features. displayFields are presentation-oriented and often omit it
+    // (e.g. Core Boxes lists box/formation but not uwi).
+    const joinKey = table.matchingField;
+    const includeJoinKey = !!joinKey && !displayFields.some(df => df.field === joinKey);
+    const headers = [
+        ...(includeJoinKey ? [joinKey] : []),
+        ...displayFields.map(df => df.label || df.field),
+    ];
+    return buildCSV(rows, headers, (row, header) => {
+        if (includeJoinKey && header === joinKey) return row[joinKey] ?? '';
+        const df = displayFields.find(d => (d.label || d.field) === header);
+        return df ? formatDisplayValue(row, df) : '';
+    });
+}


### PR DESCRIPTION
- Layerlist Download menu (`ParquetDownloadMenu`) had no related-table option, unlike the attribute table view's export dropdown
- Extracted the popup/table-view's related-table fetch dispatch (postgrest/wfs/parquet) into a shared `src/lib/related-table-fetch.ts` so both paths stay in sync
- Added `queryParquetDistinctValues` to pull join-key values off the full parquet (layerlist has no loaded feature set to draw keys from, unlike the table view)
- `exportParquet` now bundles related-table CSVs into a zip alongside the main export when configured
- Wired `relatedTables` from sublayer config through `use-custom-layerlist.tsx` → `LayerControls` → `ParquetDownloadMenu`
- Adds an "Include related data" checkbox to the download menu, matching the table view's UX

Fixes the CCUS "Wells with Rock Property Data" case reported by Ryan Gall; applies to any layer with related tables configured.