### PR TITLE
feat(subsurface): grouped legend display labels and per-group feature counts

### DIFF
--- a/src/components/sidebar/filter/symbology-legend.tsx
+++ b/src/components/sidebar/filter/symbology-legend.tsx
@@ -114,6 +114,11 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
     const stroke = useMemo(() => new Map(entries.map(e => [e.label, e.stroke])), [entries])
     const itemColor = useMemo(() => new Map(entries.flatMap(e => (e.values ?? []).map(v => [v.value, v.color] as const))), [entries])
     const colorFor = (value: string) => itemColor.get(value) ?? swatch.get(value) ?? '#bdbdbd'
+    // Display text per raw value — grouped renders may carry a friendlier `label` for a shouty-case
+    // managed code (e.g. 'CORESAMPLES' -> 'Core Samples'); flat renders have no per-item labels, so
+    // this is a no-op there and the raw field value (already fit to show) is used as-is.
+    const itemLabel = useMemo(() => new Map(entries.flatMap(e => (e.values ?? []).map(v => [v.value, v.label] as const))), [entries])
+    const displayLabel = (value: string) => itemLabel.get(value) ?? value
     // Grouped render when any legend entry carries `values`; each entry becomes a colour group.
     const groups = useMemo<LegendGroup[] | null>(() =>
         entries.some(e => e.values && e.values.length)
@@ -156,21 +161,21 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
     // swatch is its own colour (per-item shade for grouped renders, fill for flat renders).
     const renderRows = (items: string[]) => (
         <div className="grid grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] gap-x-6 gap-y-1.5">
-            {items.map(label => (
-                <label key={label} className="flex min-w-0 items-start gap-1.5 pr-1 text-xs cursor-pointer">
+            {items.map(value => (
+                <label key={value} className="flex min-w-0 items-start gap-1.5 pr-1 text-xs cursor-pointer">
                     <Checkbox
                         className="mt-0.5 shrink-0"
-                        checked={onSet.has(label)}
-                        onCheckedChange={() => toggle(label)}
-                        aria-label={`Toggle ${label}`}
+                        checked={onSet.has(value)}
+                        onCheckedChange={() => toggle(value)}
+                        aria-label={`Toggle ${displayLabel(value)}`}
                     />
                     <span
                         className="mt-0.5 inline-block w-3 h-3 rounded-full shrink-0 border"
-                        style={{ backgroundColor: colorFor(label), borderColor: stroke.get(label) ?? 'rgba(0,0,0,0.3)' }}
+                        style={{ backgroundColor: colorFor(value), borderColor: stroke.get(value) ?? 'rgba(0,0,0,0.3)' }}
                     />
                     <span className="min-w-0 break-words leading-tight">
-                        {label}
-                        {counts[label] != null && <span className="ml-1 text-muted-foreground">({counts[label].toLocaleString()})</span>}
+                        {displayLabel(value)}
+                        {counts[value] != null && <span className="ml-1 text-muted-foreground">({counts[value].toLocaleString()})</span>}
                     </span>
                 </label>
             ))}

--- a/src/components/sidebar/filter/symbology-legend.tsx
+++ b/src/components/sidebar/filter/symbology-legend.tsx
@@ -218,6 +218,8 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
                 {groups.map(g => {
                     const items = membersOf(g)
                     if (items.length === 0) return null
+                    const total = items.reduce((sum, v) => sum + (counts[v] ?? 0), 0)
+                    const shown = items.reduce((sum, v) => sum + (onSet.has(v) ? counts[v] ?? 0 : 0), 0)
                     const onCount = items.filter(i => onSet.has(i)).length
                     const groupChecked: boolean | 'indeterminate' = onCount === items.length ? true : onCount === 0 ? false : 'indeterminate'
                     const toggleGroup = () => {
@@ -231,7 +233,14 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
                             <label className="flex items-center gap-1.5 border-t border-border pt-1.5 mt-0.5 cursor-pointer">
                                 <Checkbox className="shrink-0" checked={groupChecked} onCheckedChange={toggleGroup} aria-label={`Toggle ${g.label} group`} />
                                 <span className="inline-block w-3 h-3 rounded-full shrink-0 border" style={{ backgroundColor: g.color, borderColor: 'rgba(0,0,0,0.3)' }} />
-                                <Label className="text-xs font-semibold cursor-pointer">{g.label}</Label>
+                                <Label className="text-xs font-semibold cursor-pointer">
+                                    {g.label}
+                                    {total > 0 && (
+                                        <span className="ml-1 font-normal text-muted-foreground">
+                                            ({shown === total ? total.toLocaleString() : `${shown.toLocaleString()}/${total.toLocaleString()}`})
+                                        </span>
+                                    )}
+                                </Label>
                             </label>
                             <div className="pl-4">{renderRows(items)}</div>
                         </div>

--- a/src/components/sidebar/filter/symbology-legend.tsx
+++ b/src/components/sidebar/filter/symbology-legend.tsx
@@ -157,9 +157,8 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
     if (isLoading) return <p className="text-xs text-muted-foreground px-1">Loading…</p>
     if (options.length === 0) return null
 
-    // Auto-fit: 2 columns when the sidebar is wide enough, 1 on narrow screens. Each value's
-    // swatch is its own colour (per-item shade for grouped renders, fill for flat renders).
-    const renderRows = (items: string[]) => (
+    // Auto-fit: 2 columns when the sidebar is wide enough, 1 on narrow screens.
+    const renderRows = (items: string[], showSwatch = true) => (
         <div className="grid grid-cols-[repeat(auto-fit,minmax(8rem,1fr))] gap-x-6 gap-y-1.5">
             {items.map(value => (
                 <label key={value} className="flex min-w-0 items-start gap-1.5 pr-1 text-xs cursor-pointer">
@@ -169,10 +168,12 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
                         onCheckedChange={() => toggle(value)}
                         aria-label={`Toggle ${displayLabel(value)}`}
                     />
-                    <span
-                        className="mt-0.5 inline-block w-3 h-3 rounded-full shrink-0 border"
-                        style={{ backgroundColor: colorFor(value), borderColor: stroke.get(value) ?? 'rgba(0,0,0,0.3)' }}
-                    />
+                    {showSwatch && (
+                        <span
+                            className="mt-0.5 inline-block w-3 h-3 rounded-full shrink-0 border"
+                            style={{ backgroundColor: colorFor(value), borderColor: stroke.get(value) ?? 'rgba(0,0,0,0.3)' }}
+                        />
+                    )}
                     <span className="min-w-0 break-words leading-tight">
                         {displayLabel(value)}
                         {counts[value] != null && <span className="ml-1 text-muted-foreground">({counts[value].toLocaleString()})</span>}
@@ -222,6 +223,7 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
                     const shown = items.reduce((sum, v) => sum + (onSet.has(v) ? counts[v] ?? 0 : 0), 0)
                     const onCount = items.filter(i => onSet.has(i)).length
                     const groupChecked: boolean | 'indeterminate' = onCount === items.length ? true : onCount === 0 ? false : 'indeterminate'
+                    const shadesMatchGroup = items.every(v => colorFor(v) === g.color)
                     const toggleGroup = () => {
                         const next = new Set(onSet)
                         if (onCount === items.length) items.forEach(i => next.delete(i))
@@ -242,7 +244,7 @@ function CategoryLegendGrid({ schema, field, entries }: { schema: FilterSchema; 
                                     )}
                                 </Label>
                             </label>
-                            <div className="pl-4">{renderRows(items)}</div>
+                            <div className="pl-4">{renderRows(items, !shadesMatchGroup)}</div>
                         </div>
                     )
                 })}

--- a/src/lib/map/stac/stac-layer.ts
+++ b/src/lib/map/stac/stac-layer.ts
@@ -39,7 +39,7 @@ export interface StacRenderEntry {
     /** Absolute sprite-sheet base URL (no extension) for icon renders. */
     sprite?: string;
     /** Legend swatches; icon renders carry this explicitly. */
-    legend?: Array<{ label: string; color: string; values?: readonly { value: string; color: string }[]; stroke?: string }>;
+    legend?: Array<{ label: string; color: string; values?: readonly { value: string; color: string; label?: string }[]; stroke?: string }>;
     /** Feature attribute this render symbolizes. */
     field?: string;
 }

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -165,11 +165,13 @@ export interface COGLayerProps extends BaseLayerProps {
  */
 /** One legend entry: a symbology colour + what it represents. `values` (grouped renders) =
  *  the specific field values this entry rolls up, each with its own shade of the group colour;
- *  `stroke` = optional swatch outline (flat renders). */
+ *  `stroke` = optional swatch outline (flat renders). Each grouped value's `value` is the raw
+ *  data/filter token; `label` (optional) is its display text when the raw token isn't fit to show
+ *  as-is (e.g. shouty-case managed codes) — falls back to `value` when absent. */
 export interface LegendEntry {
     label: string;
     color: string;
-    values?: readonly { value: string; color: string }[];
+    values?: readonly { value: string; color: string; label?: string }[];
     stroke?: string;
 }
 


### PR DESCRIPTION
## What
Two changes to the grouped symbology legend:

1. `SymbologyLegend` now renders a per-value `label` (when the STAC render's legend carries one) instead of always showing the raw field value.
2. Group headers now carry a feature count — `Core Samples (3,410)` when the whole group is on, `Core Samples (1,204/3,410)` when only a subset is checked.

## Why
UCRC box-type codes (`BUTTS`, `CORE CHIPS`, `CORESAMPLES`, ...) are managed shouty-case free text. They're fine as the filter/join key but read badly in the sidebar checkbox legend.

Per-value counts already existed on each row, but nothing rolled them up — you couldn't tell how much of a group you'd filtered out without adding the rows yourself.

## How
**Display labels**
- `LegendEntry.values[]` (mapping-types.ts) and `StacRenderEntry.legend[].values[]` (stac-layer.ts) gain an optional `label` field. Passthrough only — `stacRendersToPMTiles` already spreads `r.legend` verbatim.
- `symbology-legend.tsx`: new `displayLabel(value)` map built from `entries[].values[].label`, falls back to the raw value when absent. Wired into the checkbox text + aria-label in `renderRows`.
- Raw `value` still drives `checked`/`toggle`/`colorFor`/`stroke`/`counts` — only the displayed text changes.
- No-op for flat/ungrouped legends (e.g. purpose), which don't carry a `values[]` array — nothing regresses there.

**Group counts**
- `total` / `shown` summed from the same `counts` map the per-value rows already use; the ratio collapses to a plain total when `shown === total`, so the default all-on state isn't a noisy `3,410/3,410`.
- Denominator is stable while toggling: `useDistinctFieldOptions` drops the field's own predicate (`toPostgrestPredicates(schema, state, field.field)`), so the group total reflects only the *other* active filters and cascades live with them.
- Hidden when the group total is 0. Grouped layout only — flat legends are untouched.

## Depends on
UGS-GIO/ugs-styles#25 — publishes the `label` field for UCRC box-type values. This PR is safe to merge independently (falls back to raw value if the STAC catalog hasn't picked up the new label yet); the visual fix only appears once ugs-styles#25 merges, builds, and the warehouse restyle job rebinds `ugs:renders` on the live STAC item. Group counts don't depend on it.

## Verified
- `tsc --noEmit` clean.
- Confirmed the label plumbing end-to-end against a local ugs-styles build (`npm run preview`) — `dist-json/index.json` for `enmin_ucrc_wells/by-boxtype` carries `{ value: 'CORESAMPLES', label: 'Core Samples', ... }`.
- Group counts not yet exercised in the browser.
