### PR TITLE
feat(data-reviewer): serve review app behind IAP at /review/app, same-origin API

### DIFF
--- a/src/components/review/review-comments.tsx
+++ b/src/components/review/review-comments.tsx
@@ -6,13 +6,12 @@
  */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRef, useState } from 'react';
-import { useAuth } from '@/context/auth-provider';
+import { useWhoami } from '@/hooks/use-whoami';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import {
   type Comment,
-  REVIEW_API_URL,
   createComment,
   deleteComment,
   listComments,
@@ -30,12 +29,12 @@ function mentionAt(text: string, caret: number): { at: number; query: string } |
 
 export function ReviewComments({ itemId, label = 'Review comments' }: { itemId: string; label?: string }) {
   const qc = useQueryClient();
-  const { user } = useAuth();
-  const myEmail = user?.email ?? undefined;
+  const { email } = useWhoami();
+  const myEmail = email ?? undefined;
   const key = ['review-comments', itemId] as const;
-  // Need both a signed-in user (for the Firebase token) and the gateway URL (VITE_REVIEW_API_URL).
-  // Unset URL or no backend → the fetch errors → the panel hides.
-  const enabled = !!REVIEW_API_URL && !!user;
+  // IAP identity present (behind IAP `/whoami` returns the reviewer email) → load. Outside IAP the
+  // email is null → panel hidden; a missing backend also errors the fetch and the panel hides.
+  const enabled = !!email;
 
   const { data: comments = [], isLoading, error } = useQuery({
     queryKey: key,

--- a/src/hooks/use-fetch-reviewable-layers.ts
+++ b/src/hooks/use-fetch-reviewable-layers.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import { LayerProps } from '@/lib/types/mapping-types';
+import { isGroupLayer, isWMSLayer } from '@/lib/map/layer-utils';
+import { useGetLayerConfigsData } from './use-get-layer-configs';
+
+export interface LayerOption {
+  value: string; // workspace-qualified sublayer name, e.g. 'hazards:hazards_qfaults_current'
+  label: string; // friendly title from the parent WMS layer
+}
+
+// A layer is "reviewable" when its GeoServer sublayer points at a review matview — those names end in
+// `_current` (the promoted-under-review matview) or `_review`. Derived straight from the static
+// hazards-review layer config (useGetLayerConfigs), so no PostGREST round-trip.
+const REVIEW_NAME = /(_current|_review)$/;
+
+/**
+ * The reviewable hazard layers for the comments picker — derived from the hazards-review page's own
+ * layer config, not a PostGREST lookup. `value` is the sublayer name a warehouse STAC item id maps from
+ * (see `layerToItemId`); `label` is the parent layer's title.
+ */
+export const useFetchReviewableLayers = (): { data: LayerOption[] } => {
+  const layerConfig = useGetLayerConfigsData('layers');
+
+  const data = useMemo<LayerOption[]>(() => {
+    if (!layerConfig) return [];
+    const byValue = new Map<string, string>();
+
+    const walk = (layers: LayerProps[]) => {
+      for (const layer of layers) {
+        if (isWMSLayer(layer)) {
+          for (const sub of layer.sublayers) {
+            if (sub.name && sub.queryable !== false && REVIEW_NAME.test(sub.name) && !byValue.has(sub.name)) {
+              byValue.set(sub.name, layer.title);
+            }
+          }
+        } else if (isGroupLayer(layer) && layer.layers) {
+          walk(layer.layers);
+        }
+      }
+    };
+    walk(layerConfig);
+
+    return [...byValue.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  }, [layerConfig]);
+
+  return { data };
+};

--- a/src/hooks/use-whoami.ts
+++ b/src/hooks/use-whoami.ts
@@ -1,0 +1,22 @@
+/**
+ * The IAP-authenticated reviewer, from review-serving's `/whoami` endpoint (IAP injects the email header;
+ * the endpoint echoes it). Same-origin behind IAP — no token needed. Returns null email outside IAP
+ * (e.g. a public/preview build where `/whoami` 404s), so the review UI simply stays hidden there.
+ */
+import { useQuery } from '@tanstack/react-query';
+
+export type Whoami = { email: string; user: string };
+
+export function useWhoami() {
+  const { data } = useQuery({
+    queryKey: ['whoami'],
+    queryFn: async (): Promise<Whoami | null> => {
+      const res = await fetch('/whoami');
+      if (!res.ok) return null;
+      return res.json();
+    },
+    retry: false,
+    staleTime: Infinity,
+  });
+  return { email: data?.email ?? null, user: data?.user ?? null };
+}

--- a/src/lib/review-api.ts
+++ b/src/lib/review-api.ts
@@ -1,15 +1,12 @@
 /**
- * Client for the warehouse review-comments API (the non-IAP `ugs-warehouse-review-api` Cloud Run twin).
- * Same `review.*` tables as the internal warehouse review viewer, so comments/notifications written here
- * are SYNCED with it — keyed by email (Firebase/Entra and Google IAP resolve to the same @utah.gov
- * address) and by item id. Auth is the Firebase ID token (verified server-side); no cookies.
+ * Client for the warehouse review-comments API (served by review-serving under the same origin as the
+ * review app, behind IAP). Same `review.*` tables as the internal review viewer, so comments sync —
+ * keyed by email (IAP injects the reviewer's @utah.gov address, which review-serving trusts) and item id.
  *
- * Base URL = VITE_REVIEW_API_URL = the API Gateway URL (`tofu output review_api_gateway_url`). The gateway
- * validates this Firebase token, then invokes the private review-api as its own service account (org
- * requires an authenticated invoker — no public Cloud Run). When unset, the hooks degrade quietly.
+ * Auth: NONE in the client — the app is served behind IAP, so same-origin `/api/*` requests carry the
+ * IAP session cookie automatically; review-serving reads the authenticated email from the IAP header.
+ * Base URL is same-origin (relative `/api`); VITE_REVIEW_API_URL may override it for local dev.
  */
-import { auth } from '@/lib/auth';
-
 export const REVIEW_API_URL = (import.meta.env.VITE_REVIEW_API_URL as string | undefined)?.replace(/\/$/, '') ?? '';
 
 // A row comment keys on a STABLE domain key (rowKey = the column name, e.g. 'pk') so a comment resolves
@@ -54,14 +51,12 @@ export type Notification = {
   parent_id: number | null;
 };
 
-/** fetch wrapper that attaches the current user's Firebase ID token as a Bearer credential. */
+/** fetch wrapper — same-origin behind IAP, so the IAP session cookie authenticates; no Bearer token. */
 async function api<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = await auth.currentUser?.getIdToken();
   const res = await fetch(`${REVIEW_API_URL}${path}`, {
     ...init,
     headers: {
       'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       ...init?.headers,
     },
   });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,11 @@
 import ComingSoon from '@/components/coming-soon'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, redirect } from '@tanstack/react-router'
 
 export const Route = createFileRoute('/')({
+    beforeLoad: () => {
+        // Review build (served behind IAP at /review/app/) lands reviewers straight on the review section.
+        if (import.meta.env.MODE === 'review') throw redirect({ to: '/hazards-review' })
+    },
     component: RouteComponent,
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,10 @@ import { tanstackRouter } from '@tanstack/router-plugin/vite'
 // https://vitejs.dev/config/
 // Fix for MapLibre GL JS 5.12.0 __publicField issue
 // See: https://github.com/maplibre/maplibre-gl-js/issues/6680
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  // Review build (`vite build --mode review`) is served from the private review bucket under
+  // /review/app/ behind review-serving's IAP; the public build stays at root.
+  base: mode === 'review' ? '/review/app/' : '/',
   plugins: [
     tanstackRouter({
       target: 'react',
@@ -52,4 +55,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
Stacked on feat/review-catalog-render (#487).

Serve the full app as a review build behind review-serving's IAP:
- `vite build --mode review` sets base `/review/app/`
- root `/` redirects to `/hazards-review` in review mode
- `/api/*` same-origin (IAP session cookie authenticates; dropped Firebase Bearer token)
- reviewer identity from `/whoami` (IAP-injected email) instead of Firebase
- restore missing `use-fetch-reviewable-layers` hook (branch build fix)

Reviewers hit `…review-serving.run.app/review/app/` → IAP login → real hazards app + review STAC catalog + comments, all same-origin. No GIS token, no CORS. Pairs with ugs-warehouse#31 (serve.py routing).