### PR TITLE
feat(data-reviewer): review comments synced with warehouse, keyed on stable pk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Map implementation: 'arcgis' (default) or 'maplibre'
 VITE_MAP_IMPL=arcgis
+
+# Review comments API (warehouse review-api Cloud Run twin, Firebase-token auth). Unset = panel hidden.
+VITE_REVIEW_API_URL=

--- a/firebase.json
+++ b/firebase.json
@@ -10,13 +10,6 @@
       ],
       "rewrites": [
         {
-          "source": "/api/**",
-          "run": {
-            "serviceId": "ugs-warehouse-review-api",
-            "region": "us-central1"
-          }
-        },
-        {
           "source": "**",
           "destination": "/index.html"
         }

--- a/firebase.json
+++ b/firebase.json
@@ -10,6 +10,13 @@
       ],
       "rewrites": [
         {
+          "source": "/api/**",
+          "run": {
+            "serviceId": "ugs-warehouse-review-api",
+            "region": "us-central1"
+          }
+        },
+        {
           "source": "**",
           "destination": "/index.html"
         }

--- a/src/components/review/review-comments.tsx
+++ b/src/components/review/review-comments.tsx
@@ -12,7 +12,6 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
   type Comment,
-  REVIEW_API_URL,
   createComment,
   deleteComment,
   listComments,
@@ -33,7 +32,9 @@ export function ReviewComments({ itemId, label = 'Review comments' }: { itemId: 
   const { user } = useAuth();
   const myEmail = user?.email ?? undefined;
   const key = ['review-comments', itemId] as const;
-  const enabled = !!REVIEW_API_URL && !!user;
+  // Same-origin by default (empty REVIEW_API_URL + the firebase.json `/api/**` rewrite → review-api),
+  // so we gate on the signed-in user, not on a base URL. No backend → the fetch errors → panel hides.
+  const enabled = !!user;
 
   const { data: comments = [], isLoading, error } = useQuery({
     queryKey: key,
@@ -93,8 +94,9 @@ export function ReviewComments({ itemId, label = 'Review comments' }: { itemId: 
   const repliesByRoot = new Map<number, Comment[]>();
   for (const c of comments) if (c.parent_id != null) (repliesByRoot.get(c.parent_id) ?? repliesByRoot.set(c.parent_id, []).get(c.parent_id)!).push(c);
 
-  // No API configured, or the public build without it → render nothing.
-  const notConfigured = !REVIEW_API_URL || (error && /\b(401|403|503)\b|Failed to fetch|Unexpected token/i.test(String(error)));
+  // No backend reachable (public build without the rewrite → /api/* returns the SPA HTML → parse
+  // error; or 401/403/503) → render nothing.
+  const notConfigured = error && /\b(401|403|503)\b|Failed to fetch|Unexpected token|not valid JSON/i.test(String(error));
   if (notConfigured) return null;
 
   return (

--- a/src/components/review/review-comments.tsx
+++ b/src/components/review/review-comments.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
   type Comment,
+  REVIEW_API_URL,
   createComment,
   deleteComment,
   listComments,
@@ -32,9 +33,9 @@ export function ReviewComments({ itemId, label = 'Review comments' }: { itemId: 
   const { user } = useAuth();
   const myEmail = user?.email ?? undefined;
   const key = ['review-comments', itemId] as const;
-  // Same-origin by default (empty REVIEW_API_URL + the firebase.json `/api/**` rewrite → review-api),
-  // so we gate on the signed-in user, not on a base URL. No backend → the fetch errors → panel hides.
-  const enabled = !!user;
+  // Need both a signed-in user (for the Firebase token) and the gateway URL (VITE_REVIEW_API_URL).
+  // Unset URL or no backend → the fetch errors → the panel hides.
+  const enabled = !!REVIEW_API_URL && !!user;
 
   const { data: comments = [], isLoading, error } = useQuery({
     queryKey: key,

--- a/src/components/review/review-comments.tsx
+++ b/src/components/review/review-comments.tsx
@@ -1,0 +1,188 @@
+/**
+ * Review comments panel for the hazards-review app. Reads/writes the SAME warehouse review.* tables as
+ * the internal review viewer (via the non-IAP review-api, Firebase-token auth), so threads sync across
+ * both. `itemId` is the hazard layer id the comments hang off. Renders nothing until the API is
+ * configured (VITE_REVIEW_API_URL) and the user is signed in.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRef, useState } from 'react';
+import { useAuth } from '@/context/auth-provider';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  type Comment,
+  REVIEW_API_URL,
+  createComment,
+  deleteComment,
+  listComments,
+  listReviewers,
+  replyToComment,
+  setStatus,
+} from '@/lib/review-api';
+
+// The active "@token" just left of the caret (the fragment being typed), or null.
+function mentionAt(text: string, caret: number): { at: number; query: string } | null {
+  const m = /(?:^|\s)@(\S*)$/.exec(text.slice(0, caret));
+  if (!m) return null;
+  return { at: caret - m[1].length - 1, query: m[1] };
+}
+
+export function ReviewComments({ itemId, label = 'Review comments' }: { itemId: string; label?: string }) {
+  const qc = useQueryClient();
+  const { user } = useAuth();
+  const myEmail = user?.email ?? undefined;
+  const key = ['review-comments', itemId] as const;
+  const enabled = !!REVIEW_API_URL && !!user;
+
+  const { data: comments = [], isLoading, error } = useQuery({
+    queryKey: key,
+    queryFn: () => listComments(itemId),
+    retry: false,
+    enabled,
+  });
+  const invalidate = () => qc.invalidateQueries({ queryKey: key });
+
+  const [body, setBody] = useState('');
+  const reviewers = useQuery({ queryKey: ['review-reviewers'], queryFn: listReviewers, retry: false, enabled, staleTime: 5 * 60_000 });
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const [mentions, setMentions] = useState<string[]>([]);
+  const [mentionIdx, setMentionIdx] = useState(0);
+
+  const add = useMutation({
+    mutationFn: () => createComment([itemId], body),
+    onSuccess: (created) => {
+      setBody('');
+      qc.setQueryData<Comment[]>(key, (old = []) => [created, ...old]);
+      invalidate();
+    },
+  });
+  const toggle = useMutation({ mutationFn: (c: Comment) => setStatus(c.id, c.status === 'resolved' ? 'open' : 'resolved'), onSuccess: invalidate });
+  const remove = useMutation({ mutationFn: (id: number) => deleteComment(id), onSuccess: invalidate });
+  const reply = useMutation({ mutationFn: (v: { parentId: number; body: string }) => replyToComment(v.parentId, v.body), onSuccess: invalidate });
+
+  const onBodyChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const v = e.target.value;
+    setBody(v);
+    const tok = mentionAt(v, e.target.selectionStart ?? v.length);
+    if (!tok || !reviewers.data?.length) return setMentions([]);
+    const q = tok.query.toLowerCase();
+    setMentions(reviewers.data.filter((r) => r.toLowerCase().includes(q)).slice(0, 6));
+    setMentionIdx(0);
+  };
+  const pickMention = (email: string) => {
+    const ta = taRef.current;
+    const caret = ta?.selectionStart ?? body.length;
+    const tok = mentionAt(body, caret);
+    if (!tok) return;
+    const local = email.split('@')[0];
+    setBody(`${body.slice(0, tok.at)}@${local} ${body.slice(caret)}`);
+    setMentions([]);
+    const pos = tok.at + local.length + 2;
+    requestAnimationFrame(() => { ta?.focus(); ta?.setSelectionRange(pos, pos); });
+  };
+  const onBodyKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (mentions.length === 0) return;
+    if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIdx((i) => (i + 1) % mentions.length); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); setMentionIdx((i) => (i - 1 + mentions.length) % mentions.length); }
+    else if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); pickMention(mentions[mentionIdx]); }
+    else if (e.key === 'Escape') { e.preventDefault(); setMentions([]); }
+  };
+
+  const roots = comments.filter((c) => c.parent_id == null);
+  const repliesByRoot = new Map<number, Comment[]>();
+  for (const c of comments) if (c.parent_id != null) (repliesByRoot.get(c.parent_id) ?? repliesByRoot.set(c.parent_id, []).get(c.parent_id)!).push(c);
+
+  // No API configured, or the public build without it → render nothing.
+  const notConfigured = !REVIEW_API_URL || (error && /\b(401|403|503)\b|Failed to fetch|Unexpected token/i.test(String(error)));
+  if (notConfigured) return null;
+
+  return (
+    <div className="rounded-md border bg-card/50 p-2 text-xs">
+      <div className="mb-1.5 font-medium">{label}{comments.length ? ` (${comments.length})` : ''}</div>
+
+      {isLoading && <p className="text-muted-foreground">Loading…</p>}
+      {!isLoading && !error && roots.length === 0 && <p className="text-muted-foreground">No comments yet.</p>}
+
+      <ul className="space-y-1.5">
+        {roots.map((root) => (
+          <li key={root.id} className="rounded border bg-background p-1.5">
+            <CommentRow c={root} myEmail={myEmail}
+              onToggle={() => toggle.mutate(root)} onDelete={() => remove.mutate(root.id)} />
+            {(repliesByRoot.get(root.id) ?? []).map((r) => (
+              <div key={r.id} className="mt-1.5 border-l-2 pl-2">
+                <CommentRow c={r} myEmail={myEmail} onDelete={() => remove.mutate(r.id)} />
+              </div>
+            ))}
+            <ReplyBox onReply={(text) => reply.mutate({ parentId: root.id, body: text })} pending={reply.isPending} />
+          </li>
+        ))}
+      </ul>
+
+      <div className="relative mt-2 flex gap-1.5">
+        {mentions.length > 0 && (
+          <ul className="absolute bottom-full left-0 z-10 mb-1 max-h-40 w-56 overflow-auto rounded border bg-card shadow">
+            {mentions.map((email, i) => (
+              <li key={email}>
+                <button type="button" onMouseDown={(e) => { e.preventDefault(); pickMention(email); }}
+                  onMouseEnter={() => setMentionIdx(i)}
+                  className={`block w-full px-2 py-1 text-left ${i === mentionIdx ? 'bg-muted' : ''}`}>
+                  <span className="font-medium text-foreground">@{email.split('@')[0]}</span>
+                  <span className="ml-1 text-[10px] text-muted-foreground">{email}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <Textarea ref={taRef} value={body} onChange={onBodyChange} onKeyDown={onBodyKeyDown} rows={2}
+          onBlur={() => setMentions([])} placeholder="Add a review note… (@ to mention)" className="flex-1 text-xs" />
+        <Button size="sm" disabled={!body.trim() || add.isPending} onClick={() => add.mutate()} className="self-end">
+          {add.isPending ? '…' : 'Add'}
+        </Button>
+      </div>
+      {add.error && <p className="mt-1 text-destructive">Failed to add: {String(add.error)}</p>}
+    </div>
+  );
+}
+
+function renderBody(text: string) {
+  return text.split(/(?<!\S)(@[A-Za-z0-9][A-Za-z0-9._%+-]*)/g).map((part, i) =>
+    /^@[A-Za-z0-9]/.test(part)
+      ? <span key={i} className="rounded bg-primary/10 px-0.5 font-medium text-primary">{part}</span>
+      : part,
+  );
+}
+
+function CommentRow({ c, myEmail, onToggle, onDelete }: {
+  c: Comment; myEmail?: string; onToggle?: () => void; onDelete: () => void;
+}) {
+  return (
+    <>
+      <div className="flex flex-wrap items-baseline gap-2">
+        <span className="font-medium text-foreground">{c.author.split('@')[0]}</span>
+        <span className="text-[10px] text-muted-foreground">{new Date(c.created_at).toLocaleString()}</span>
+        {c.status === 'resolved' && <Badge variant="outline" className="px-1.5 py-0 text-[10px] text-green-600">resolved</Badge>}
+      </div>
+      <p className="mt-0.5 whitespace-pre-wrap text-foreground">{renderBody(c.body)}</p>
+      <div className="mt-1 flex gap-3 text-[11px]">
+        {onToggle && <button className="text-primary hover:underline" onClick={onToggle}>{c.status === 'resolved' ? 'reopen' : 'resolve'}</button>}
+        {myEmail === c.author && <button className="text-destructive hover:underline" onClick={onDelete}>delete</button>}
+      </div>
+    </>
+  );
+}
+
+function ReplyBox({ onReply, pending }: { onReply: (body: string) => void; pending?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  if (!open) return <button className="mt-1 text-[11px] text-primary hover:underline" onClick={() => setOpen(true)}>Reply</button>;
+  return (
+    <div className="mt-1 flex gap-1.5">
+      <Textarea value={text} onChange={(e) => setText(e.target.value)} rows={1} autoFocus placeholder="Reply…" className="flex-1 text-xs" />
+      <Button size="sm" disabled={!text.trim() || pending} className="self-end"
+        onClick={() => { onReply(text.trim()); setText(''); setOpen(false); }}>
+        {pending ? '…' : 'Reply'}
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/use-fetch-reviewable-layers.ts
+++ b/src/hooks/use-fetch-reviewable-layers.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { LayerProps } from '@/lib/types/mapping-types';
+import { isGroupLayer, isWMSLayer } from '@/lib/map/layer-utils';
+import { useGetLayerConfigsData } from './use-get-layer-configs';
+
+export interface LayerOption {
+  value: string; // workspace-qualified sublayer name, e.g. 'hazards:hazards_qfaults_current'
+  label: string; // friendly title from the parent WMS layer
+}
+
+// A layer is "reviewable" when its GeoServer sublayer points at a review matview — those names end in
+// `_current` (the promoted-under-review matview) or `_review`. Derived straight from the static
+// hazards-review layer config (useGetLayerConfigs), so no PostGREST round-trip.
+const REVIEW_NAME = /(_current|_review)$/;
+
+/**
+ * The reviewable hazard layers for the comments picker — derived from the hazards-review page's own
+ * layer config, not a PostGREST lookup. `value` is the sublayer name a warehouse STAC item id maps from
+ * (see `layerToItemId`); `label` is the parent layer's title.
+ */
+export const useFetchReviewableLayers = (): { data: LayerOption[] } => {
+  const layerConfig = useGetLayerConfigsData('layers');
+
+  const data = useMemo<LayerOption[]>(() => {
+    if (!layerConfig) return [];
+    const byValue = new Map<string, string>();
+
+    const walk = (layers: LayerProps[]) => {
+      for (const layer of layers) {
+        if (isWMSLayer(layer)) {
+          for (const sub of layer.sublayers) {
+            if (sub.name && sub.queryable !== false && REVIEW_NAME.test(sub.name) && !byValue.has(sub.name)) {
+              byValue.set(sub.name, layer.title);
+            }
+          }
+        } else if (isGroupLayer(layer) && layer.layers) {
+          walk(layer.layers);
+        }
+      }
+    };
+    walk(layerConfig);
+
+    return [...byValue.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [layerConfig]);
+
+  return { data };
+};

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -28,9 +28,10 @@ export const auth = getAuth(app);
 // Configure OIDC provider
 const oidcProvider = new OAuthProvider('oidc.entra-d');
 
-// Optional: Configure additional scopes if needed
-// oidcProvider.addScope('email');
-// oidcProvider.addScope('profile');
+// Request email + profile so the ID token carries the `email` claim — the review-api verifies the
+// token server-side and keys comments/notifications on that email (must match the internal viewer).
+oidcProvider.addScope('email');
+oidcProvider.addScope('profile');
 
 export const signInWithOIDC = () => {
   return signInWithPopup(auth, oidcProvider);

--- a/src/lib/review-api.ts
+++ b/src/lib/review-api.ts
@@ -4,8 +4,9 @@
  * are SYNCED with it — keyed by email (Firebase/Entra and Google IAP resolve to the same @utah.gov
  * address) and by item id. Auth is the Firebase ID token (verified server-side); no cookies.
  *
- * Base URL comes from VITE_REVIEW_API_URL. When unset (e.g. before the service is deployed), calls are
- * skipped by the hooks so the UI degrades quietly.
+ * Base URL = VITE_REVIEW_API_URL = the API Gateway URL (`tofu output review_api_gateway_url`). The gateway
+ * validates this Firebase token, then invokes the private review-api as its own service account (org
+ * requires an authenticated invoker — no public Cloud Run). When unset, the hooks degrade quietly.
  */
 import { auth } from '@/lib/auth';
 

--- a/src/lib/review-api.ts
+++ b/src/lib/review-api.ts
@@ -1,0 +1,105 @@
+/**
+ * Client for the warehouse review-comments API (the non-IAP `ugs-warehouse-review-api` Cloud Run twin).
+ * Same `review.*` tables as the internal warehouse review viewer, so comments/notifications written here
+ * are SYNCED with it — keyed by email (Firebase/Entra and Google IAP resolve to the same @utah.gov
+ * address) and by item id. Auth is the Firebase ID token (verified server-side); no cookies.
+ *
+ * Base URL comes from VITE_REVIEW_API_URL. When unset (e.g. before the service is deployed), calls are
+ * skipped by the hooks so the UI degrades quietly.
+ */
+import { auth } from '@/lib/auth';
+
+export const REVIEW_API_URL = (import.meta.env.VITE_REVIEW_API_URL as string | undefined)?.replace(/\/$/, '') ?? '';
+
+export type CommentTarget = {
+  kind?: 'item' | 'row' | 'column';
+  featureId?: number;
+  featureIds?: number[];
+  column?: string;
+};
+
+export type Comment = {
+  id: number;
+  item_ids: string[];
+  target_kind: 'item' | 'row' | 'column';
+  feature_ids: number[] | null;
+  column_name: string | null;
+  parent_id: number | null;
+  body: string;
+  author: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Notification = {
+  id: number;
+  actor: string;
+  kind: 'mention' | 'reply';
+  seen_at: string | null;
+  created_at: string;
+  comment_id: number;
+  body: string;
+  item_ids: string[];
+  target_kind: string;
+  feature_ids: number[] | null;
+  column_name: string | null;
+  parent_id: number | null;
+};
+
+/** fetch wrapper that attaches the current user's Firebase ID token as a Bearer credential. */
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const token = await auth.currentUser?.getIdToken();
+  const res = await fetch(`${REVIEW_API_URL}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...init?.headers,
+    },
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`${res.status} ${detail.slice(0, 200)}`);
+  }
+  return (res.status === 204 ? undefined : await res.json()) as T;
+}
+
+// Comments for an item (a hazard layer id), optionally narrowed to a feature/column.
+export const listComments = (itemId: string, target?: { featureId?: number; column?: string }) => {
+  const q = new URLSearchParams({ item_id: itemId });
+  if (target?.featureId != null) q.set('feature_id', String(target.featureId));
+  if (target?.column) q.set('column', target.column);
+  return api<Comment[]>(`/api/comments?${q.toString()}`);
+};
+
+export const createComment = (itemIds: string[], body: string, target?: CommentTarget) => {
+  const featureIds = target?.featureIds ?? (target?.featureId != null ? [target.featureId] : null);
+  return api<Comment>(`/api/comments`, {
+    method: 'POST',
+    body: JSON.stringify({
+      item_ids: itemIds,
+      body,
+      target_kind: target?.kind ?? 'item',
+      feature_ids: featureIds,
+      column_name: target?.column ?? null,
+    }),
+  });
+};
+
+export const replyToComment = (parentId: number, body: string) =>
+  api<Comment>(`/api/comments`, { method: 'POST', body: JSON.stringify({ parent_id: parentId, body }) });
+
+export const setStatus = (id: number, status: string) =>
+  api<Comment>(`/api/comments/${id}`, { method: 'PATCH', body: JSON.stringify({ status }) });
+
+export const deleteComment = (id: number) =>
+  api<{ deleted: number }>(`/api/comments/${id}`, { method: 'DELETE' });
+
+export const listReviewers = () => api<string[]>(`/api/reviewers`);
+
+export const listNotifications = (unseen = false) =>
+  api<Notification[]>(`/api/notifications${unseen ? '?unseen=true' : ''}`);
+
+export const markNotificationsSeen = (ids?: number[]) =>
+  api<{ ok: boolean }>(`/api/notifications/seen`, { method: 'POST', body: JSON.stringify({ ids: ids ?? null }) });

--- a/src/lib/review-api.ts
+++ b/src/lib/review-api.ts
@@ -98,6 +98,12 @@ export const deleteComment = (id: number) =>
 
 export const listReviewers = () => api<string[]>(`/api/reviewers`);
 
+// Map a hazards-review layer value to the warehouse STAC item id so a comment lands on the SAME thread
+// as the internal review viewer. 'hazards:hazards_qfaults_current' → 'hazards_qfaults' (drop the
+// workspace prefix + the _current suffix; the matview name already embeds the schema).
+export const layerToItemId = (layerValue: string): string =>
+  (layerValue.split(':').pop() ?? layerValue).replace(/_current$/, '');
+
 export const listNotifications = (unseen = false) =>
   api<Notification[]>(`/api/notifications${unseen ? '?unseen=true' : ''}`);
 

--- a/src/lib/review-api.ts
+++ b/src/lib/review-api.ts
@@ -12,10 +12,14 @@ import { auth } from '@/lib/auth';
 
 export const REVIEW_API_URL = (import.meta.env.VITE_REVIEW_API_URL as string | undefined)?.replace(/\/$/, '') ?? '';
 
+// A row comment keys on a STABLE domain key (rowKey = the column name, e.g. 'pk') so a comment resolves
+// to the same row across the internal warehouse viewer (parquet/PMTiles) and this app (PostGIS pk).
+// rowVal = one row's thread (list); rowVals = create on N rows at once.
 export type CommentTarget = {
   kind?: 'item' | 'row' | 'column';
-  featureId?: number;
-  featureIds?: number[];
+  rowKey?: string;
+  rowVal?: string;
+  rowVals?: string[];
   column?: string;
 };
 
@@ -23,7 +27,8 @@ export type Comment = {
   id: number;
   item_ids: string[];
   target_kind: 'item' | 'row' | 'column';
-  feature_ids: number[] | null;
+  row_key: string | null;        // the stable-key column name (e.g. 'pk') when target_kind = row
+  row_key_vals: string[] | null; // 1..N stable key values
   column_name: string | null;
   parent_id: number | null;
   body: string;
@@ -43,7 +48,8 @@ export type Notification = {
   body: string;
   item_ids: string[];
   target_kind: string;
-  feature_ids: number[] | null;
+  row_key: string | null;
+  row_key_vals: string[] | null;
   column_name: string | null;
   parent_id: number | null;
 };
@@ -66,23 +72,24 @@ async function api<T>(path: string, init?: RequestInit): Promise<T> {
   return (res.status === 204 ? undefined : await res.json()) as T;
 }
 
-// Comments for an item (a hazard layer id), optionally narrowed to a feature/column.
-export const listComments = (itemId: string, target?: { featureId?: number; column?: string }) => {
+// Comments for an item (a hazard layer id), optionally narrowed to a row (by stable key value) or column.
+export const listComments = (itemId: string, target?: { rowVal?: string; column?: string }) => {
   const q = new URLSearchParams({ item_id: itemId });
-  if (target?.featureId != null) q.set('feature_id', String(target.featureId));
+  if (target?.rowVal != null) q.set('row_val', target.rowVal);
   if (target?.column) q.set('column', target.column);
   return api<Comment[]>(`/api/comments?${q.toString()}`);
 };
 
 export const createComment = (itemIds: string[], body: string, target?: CommentTarget) => {
-  const featureIds = target?.featureIds ?? (target?.featureId != null ? [target.featureId] : null);
+  const rowVals = target?.rowVals ?? (target?.rowVal != null ? [target.rowVal] : null);
   return api<Comment>(`/api/comments`, {
     method: 'POST',
     body: JSON.stringify({
       item_ids: itemIds,
       body,
       target_kind: target?.kind ?? 'item',
-      feature_ids: featureIds,
+      row_key: target?.rowKey ?? null,
+      row_key_vals: rowVals,
       column_name: target?.column ?? null,
     }),
   });

--- a/src/routes/_map/hazards-review/-components/sidebar/review/review-panel.tsx
+++ b/src/routes/_map/hazards-review/-components/sidebar/review/review-panel.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ReviewComments } from '@/components/review/review-comments';
-import { REVIEW_API_URL } from '@/lib/review-api';
+import { layerToItemId } from '@/lib/review-api';
 import { useFetchReviewableLayers } from '@/hooks/use-fetch-reviewable-layers';
 
 function ReviewPanel() {
@@ -25,9 +25,6 @@ function ReviewPanel() {
           <CardDescription>Pick a layer under review to read and add comments. Comments sync with the internal review app.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
-          {!REVIEW_API_URL && (
-            <p className="text-xs text-muted-foreground">Review API not configured (set VITE_REVIEW_API_URL).</p>
-          )}
           <div className="space-y-1">
             <Label className="text-xs">Reviewable layer</Label>
             <Select value={layer} onValueChange={setLayer}>
@@ -42,7 +39,7 @@ function ReviewPanel() {
             </Select>
           </div>
 
-          {layer && <ReviewComments itemId={layer} label={`Comments — ${layers.find((l) => l.value === layer)?.label ?? layer}`} />}
+          {layer && <ReviewComments itemId={layerToItemId(layer)} label={`Comments — ${layers.find((l) => l.value === layer)?.label ?? layer}`} />}
         </CardContent>
       </Card>
     </div>

--- a/src/routes/_map/hazards-review/-components/sidebar/review/review-panel.tsx
+++ b/src/routes/_map/hazards-review/-components/sidebar/review/review-panel.tsx
@@ -1,0 +1,52 @@
+/**
+ * Review sidebar section: pick a reviewable hazard layer, read/add comments on it. Comments live in the
+ * shared warehouse review.* tables (via the review-api), so threads sync with the internal review viewer.
+ */
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { ReviewComments } from '@/components/review/review-comments';
+import { REVIEW_API_URL } from '@/lib/review-api';
+import { useFetchReviewableLayers } from '@/hooks/use-fetch-reviewable-layers';
+
+function ReviewPanel() {
+  const { data: layers = [] } = useFetchReviewableLayers();
+  const [layer, setLayer] = useState<string>('');
+
+  return (
+    <div className="space-y-2">
+      <div className="mb-4">
+        <h3 className="text-lg font-medium mb-2">Review Comments</h3>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Layer</CardTitle>
+          <CardDescription>Pick a layer under review to read and add comments. Comments sync with the internal review app.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {!REVIEW_API_URL && (
+            <p className="text-xs text-muted-foreground">Review API not configured (set VITE_REVIEW_API_URL).</p>
+          )}
+          <div className="space-y-1">
+            <Label className="text-xs">Reviewable layer</Label>
+            <Select value={layer} onValueChange={setLayer}>
+              <SelectTrigger className="text-xs">
+                <SelectValue placeholder="Select a layer…" />
+              </SelectTrigger>
+              <SelectContent>
+                {layers.map((l) => (
+                  <SelectItem key={l.value} value={l.value} className="text-xs">{l.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {layer && <ReviewComments itemId={layer} label={`Comments — ${layers.find((l) => l.value === layer)?.label ?? layer}`} />}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default ReviewPanel;

--- a/src/routes/_map/hazards-review/-data/sidelinks.tsx
+++ b/src/routes/_map/hazards-review/-data/sidelinks.tsx
@@ -1,7 +1,8 @@
-import { House, Info as InfoIcon, Layers as LayersIcon, Settings } from 'lucide-react'
+import { House, Info as InfoIcon, Layers as LayersIcon, MessageSquare, Settings } from 'lucide-react'
 import Info from '@/components/sidebar/info'
 import MapConfigurations from '../-components/sidebar/map-configurations/map-configurations'
 import { HazardsReviewLayers } from '../-components/sidebar/hazards-review-layers'
+import ReviewPanel from '../-components/sidebar/review/review-panel'
 export interface NavLink {
   title: string
   label?: string
@@ -33,6 +34,12 @@ export const sidelinks: SideLink[] = [
     label: '',
     icon: <LayersIcon className='stroke-foreground' />,
     component: HazardsReviewLayers, // Direct component reference
+  },
+  {
+    title: 'Review Comments',
+    label: '',
+    icon: <MessageSquare className='stroke-foreground' />,
+    component: ReviewPanel, // Direct component reference
   },
   {
     title: 'Map Configurations',


### PR DESCRIPTION
Stacks on insar (#426). Adds the review-comments panel + review-api client, keyed on the warehouse stable row key (`row_key`/`row_key_vals`) so threads sync with the internal review viewer. Reviewable-layer picker sourced from the static layer config, not PostGREST.