### PR TITLE
feat(common): Power Plants from the warehouse, with PMTiles legends and parquet-backed filter options

### DIFF
--- a/src/components/maps/stac-render-legend.tsx
+++ b/src/components/maps/stac-render-legend.tsx
@@ -1,0 +1,27 @@
+import { toTitleCase } from '@/lib/utils'
+import type { PMTilesLayerProps } from '@/lib/types/mapping-types'
+
+/**
+ * Read-only legend for a PMTiles layer, straight from its STAC render's `legend`.
+ * Replaces the WMS GetLegendGraphic image that vector layers no longer have.
+ */
+export function StacRenderLegend({ layer }: { layer: PMTilesLayerProps }) {
+    const render = layer.renders?.find(r => r.id === layer.defaultRenderId) ?? layer.renders?.[0]
+    const entries = render?.legend ?? []
+    if (entries.length === 0) return null
+
+    return (
+        <ul className="flex flex-col gap-1 px-1 py-1">
+            {entries.map(entry => (
+                <li key={entry.label} className="flex items-center gap-2 text-xs">
+                    <span
+                        className="inline-block h-3 w-3 shrink-0 rounded-full border"
+                        style={{ backgroundColor: entry.color, borderColor: entry.stroke ?? 'rgba(0,0,0,0.3)' }}
+                    />
+                    {/* ugs-styles keeps labels as the raw field value (lowercase) so consumers can join on it. */}
+                    <span className="min-w-0 break-words leading-tight">{toTitleCase(entry.label)}</span>
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/src/hooks/use-custom-layerlist.tsx
+++ b/src/hooks/use-custom-layerlist.tsx
@@ -16,6 +16,7 @@ import { useFetchLayerDescriptions } from '@/hooks/use-fetch-layer-descriptions'
 import { useSidebar } from '@/hooks/use-sidebar';
 import LayerControls from '@/components/maps/layer-controls';
 import { WfsVectorLegend } from '@/components/maps/wfs-vector-legend';
+import { StacRenderLegend } from '@/components/maps/stac-render-legend';
 import { ZoomHintPill } from '@/components/maps/zoom-hint-pill';
 import { useIsMobile } from './use-mobile';
 import { PROD_GEOSERVER_URL, HAZARDS_WORKSPACE } from '@/lib/constants';
@@ -297,7 +298,9 @@ const LayerAccordionItem = ({ layerConfig, isTopLevel, disableExport, groupExtra
         (layerConfig.title ? layerLegendRender?.(layerConfig) : undefined)
         ?? layerConfig.customLegend
         ?? (isCOGLayer(layerConfig) ? <CogLegend layer={layerConfig} /> : undefined)
-        ?? (isWFSLayer(layerConfig) ? <WfsVectorLegend layer={layerConfig} /> : undefined);
+        ?? (isWFSLayer(layerConfig) ? <WfsVectorLegend layer={layerConfig} /> : undefined)
+        // PMTiles layers have no GetLegendGraphic; swatches come from the STAC render.
+        ?? (isPMTilesLayer(layerConfig) ? <StacRenderLegend layer={layerConfig} /> : undefined);
 
     // --- Single Layer Rendering ---
     return (

--- a/src/hooks/use-distinct-field-options.ts
+++ b/src/hooks/use-distinct-field-options.ts
@@ -8,7 +8,8 @@
  */
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import type { FilterSchema, FilterState, FilterFieldKind } from '@/lib/filter/types';
-import { toPostgrestPredicates } from '@/lib/filter/generators';
+import { toPostgrestPredicates, toSqlPredicates } from '@/lib/filter/generators';
+import { useSchemaParquetUrl } from '@/hooks/use-schema-parquet-url';
 
 interface Options {
     schema: FilterSchema;
@@ -38,9 +39,22 @@ export const useDistinctFieldOptions = ({
     splitCommaDelimited = false,
     enabled = true,
 }: Options) => {
+    const { parquetUrl, isResolving } = useSchemaParquetUrl(schema);
     const url = buildUrl(schema, field, state);
+    const predicates = parquetUrl ? toSqlPredicates(schema, state, field.field) : [];
 
-    return useQuery({
+    const parquetQuery = useQuery({
+        queryKey: ['distinct-field-options', 'parquet', parquetUrl, field.field, predicates, splitCommaDelimited],
+        queryFn: async (): Promise<{ options: string[]; counts: Record<string, number> }> => {
+            const { queryParquetFieldOptions } = await import('@/lib/duckdb/client');
+            return queryParquetFieldOptions({ url: parquetUrl!, field: field.field, predicates, splitCommaDelimited });
+        },
+        enabled: enabled && !!parquetUrl,
+        placeholderData: keepPreviousData,
+        staleTime: 1000 * 60 * 5,
+    });
+
+    const postgrestQuery = useQuery({
         queryKey: ['distinct-field-options', schema.recordKey, field.field, url],
         queryFn: async (): Promise<{ options: string[]; counts: Record<string, number> }> => {
             const res = await fetch(url, {
@@ -71,8 +85,13 @@ export const useDistinctFieldOptions = ({
             if (splitCommaDelimited) out.sort();
             return { options: out, counts };
         },
-        enabled,
+        enabled: enabled && !schema.stacItemId,
         placeholderData: keepPreviousData,
         staleTime: 1000 * 60 * 5,
     });
+
+    if (schema.stacItemId) {
+        return { ...parquetQuery, isLoading: parquetQuery.isLoading || isResolving };
+    }
+    return postgrestQuery;
 };

--- a/src/hooks/use-field-range-extent.ts
+++ b/src/hooks/use-field-range-extent.ts
@@ -5,6 +5,7 @@
  */
 import { useQuery } from '@tanstack/react-query';
 import type { FilterSchema, FilterFieldKind } from '@/lib/filter/types';
+import { useSchemaParquetUrl } from '@/hooks/use-schema-parquet-url';
 
 interface Options {
     schema: FilterSchema;
@@ -12,8 +13,27 @@ interface Options {
     enabled?: boolean;
 }
 
+const snapped = (
+    { min, max }: { min: number; max: number },
+    snap: number | undefined,
+): { min: number; max: number } => (snap && snap > 0
+    ? { min: Math.floor(min / snap) * snap, max: Math.ceil(max / snap) * snap }
+    : { min, max });
+
 export const useFieldRangeExtent = ({ schema, field, enabled = true }: Options) => {
-    return useQuery({
+    const { parquetUrl } = useSchemaParquetUrl(schema);
+
+    const parquetQuery = useQuery({
+        queryKey: ['field-range-extent', 'parquet', parquetUrl, field.field],
+        queryFn: async (): Promise<{ min: number; max: number }> => {
+            const { queryParquetFieldExtent } = await import('@/lib/duckdb/client');
+            return snapped(await queryParquetFieldExtent({ url: parquetUrl!, field: field.field }), field.snapStep);
+        },
+        enabled: enabled && !!parquetUrl,
+        staleTime: 1000 * 60 * 60,
+    });
+
+    const postgrestQuery = useQuery({
         queryKey: ['field-range-extent', schema.recordKey, field.field],
         queryFn: async (): Promise<{ min: number; max: number }> => {
             const headers = { Accept: 'application/json', ...(schema.tableHeaders ?? {}) };
@@ -29,12 +49,11 @@ export const useFieldRangeExtent = ({ schema, field, enabled = true }: Options) 
             ]);
             const rawMin = minRows[0]?.[field.field] ?? 0;
             const rawMax = maxRows[0]?.[field.field] ?? 0;
-            const snap = field.snapStep;
-            return snap && snap > 0
-                ? { min: Math.floor(rawMin / snap) * snap, max: Math.ceil(rawMax / snap) * snap }
-                : { min: rawMin, max: rawMax };
+            return snapped({ min: rawMin, max: rawMax }, field.snapStep);
         },
-        enabled,
+        enabled: enabled && !schema.stacItemId,
         staleTime: 1000 * 60 * 60,
     });
+
+    return schema.stacItemId ? parquetQuery : postgrestQuery;
 };

--- a/src/hooks/use-schema-parquet-url.ts
+++ b/src/hooks/use-schema-parquet-url.ts
@@ -1,0 +1,15 @@
+/** Schema's geoparquet URL from its STAC item; undefined keeps the schema on PostgREST. */
+import { useQuery } from '@tanstack/react-query';
+import { fetchStacAssetHref } from '@/lib/map/stac/stac-layer';
+import type { FilterSchema } from '@/lib/filter/types';
+
+export const useSchemaParquetUrl = (schema: FilterSchema) => {
+    const stacItemId = schema.stacItemId;
+    const { data } = useQuery({
+        queryKey: ['schema-parquet-url', stacItemId],
+        queryFn: () => fetchStacAssetHref(stacItemId!, 'data').then(href => href ?? null),
+        enabled: !!stacItemId,
+        staleTime: 1000 * 60 * 30,
+    });
+    return { parquetUrl: data ?? undefined, isResolving: !!stacItemId && data === undefined };
+};

--- a/src/lib/duckdb/client.ts
+++ b/src/lib/duckdb/client.ts
@@ -166,3 +166,46 @@ export const queryParquetDistinctValues = async (
             .map(String);
     });
 };
+
+/** Value → row count for one column. `splitCommaDelimited` counts each comma-separated token. */
+export const queryParquetFieldOptions = async (
+    { url, field, predicates = [], splitCommaDelimited = false }:
+        { url: string; field: string; predicates?: string[]; splitCommaDelimited?: boolean },
+): Promise<{ options: string[]; counts: Record<string, number> }> => {
+    const col = quoteIdent(field);
+    const where = [`${col} IS NOT NULL`, `CAST(${col} AS VARCHAR) <> ''`, ...predicates].join(' AND ');
+    const value = splitCommaDelimited
+        ? `TRIM(UNNEST(string_split(CAST(${col} AS VARCHAR), ',')))`
+        : `TRIM(CAST(${col} AS VARCHAR))`;
+
+    return withConnection(async (conn) => {
+        const result = await conn.query(`
+            SELECT v, COUNT(*) AS n FROM (
+                SELECT ${value} AS v FROM read_parquet('${escapeSql(url)}') WHERE ${where}
+            ) WHERE v <> '' GROUP BY v ORDER BY n DESC, v ASC
+        `);
+        const options: string[] = [];
+        const counts: Record<string, number> = {};
+        for (const row of result.toArray()) {
+            const { v, n } = row.toJSON() as { v: unknown; n: unknown };
+            if (v == null) continue;
+            options.push(String(v));
+            counts[String(v)] = Number(n);
+        }
+        return { options, counts };
+    });
+};
+
+/** Global min/max of a numeric column, for a range slider's rails. */
+export const queryParquetFieldExtent = async (
+    { url, field }: { url: string; field: string },
+): Promise<{ min: number; max: number }> => {
+    const col = quoteIdent(field);
+    return withConnection(async (conn) => {
+        const result = await conn.query(
+            `SELECT MIN(${col}) AS lo, MAX(${col}) AS hi FROM read_parquet('${escapeSql(url)}') WHERE ${col} IS NOT NULL`,
+        );
+        const { lo, hi } = (result.toArray()[0]?.toJSON() ?? {}) as { lo: unknown; hi: unknown };
+        return { min: Number(lo ?? 0), max: Number(hi ?? 0) };
+    });
+};

--- a/src/lib/filter/generators.ts
+++ b/src/lib/filter/generators.ts
@@ -187,3 +187,49 @@ export const toPostgrestPredicates = (
     }
     return parts;
 };
+
+const sqlLiteral = (v: string): string => `'${v.replace(/'/g, "''")}'`;
+const sqlIdent = (v: string): string => `"${v.replace(/"/g, '""')}"`;
+
+const fieldToSqlParts = (field: FilterFieldKind, state: FilterState): string[] => {
+    const v = state[field.field];
+    if (!v) return [];
+    const col = sqlIdent(field.field);
+    switch (field.kind) {
+        case 'multiSelect':
+            if (v.kind !== 'multiSelect' || v.values.length === 0) return [];
+            return [`CAST(${col} AS VARCHAR) IN (${v.values.map(sqlLiteral).join(',')})`];
+        case 'containsAny': {
+            // Comma-delimited cells: match the same way the option list splits them.
+            if (v.kind !== 'containsAny' || v.values.length === 0) return [];
+            const clauses = v.values.map(val => `${col} ILIKE ${sqlLiteral(`%${val}%`)}`);
+            return [`(${clauses.join(' OR ')})`];
+        }
+        case 'range': {
+            if (v.kind !== 'range') return [];
+            const parts: string[] = [];
+            if (v.min != null) parts.push(`${col} >= ${Number(v.min)}`);
+            if (v.max != null) parts.push(`${col} <= ${Number(v.max)}`);
+            return parts;
+        }
+        case 'boolean': {
+            if (v.kind !== 'boolean' || v.value === 'all') return [];
+            const lit = v.value === 'yes' ? field.trueValue ?? 'True' : field.falseValue ?? 'False';
+            return [`CAST(${col} AS VARCHAR) = ${sqlLiteral(lit)}`];
+        }
+    }
+};
+
+/** SQL counterpart of {@link toPostgrestPredicates}, for querying the layer's geoparquet. */
+export const toSqlPredicates = (
+    schema: FilterSchema,
+    state: FilterState,
+    excludeField?: string,
+): string[] => {
+    const parts: string[] = [];
+    for (const f of schema.fields) {
+        if (excludeField && f.field === excludeField) continue;
+        parts.push(...fieldToSqlParts(f, state));
+    }
+    return parts;
+};

--- a/src/lib/filter/types.ts
+++ b/src/lib/filter/types.ts
@@ -61,8 +61,12 @@ export type FilterFieldKind =
 export interface FilterSchema {
     /** Key under `search.filters[recordKey]` where the CQL lives. */
     recordKey: string;
-    /** PostgREST base URL for distinct-option / range-extent queries. */
-    tableUrl: string;
+    /**
+     * PostgREST base URL for distinct-option / range-extent queries. Omit when the layer has
+     * no PostgREST table at all (fully warehouse-sourced) — `stacItemId` alone drives the
+     * geoparquet path in that case and the PostgREST path is never enabled.
+     */
+    tableUrl?: string;
     /** Extra headers to send with PostgREST requests. */
     tableHeaders?: Record<string, string>;
     /** Set to source options/extents from the STAC geoparquet instead of `tableUrl`. */

--- a/src/lib/filter/types.ts
+++ b/src/lib/filter/types.ts
@@ -65,6 +65,8 @@ export interface FilterSchema {
     tableUrl: string;
     /** Extra headers to send with PostgREST requests. */
     tableHeaders?: Record<string, string>;
+    /** Set to source options/extents from the STAC geoparquet instead of `tableUrl`. */
+    stacItemId?: string;
     /** Ordered field list. Renders top-to-bottom in the UI. */
     fields: FilterFieldKind[];
 }

--- a/src/routes/_map/carbonstorage/-components/sidebar/carbonstorage-layers.tsx
+++ b/src/routes/_map/carbonstorage/-components/sidebar/carbonstorage-layers.tsx
@@ -1,0 +1,33 @@
+import { BackToMenuButton } from '@/components/ui/back-to-menu-button'
+import { useCustomLayerList } from '@/hooks/use-custom-layerlist'
+import { useGetLayerConfigs } from '@/hooks/use-get-layer-configs'
+import { renderCarbonStorageLegend } from './carbonstorage-symbology-legend'
+
+/**
+ * Carbon storage variant of the shared Layers sidebar. Identical layout but wires the
+ * Power Plants layer's interactive, STAC-derived checkbox legend via the
+ * `layerLegendRender` render-prop. Mirrors subsurface's UCRC wiring.
+ */
+function CarbonStorageLayers({ disableExport = false }: { disableExport?: boolean } = {}) {
+    const { layerConfigs, isLoading } = useGetLayerConfigs('layers')
+    const layerList = useCustomLayerList({
+        config: layerConfigs,
+        disableExport,
+        layerLegendRender: renderCarbonStorageLegend,
+    })
+
+    if (isLoading) {
+        return <div>Loading layers...</div>
+    }
+
+    return (
+        <>
+            <BackToMenuButton />
+            <div key='layer-list' className='overflow-y-visible max-h-[calc(100vh)]' data-tour="layer-panel">
+                {layerList}
+            </div>
+        </>
+    )
+}
+
+export default CarbonStorageLayers

--- a/src/routes/_map/carbonstorage/-components/sidebar/carbonstorage-symbology-legend.tsx
+++ b/src/routes/_map/carbonstorage/-components/sidebar/carbonstorage-symbology-legend.tsx
@@ -1,0 +1,17 @@
+import type { LayerProps } from '@/lib/types/mapping-types'
+import { isPMTilesLayer } from '@/lib/map/layer-utils'
+import { SymbologyLegend } from '@/components/sidebar/filter/symbology-legend'
+import { powerplantsTitle } from '../../-data/layers/layers'
+import { powerplantsFilterSchema } from '../../-data/layers/powerplants-schema'
+
+/**
+ * Carbon storage's `layerLegendRender` wiring. The legend engine ({@link SymbologyLegend})
+ * is generic + STAC-derived — this just points it at the Power Plants layer's filter
+ * schema when that layer renders. Mirrors subsurface's UCRC wiring.
+ */
+export function renderCarbonStorageLegend(layer: LayerProps): React.ReactNode {
+    if (layer.title === powerplantsTitle && isPMTilesLayer(layer)) {
+        return <SymbologyLegend layer={layer} schema={powerplantsFilterSchema} />
+    }
+    return null
+}

--- a/src/routes/_map/carbonstorage/-data/layers/layers.tsx
+++ b/src/routes/_map/carbonstorage/-data/layers/layers.tsx
@@ -833,7 +833,7 @@ const ccusProjectsWMSConfig: WMSLayerProps = {
 // STAC-driven: pmtilesUrl, sourceLayer, renders (colour by `primsource`, radius by `total_mw`)
 // and parquet come from the warehouse item `enmin_powerplants`. Symbology lives in ugs-styles.
 const powerplantsLayerName = 'enmin_powerplants';
-const powerplantsTitle = 'Power Plants';
+export const powerplantsTitle = 'Power Plants';
 const powerplantsConfig: PMTilesLayerProps = {
     type: 'pmtiles',
     stacItemId: powerplantsLayerName,

--- a/src/routes/_map/carbonstorage/-data/layers/layers.tsx
+++ b/src/routes/_map/carbonstorage/-data/layers/layers.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@/components/ui/link";
 import { MAPS_ASSETS_CDN_URL, parquetUrl, ENERGY_MINERALS_WORKSPACE, GEN_GIS_WORKSPACE, HAZARDS_WORKSPACE, MAPPING_WORKSPACE, PROD_GEOSERVER_URL, PROD_POSTGREST_URL } from "@/lib/constants";
-import { ArcGISMapServerLayerProps, LayerProps, WFSLayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
+import { ArcGISMapServerLayerProps, LayerProps, PMTilesLayerProps, WFSLayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
 import { addThousandsSeparator, toTitleCase, toSentenceCase } from "@/lib/utils";
 import { GeoJsonProperties } from "geojson";
 
@@ -830,21 +830,26 @@ const ccusProjectsWMSConfig: WMSLayerProps = {
     ],
 };
 
-const geothermalPowerplantsLayerName = 'enmin_powerplants_current';
-const geothermalPowerplantsWMSTitle = 'Power Plants';
-const geothermalPowerplantsWMSConfig: WMSLayerProps = {
-    type: 'wms',
-    url: `${PROD_GEOSERVER_URL}/wms`,
-    title: geothermalPowerplantsWMSTitle,
+// STAC-driven: pmtilesUrl, sourceLayer, renders (colour by `primsource`, radius by `total_mw`)
+// and parquet come from the warehouse item `enmin_powerplants`. Symbology lives in ugs-styles.
+const powerplantsLayerName = 'enmin_powerplants';
+const powerplantsTitle = 'Power Plants';
+const powerplantsConfig: PMTilesLayerProps = {
+    type: 'pmtiles',
+    stacItemId: powerplantsLayerName,
+    pmtilesUrl: '',
+    sourceLayer: powerplantsLayerName,
+    title: powerplantsTitle,
     visible: false,
-    crs: 'EPSG:26912',
+    opacity: 1,
     sublayers: [
         {
-            name: `${ENERGY_MINERALS_WORKSPACE}:${geothermalPowerplantsLayerName}`,
+            name: powerplantsLayerName,
             popupEnabled: false,
             queryable: true,
             popupFields: {
                 'Name': { field: 'plant_name', type: 'string', transform: (value: string | null) => toTitleCase(value || '') },
+                'Primary Source': { field: 'primsource', type: 'string', transform: (value: string | null) => toTitleCase(value || '') },
                 'Capacity (MW)': { field: 'total_mw', type: 'number' },
                 'Operator': { field: 'utility_na', type: 'string' },
                 'City': { field: 'city', type: 'string' },
@@ -1347,7 +1352,7 @@ const infrastructureAndLandUseConfig: LayerProps = {
     title: 'Infrastructure and Land Use',
     visible: false,
     layers: [
-        geothermalPowerplantsWMSConfig,
+        powerplantsConfig,
         pipelinesWMSConfig,
         riversWMSConfig,
         roadsWMSConfig,

--- a/src/routes/_map/carbonstorage/-data/layers/powerplants-schema.ts
+++ b/src/routes/_map/carbonstorage/-data/layers/powerplants-schema.ts
@@ -1,0 +1,18 @@
+import type { FilterSchema } from '@/lib/filter/types';
+
+/**
+ * Power Plants is fully warehouse-sourced (PMTiles + geoparquet from the STAC item, no
+ * PostgREST table behind it) — `stacItemId` alone drives distinct-option queries straight
+ * off the geoparquet via DuckDB-wasm (see `useDistinctFieldOptions`), no `tableUrl` needed.
+ * `primsource` is the only field surfaced, matching the STAC render's colour category
+ * (see `SymbologyLegend`) — capacity/operator filters can be added here later if needed.
+ */
+export const powerplantsFilterSchema: FilterSchema = {
+    recordKey: 'powerplants',
+    stacItemId: 'enmin_powerplants',
+    fields: [
+        { kind: 'multiSelect', field: 'primsource', label: 'Plant Type' },
+    ],
+};
+
+export default powerplantsFilterSchema;

--- a/src/routes/_map/carbonstorage/-data/sidelinks.tsx
+++ b/src/routes/_map/carbonstorage/-data/sidelinks.tsx
@@ -1,6 +1,6 @@
 import { House, Info as InfoIcon, Layers as LayersIcon, Settings, ExternalLink, MessageSquare } from 'lucide-react'
 import Info from '@/components/sidebar/info'
-import Layers from '@/components/sidebar/layers'
+import CarbonStorageLayers from '../-components/sidebar/carbonstorage-layers'
 import MapConfigurations from '../-components/sidebar/map-configurations/map-configurations'
 
 export interface NavLink {
@@ -33,7 +33,7 @@ export const sidelinks: SideLink[] = [
     title: 'Layers',
     label: '',
     icon: <LayersIcon className='stroke-foreground' />,
-    component: Layers, // Direct component reference
+    component: CarbonStorageLayers, // Carbon storage variant: interactive Power Plants legend
   },
   {
     title: 'Map Configurations',

--- a/src/routes/_map/carbonstorage/-index.tsx
+++ b/src/routes/_map/carbonstorage/-index.tsx
@@ -9,12 +9,16 @@ import Sidebar from '@/components/sidebar'
 import { useSidebar } from '@/hooks/use-sidebar'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { useLayerUrl } from '@/context/layer-url-provider'
-import { wellWithTopsWMSTitle, seamlessGeolunitsWMSTitle, utTownshipRangesTitle } from './-data/layers/layers'
+import { wellWithTopsWMSTitle, seamlessGeolunitsWMSTitle, utTownshipRangesTitle, powerplantsTitle } from './-data/layers/layers'
 import { useMapContextState } from '@/hooks/use-map-context-state'
 import { MapContext } from '@/context/map-context'
 import { TourAutoStart } from '@/components/tour-auto-start'
 import { SearchCombobox, SearchSourceConfig, defaultMasqueradeConfig, handleCollectionSelect, handleSearchSelect, type SearchComboboxHandle } from '@/components/sidebar/filter/search-combobox'
 import { PROD_POSTGREST_URL } from '@/lib/constants'
+import { powerplantsFilterSchema } from './-data/layers/powerplants-schema'
+import { toMaplibreFilter } from '@/lib/filter/generators'
+import { fromCql } from '@/lib/filter/parse'
+import type { ExpressionSpecification, FilterSpecification } from 'maplibre-gl'
 
 // Carbon Storage specific filter mapping
 const CCS_FILTER_MAPPING: Record<string, string> = {
@@ -101,11 +105,24 @@ export default function Map() {
     return filters
   }, [filtersFromUrl])
 
+  // Translate Power Plants' stored CQL filter (from its checkbox legend) into a maplibre
+  // filter expression for the PMTiles layer.
+  const vectorLayerFilters = useMemo(() => {
+    const powerplantsCql = filtersFromUrl[powerplantsFilterSchema.recordKey]
+    const result: Record<string, FilterSpecification> = {}
+    if (powerplantsCql) {
+      const expr: ExpressionSpecification | null = toMaplibreFilter(powerplantsFilterSchema, fromCql(powerplantsFilterSchema, powerplantsCql))
+      if (expr) result[powerplantsTitle] = expr
+    }
+    return result
+  }, [filtersFromUrl])
+
   // A filtered layer must be on screen (selection reveals its groups too).
   useEffect(() => {
     for (const [filterKey, layerTitle] of Object.entries(CCS_FILTER_MAPPING)) {
       if (filtersFromUrl[filterKey]) updateLayerSelection(layerTitle, true)
     }
+    if (filtersFromUrl[powerplantsFilterSchema.recordKey]) updateLayerSelection(powerplantsTitle, true)
   }, [filtersFromUrl, updateLayerSelection])
 
   const onFeatureSelect = handleSearchSelect
@@ -142,6 +159,7 @@ export default function Map() {
             <Layout.Body>
               <GenericMapContainer
                 layerFilters={layerFilters}
+                vectorLayerFilters={vectorLayerFilters}
                 onClearSearch={() => searchRef.current?.clear()}
               />
             </Layout.Body>

--- a/src/routes/_map/geophysics/-components/sidebar/geophysics-layers.tsx
+++ b/src/routes/_map/geophysics/-components/sidebar/geophysics-layers.tsx
@@ -1,0 +1,33 @@
+import { BackToMenuButton } from '@/components/ui/back-to-menu-button'
+import { useCustomLayerList } from '@/hooks/use-custom-layerlist'
+import { useGetLayerConfigs } from '@/hooks/use-get-layer-configs'
+import { renderGeophysicsLegend } from './geophysics-symbology-legend'
+
+/**
+ * Geophysics variant of the shared Layers sidebar. Identical layout but wires the Power
+ * Plants layer's interactive, STAC-derived checkbox legend via the `layerLegendRender`
+ * render-prop. Mirrors subsurface's UCRC wiring.
+ */
+function GeophysicsLayers({ disableExport = false }: { disableExport?: boolean } = {}) {
+    const { layerConfigs, isLoading } = useGetLayerConfigs('layers')
+    const layerList = useCustomLayerList({
+        config: layerConfigs,
+        disableExport,
+        layerLegendRender: renderGeophysicsLegend,
+    })
+
+    if (isLoading) {
+        return <div>Loading layers...</div>
+    }
+
+    return (
+        <>
+            <BackToMenuButton />
+            <div key='layer-list' className='overflow-y-visible max-h-[calc(100vh)]' data-tour="layer-panel">
+                {layerList}
+            </div>
+        </>
+    )
+}
+
+export default GeophysicsLayers

--- a/src/routes/_map/geophysics/-components/sidebar/geophysics-symbology-legend.tsx
+++ b/src/routes/_map/geophysics/-components/sidebar/geophysics-symbology-legend.tsx
@@ -1,0 +1,17 @@
+import type { LayerProps } from '@/lib/types/mapping-types'
+import { isPMTilesLayer } from '@/lib/map/layer-utils'
+import { SymbologyLegend } from '@/components/sidebar/filter/symbology-legend'
+import { powerplantsTitle } from '../../-data/layers/layers'
+import { powerplantsFilterSchema } from '../../-data/layers/powerplants-schema'
+
+/**
+ * Geophysics's `layerLegendRender` wiring. The legend engine ({@link SymbologyLegend})
+ * is generic + STAC-derived — this just points it at the Power Plants layer's filter
+ * schema when that layer renders. Mirrors subsurface's UCRC wiring.
+ */
+export function renderGeophysicsLegend(layer: LayerProps): React.ReactNode {
+    if (layer.title === powerplantsTitle && isPMTilesLayer(layer)) {
+        return <SymbologyLegend layer={layer} schema={powerplantsFilterSchema} />
+    }
+    return null
+}

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -1,5 +1,5 @@
 import { ENERGY_MINERALS_WORKSPACE, HAZARDS_WORKSPACE, MAPPING_WORKSPACE, parquetUrl, PROD_GEOSERVER_URL } from "@/lib/constants";
-import { ArcGISMapServerLayerProps, COGLayerProps, LayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
+import { ArcGISMapServerLayerProps, COGLayerProps, LayerProps, PMTilesLayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
 import { GeoJsonProperties } from "geojson";
 import { toTitleCase, toSentenceCase } from "@/lib/utils";
 
@@ -233,21 +233,26 @@ const qFaultsWMSConfig: WMSLayerProps = {
     ],
 };
 
-// Geothermal Power Plants WMS Layer
-const geothermalPowerplantsLayerName = 'enmin_powerplants_current';
-const geothermalPowerplantsWMSTitle = 'Power Plants';
-const geothermalPowerplantsWMSConfig: WMSLayerProps = {
-    type: 'wms',
-    url: `${PROD_GEOSERVER_URL}/wms`,
-    title: geothermalPowerplantsWMSTitle,
+// Power Plants — STAC-driven: pmtilesUrl, sourceLayer, renders (colour by `primsource`, radius by
+// `total_mw`) and parquet come from the warehouse item `enmin_powerplants`. Symbology in ugs-styles.
+const powerplantsLayerName = 'enmin_powerplants';
+const powerplantsTitle = 'Power Plants';
+const powerplantsConfig: PMTilesLayerProps = {
+    type: 'pmtiles',
+    stacItemId: powerplantsLayerName,
+    pmtilesUrl: '',
+    sourceLayer: powerplantsLayerName,
+    title: powerplantsTitle,
     visible: true,
+    opacity: 1,
     sublayers: [
         {
-            name: `${ENERGY_MINERALS_WORKSPACE}:${geothermalPowerplantsLayerName}`,
+            name: powerplantsLayerName,
             popupEnabled: false,
             queryable: true,
             popupFields: {
                 'Name': { field: 'plant_name', type: 'string', transform: (value: string | null) => toTitleCase(value || '') },
+                'Primary Source': { field: 'primsource', type: 'string', transform: (value: string | null) => toTitleCase(value || '') },
                 'Capacity (MW)': { field: 'total_mw', type: 'number' },
                 'Operator': { field: 'utility_na', type: 'string' },
                 'City': { field: 'city', type: 'string' },
@@ -844,7 +849,7 @@ const infrastructureAndLandUseConfig: LayerProps = {
     title: 'Infrastructure and Land Use',
     visible: false,
     layers: [
-        geothermalPowerplantsWMSConfig,
+        powerplantsConfig,
         roadsWMSConfig,
         railroadsWMSConfig,
         transmissionLinesWMSConfig,

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -236,7 +236,7 @@ const qFaultsWMSConfig: WMSLayerProps = {
 // Power Plants — STAC-driven: pmtilesUrl, sourceLayer, renders (colour by `primsource`, radius by
 // `total_mw`) and parquet come from the warehouse item `enmin_powerplants`. Symbology in ugs-styles.
 const powerplantsLayerName = 'enmin_powerplants';
-const powerplantsTitle = 'Power Plants';
+export const powerplantsTitle = 'Power Plants';
 const powerplantsConfig: PMTilesLayerProps = {
     type: 'pmtiles',
     stacItemId: powerplantsLayerName,

--- a/src/routes/_map/geophysics/-data/layers/powerplants-schema.ts
+++ b/src/routes/_map/geophysics/-data/layers/powerplants-schema.ts
@@ -1,0 +1,18 @@
+import type { FilterSchema } from '@/lib/filter/types';
+
+/**
+ * Power Plants is fully warehouse-sourced (PMTiles + geoparquet from the STAC item, no
+ * PostgREST table behind it) — `stacItemId` alone drives distinct-option queries straight
+ * off the geoparquet via DuckDB-wasm (see `useDistinctFieldOptions`), no `tableUrl` needed.
+ * `primsource` is the only field surfaced, matching the STAC render's colour category
+ * (see `SymbologyLegend`) — capacity/operator filters can be added here later if needed.
+ */
+export const powerplantsFilterSchema: FilterSchema = {
+    recordKey: 'powerplants',
+    stacItemId: 'enmin_powerplants',
+    fields: [
+        { kind: 'multiSelect', field: 'primsource', label: 'Plant Type' },
+    ],
+};
+
+export default powerplantsFilterSchema;

--- a/src/routes/_map/geophysics/-data/sidelinks.tsx
+++ b/src/routes/_map/geophysics/-data/sidelinks.tsx
@@ -1,6 +1,6 @@
 import { House, Info as InfoIcon, Layers as LayersIcon, Settings } from 'lucide-react'
 import Info from '@/components/sidebar/info'
-import Layers from '@/components/sidebar/layers'
+import GeophysicsLayers from '../-components/sidebar/geophysics-layers'
 import MapConfigurations from '@/routes/_map/wetlands/-components/sidebar/map-configurations/map-configurations'
 
 export interface NavLink {
@@ -33,7 +33,7 @@ export const sidelinks: SideLink[] = [
     title: 'Layers',
     label: '',
     icon: <LayersIcon className='stroke-foreground' />,
-    component: Layers, // Direct component reference
+    component: GeophysicsLayers, // Geophysics variant: interactive Power Plants legend
   },
   {
     title: 'Map Configurations',

--- a/src/routes/_map/geophysics/-index.tsx
+++ b/src/routes/_map/geophysics/-index.tsx
@@ -1,3 +1,5 @@
+import { useMemo, useEffect } from 'react'
+import { useSearch } from '@tanstack/react-router'
 import { Layout } from '@/components/layout/layout'
 import { TopNav } from '@/components/top-nav'
 import { MapFooter } from '@/components/maps/map-footer'
@@ -6,18 +8,45 @@ import GenericMapContainer from '@/components/maps/generic-map-container'
 import Sidebar from '@/components/sidebar'
 import { useSidebar } from '@/hooks/use-sidebar'
 import { useIsMobile } from '@/hooks/use-mobile'
+import { useLayerUrl } from '@/context/layer-url-provider'
 import { useMapContextState } from '@/hooks/use-map-context-state'
 import { MapContext } from '@/context/map-context'
 import { TourAutoStart } from '@/components/tour-auto-start'
 import { PROD_POSTGREST_URL } from '@/lib/constants';
 import { SearchCombobox, SearchSourceConfig, defaultMasqueradeConfig, handleCollectionSelect, handleSearchSelect } from '@/components/sidebar/filter/search-combobox';
-import { geothermalTEMLayerTitle, gravityStationsLayeTitle } from './-data/layers/layers';
+import { geothermalTEMLayerTitle, gravityStationsLayeTitle, powerplantsTitle } from './-data/layers/layers';
+import { powerplantsFilterSchema } from './-data/layers/powerplants-schema'
+import { toMaplibreFilter } from '@/lib/filter/generators'
+import { fromCql } from '@/lib/filter/parse'
+import type { ExpressionSpecification, FilterSpecification } from 'maplibre-gl'
 
 export default function Map() {
     const { isCollapsed, sidebarWidthPx } = useSidebar();
     const isMobile = useIsMobile();
     const sidebarMargin = isMobile ? 0 : (isCollapsed ? 56 : sidebarWidthPx);
+    const { updateLayerSelection } = useLayerUrl();
     const { contextValue } = useMapContextState();
+
+    // Get URL filters
+    const searchParams = useSearch({ from: '/_map/geophysics/' })
+    const filtersFromUrl = searchParams.filters ?? {}
+
+    // Translate Power Plants' stored CQL filter (from its checkbox legend) into a maplibre
+    // filter expression for the PMTiles layer.
+    const vectorLayerFilters = useMemo(() => {
+        const powerplantsCql = filtersFromUrl[powerplantsFilterSchema.recordKey]
+        const result: Record<string, FilterSpecification> = {}
+        if (powerplantsCql) {
+            const expr: ExpressionSpecification | null = toMaplibreFilter(powerplantsFilterSchema, fromCql(powerplantsFilterSchema, powerplantsCql))
+            if (expr) result[powerplantsTitle] = expr
+        }
+        return result
+    }, [filtersFromUrl])
+
+    // A filtered layer must be on screen (selection reveals its groups too).
+    useEffect(() => {
+        if (filtersFromUrl[powerplantsFilterSchema.recordKey]) updateLayerSelection(powerplantsTitle, true)
+    }, [filtersFromUrl, updateLayerSelection])
 
     const searchConfig: SearchSourceConfig[] = [
         defaultMasqueradeConfig,
@@ -74,7 +103,7 @@ export default function Map() {
 
                         {/* ===== Main ===== */}
                         <Layout.Body>
-                            <GenericMapContainer />
+                            <GenericMapContainer vectorLayerFilters={vectorLayerFilters} />
                         </Layout.Body>
 
                         {/* ===== Footer ===== */}

--- a/src/routes/_map/subsurface/-data/layers/ucrc-schema.ts
+++ b/src/routes/_map/subsurface/-data/layers/ucrc-schema.ts
@@ -6,6 +6,7 @@ export const ucrcFilterSchema: FilterSchema = {
     recordKey: ucrcWellsWMSTitle,
     tableUrl: `${PROD_POSTGREST_URL}/enmin_ucrc_wells_current`,
     tableHeaders: { 'Accept-Profile': 'emp' },
+    stacItemId: 'enmin_ucrc_wells',
     fields: [
         {
             kind: 'multiSelect',


### PR DESCRIPTION
## What
Moves Power Plants onto the warehouse, and adds the two generic pieces it needed: a legend for PMTiles layers, and filter options sourced from geoparquet instead of PostgREST.

## How
**Power Plants → warehouse** (`1cdf03dd`)
- `carbonstorage` + `geophysics` layer configs: GeoServer WMS `enmin_powerplants_current` → `stacItemId: 'enmin_powerplants'`. STAC fills `pmtilesUrl`, `sourceLayer`, `renders`, parquet.
- Popup fields carry over 1:1 (verified against the parquet); added `primsource`, which the new render colours by.

**PMTiles legends** (`262f49b3`)
- Legends came from WMS `GetLegendGraphic`, which vector layers don't have. The only PMTiles path was the interactive `SymbologyLegend`, wired solely by subsurface — so a PMTiles layer on any other route showed an empty Legend panel.
- New `StacRenderLegend`: read-only swatches from the render's `legend`, as the default for PMTiles layers in the legend chain. Subsurface unaffected — `layerLegendRender` still wins.

**Filter options from geoparquet** (`241232dd`)
- A schema opts in with `stacItemId`; options/extents then come from the parquet via DuckDB. Without it, the existing `tableUrl` PostgREST path is untouched, so layers move one at a time.
- Adds `toSqlPredicates` (mirrors `toPostgrestPredicates` across all four field kinds), `queryParquetFieldOptions` (one `GROUP BY` returns options *and* counts, replacing fetch-all-rows-and-tally-in-JS), `queryParquetFieldExtent`, and `useSchemaParquetUrl` resolving the item's `data` asset.
- UCRC flipped as the first consumer.

## Verified
- Power Plants legend renders in geophysics: Coal, Natural Gas, Petroleum, Hydroelectric, Wind, Solar, Geothermal, Biomass, Other.
- UCRC counts identical across both sources — `CUTTINGS 4779`, `WHOLE CORE 875`, `SLABS 625`, `CORE CHIPS 542`, `BUTTS 498`.
- Cascading works: filtered to Uintah, UI shows 426 / 1,454 / 13; an independent DuckDB query returns `426|1454|13`. Range extent 0–22,100 ft.
- 0 console errors. `tsc` + eslint clean.

## Watch in review
DuckDB-WASM now boots on first legend open, not only on export. It stays behind a dynamic `import()` and existing loading states cover it, but the first open has a delay.
