### PR TITLE
fix(hazards): rename PostgREST endpoint to hazards_unitdescriptions_current

### DIFF
--- a/src/routes/_map/hazards-review/-data/layers/layers.tsx
+++ b/src/routes/_map/hazards-review/-data/layers/layers.tsx
@@ -66,7 +66,7 @@ const landslideInventoryWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -106,7 +106,7 @@ const landslideSusceptibilityWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -145,7 +145,7 @@ const liquefactionWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lqshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -271,7 +271,7 @@ const surfaceFaultRuptureWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sfrhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -307,7 +307,7 @@ const windBlownSandWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'wsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -345,7 +345,7 @@ const saltTectonicsDeformationWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sdhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -383,7 +383,7 @@ const shallowBedrockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sbphazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -421,7 +421,7 @@ const rockfallHazardWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'rfhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -459,7 +459,7 @@ const pipingAndErosionWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'peshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -497,7 +497,7 @@ const expansiveSoilRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'exshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -536,7 +536,7 @@ const shallowGroundwaterWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sgshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -574,7 +574,7 @@ const radonSusceptibilityWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'grshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -612,7 +612,7 @@ const corrosiveSoilRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'crshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -650,7 +650,7 @@ const collapsibleSoilWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'csshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -688,7 +688,7 @@ const solubleSoilAndRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'slshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -726,7 +726,7 @@ const alluvialFanWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'aafhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -763,7 +763,7 @@ const floodAndDebrisWMSConfig: WMSLayerProps = {
                     fieldLabel: 'hazard_symbology_text',
                     matchingField: 'Relate_ID',
                     targetField: 'flhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -797,7 +797,7 @@ const earthFissureWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'efhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -835,7 +835,7 @@ const erosionHazardZoneWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'erzhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -872,7 +872,7 @@ const karstFeaturesWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'mkfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",

--- a/src/routes/_map/hazards-review/-data/layers/review-layers.tsx
+++ b/src/routes/_map/hazards-review/-data/layers/review-layers.tsx
@@ -68,7 +68,7 @@ const landslideInventoryWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -106,7 +106,7 @@ const landslideSusceptibilityWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -143,7 +143,7 @@ const liquefactionWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lqshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -256,7 +256,7 @@ const surfaceFaultRuptureWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sfrhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -290,7 +290,7 @@ const windBlownSandWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'wsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -326,7 +326,7 @@ const saltTectonicsDeformationWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sdhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -362,7 +362,7 @@ const shallowBedrockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sbphazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -398,7 +398,7 @@ const rockfallHazardWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'rfhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -434,7 +434,7 @@ const pipingAndErosionWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'peshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -470,7 +470,7 @@ const expansiveSoilRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'exshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -506,7 +506,7 @@ const shallowGroundwaterWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sgshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -542,7 +542,7 @@ const radonSusceptibilityWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'grshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -578,7 +578,7 @@ const corrosiveSoilRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'crshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -614,7 +614,7 @@ const collapsibleSoilWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'csshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -650,7 +650,7 @@ const solubleSoilAndRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'slshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -686,7 +686,7 @@ const alluvialFanWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'aafhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -722,7 +722,7 @@ const floodAndDebrisWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'flhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -757,7 +757,7 @@ const earthFissureWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'efhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -793,7 +793,7 @@ const erosionHazardZoneWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'erzhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -828,7 +828,7 @@ const karstFeaturesWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'mkfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",

--- a/src/routes/_map/hazards/-data/layers/layers-pmtiles.tsx
+++ b/src/routes/_map/hazards/-data/layers/layers-pmtiles.tsx
@@ -70,7 +70,7 @@ const landslideInventoryConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -109,7 +109,7 @@ const landslideSusceptibilityConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -147,7 +147,7 @@ const liquefactionConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lqshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -286,7 +286,7 @@ const surfaceFaultRuptureConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sfrhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -321,7 +321,7 @@ const windBlownSandConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'wsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -358,7 +358,7 @@ const saltTectonicsDeformationConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sdhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -395,7 +395,7 @@ const shallowBedrockConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sbphazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -432,7 +432,7 @@ const rockfallHazardConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'rfhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -469,7 +469,7 @@ const pipingAndErosionConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'peshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -506,7 +506,7 @@ const expansiveSoilRockConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'exshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -543,7 +543,7 @@ const shallowGroundwaterConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sgshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -580,7 +580,7 @@ const radonSusceptibilityConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'grshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -617,7 +617,7 @@ const corrosiveSoilRockConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'crshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -654,7 +654,7 @@ const collapsibleSoilConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'csshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -691,7 +691,7 @@ const solubleSoilAndRockConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'slshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -728,7 +728,7 @@ const alluvialFanConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'aafhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -765,7 +765,7 @@ const floodAndDebrisConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'flhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -801,7 +801,7 @@ const earthFissureConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'efhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -838,7 +838,7 @@ const erosionHazardZoneConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'erzhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -874,7 +874,7 @@ const karstFeaturesConfig: PMTilesLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'mkfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",

--- a/src/routes/_map/hazards/-data/layers/layers.tsx
+++ b/src/routes/_map/hazards/-data/layers/layers.tsx
@@ -69,7 +69,7 @@ const landslideInventoryWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -110,7 +110,7 @@ const landslideSusceptibilityWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -150,7 +150,7 @@ const liquefactionWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'lqshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -300,7 +300,7 @@ const surfaceFaultRuptureWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sfrhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -337,7 +337,7 @@ const windBlownSandWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'wsshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -376,7 +376,7 @@ const saltTectonicsDeformationWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sdhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -415,7 +415,7 @@ const shallowBedrockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sbphazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -454,7 +454,7 @@ const rockfallHazardWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'rfhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -493,7 +493,7 @@ const pipingAndErosionWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'peshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -532,7 +532,7 @@ const expansiveSoilRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'exshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -572,7 +572,7 @@ const shallowGroundwaterWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'sgshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -611,7 +611,7 @@ const radonSusceptibilityWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'grshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -650,7 +650,7 @@ const corrosiveSoilRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'crshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -689,7 +689,7 @@ const collapsibleSoilWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'csshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -728,7 +728,7 @@ const solubleSoilAndRockWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'slshazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -767,7 +767,7 @@ const alluvialFanWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'aafhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -806,7 +806,7 @@ const floodAndDebrisWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'flhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -844,7 +844,7 @@ const earthFissureWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'efhhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -883,7 +883,7 @@ const erosionHazardZoneWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'erzhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",
@@ -921,7 +921,7 @@ const karstFeaturesWMSConfig: WMSLayerProps = {
                     fieldLabel: '',
                     matchingField: 'relate_id',
                     targetField: 'mkfhazardunit',
-                    url: `${PROD_POSTGREST_URL}/unitdescriptions_current`,
+                    url: `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current`,
                     headers: {
                         "Accept-Profile": 'hazards',
                         "Accept": "application/json",

--- a/src/routes/_map/hazards/__tests__/layer-config-consistency.test.ts
+++ b/src/routes/_map/hazards/__tests__/layer-config-consistency.test.ts
@@ -197,7 +197,7 @@ describe('hazard layer config ↔ report data consistency', () => {
       const codes = Object.keys(hazardLayerNameMap)
       const filter = codes.map(c => `hazardcode.eq.${c}`).join(',')
       const res = await fetch(
-        `${PROD_POSTGREST_URL}/unitdescriptions_current?or=(${filter})&select=hazardcode,hazardname`,
+        `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current?or=(${filter})&select=hazardcode,hazardname`,
         { headers: { 'Accept-Profile': 'hazards', 'Accept': 'application/json' } }
       )
       const rows: { hazardcode: string; hazardname: string }[] = await res.json()

--- a/src/routes/_report/-utils/static-hazards-service.ts
+++ b/src/routes/_report/-utils/static-hazards-service.ts
@@ -43,7 +43,7 @@ export interface HazardTextSections {
 }
 
 /**
- * Type for PostgREST unitdescriptions_current table response rows
+ * Type for PostgREST hazards_unitdescriptions_current table response rows
  */
 type HazardUnitRow = PostgRESTRowOf<{
     relate_id: string;
@@ -87,7 +87,7 @@ export async function queryAllUnitsForHazardCodes(hazardCodes: string[]): Promis
         // Query using hazardcode field with exact match
         // This will get ALL units for each hazard code, not just ones in the polygon
         const filter = hazardCodes.map(code => `hazardcode.eq.${code}`).join(',');
-        const url = `${PROD_POSTGREST_URL}/unitdescriptions_current?or=(${filter})`;
+        const url = `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current?or=(${filter})`;
 
         const response = await fetch(url, {
             headers: {
@@ -130,7 +130,7 @@ export async function queryHazardUnitsStatic(units: string[]): Promise<HazardUni
 
     try {
         const filter = `relate_id=in.(${units.join(',')})`;
-        const url = `${PROD_POSTGREST_URL}/unitdescriptions_current?${filter}`;
+        const url = `${PROD_POSTGREST_URL}/hazards_unitdescriptions_current?${filter}`;
 
         const response = await fetch(url, {
             headers: {


### PR DESCRIPTION
## What

Renames the PostgREST endpoint `unitdescriptions_current` to `hazards_unitdescriptions_current` across all hazards layer sources and the static report service (84 occurrences in 6 files).

## Why

Updating the `unitdescriptions_current` datatopic unexpectedly dropped the `unitdescriptions_current` matview and replaced it with the `hazards_unitdescriptions_current` table. The old endpoint no longer resolves, so hazard unit-description lookups (map popups/related tables and static report generation) break against production PostgREST.

## Changes

- `src/routes/_map/hazards/-data/layers/layers.tsx`, `layers-pmtiles.tsx`
- `src/routes/_map/hazards-review/-data/layers/layers.tsx`, `review-layers.tsx`
- `src/routes/_report/-utils/static-hazards-service.ts` (URLs + doc comment)
- `src/routes/_map/hazards/__tests__/layer-config-consistency.test.ts` (expected URL kept in sync)

Pure string-literal replacement; no type or logic changes. The consistency test was updated in lockstep so it continues to assert the correct endpoint.