### PR TITLE
refactor(subsurface): show Sample Types before Core Boxes in UCRC popup

### DIFF
--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -493,6 +493,30 @@ const ucrcWellsWFSConfig: PMTilesLayerProps = {
             },
             relatedTables: [
                 {
+                    // Client-side rollup of the SAME enmin_ucrc_boxes rows used by "Core Boxes"
+                    // below: collapses individual box records into contiguous Core/Cuttings
+                    // depth intervals, starting a new interval whenever the gap to the next
+                    // same-type sample exceeds 10 ft (ALL-4766). `box_type_group` exists on the
+                    // published data but mislabels every Core-family type as OTHER, so we bucket
+                    // from raw `box_type` via `boxTypeToSampleGroup` instead (see sample-intervals.ts).
+                    fieldLabel: 'Sample Types',
+                    stacAsset: 'enmin_ucrc_boxes',
+                    displayAs: 'table',
+                    rowsTransform: (rows) => mergeSampleIntervals(rows, {
+                        typeField: 'box_type',
+                        groupBy: boxTypeToSampleGroup,
+                        topField: 'box_top_ft',
+                        bottomField: 'box_bottom_ft',
+                        notesField: 'notes_public',
+                    }),
+                    displayFields: [
+                        { field: 'sample_type', label: 'Type' },
+                        { field: 'top_ft', label: 'Top (ft)', format: 'number' },
+                        { field: 'bottom_ft', label: 'Bottom (ft)', format: 'number' },
+                        { field: 'notes_public', label: 'Notes', transform: (v) => v || '—' },
+                    ],
+                },
+                {
                     // STAC-backed: url + uwi join filled from the enmin_ucrc_boxes related asset.
                     fieldLabel: 'Core Boxes',
                     stacAsset: 'enmin_ucrc_boxes',
@@ -523,30 +547,6 @@ const ucrcWellsWFSConfig: PMTilesLayerProps = {
                     ],
                     sortBy: 'box_number',
                     sortDirection: 'asc',
-                },
-                {
-                    // Client-side rollup of the SAME enmin_ucrc_boxes rows used by "Core Boxes"
-                    // above: collapses individual box records into contiguous Core/Cuttings
-                    // depth intervals, starting a new interval whenever the gap to the next
-                    // same-type sample exceeds 10 ft (ALL-4766). `box_type_group` exists on the
-                    // published data but mislabels every Core-family type as OTHER, so we bucket
-                    // from raw `box_type` via `boxTypeToSampleGroup` instead (see sample-intervals.ts).
-                    fieldLabel: 'Sample Types',
-                    stacAsset: 'enmin_ucrc_boxes',
-                    displayAs: 'table',
-                    rowsTransform: (rows) => mergeSampleIntervals(rows, {
-                        typeField: 'box_type',
-                        groupBy: boxTypeToSampleGroup,
-                        topField: 'box_top_ft',
-                        bottomField: 'box_bottom_ft',
-                        notesField: 'notes_public',
-                    }),
-                    displayFields: [
-                        { field: 'sample_type', label: 'Type' },
-                        { field: 'top_ft', label: 'Top (ft)', format: 'number' },
-                        { field: 'bottom_ft', label: 'Bottom (ft)', format: 'number' },
-                        { field: 'notes_public', label: 'Notes', transform: (v) => v || '—' },
-                    ],
                 },
                 {
                     fieldLabel: 'Attachments',


### PR DESCRIPTION
## Summary

Swaps the draw order of the "Sample Types" and "Core Boxes" related-table dropdowns in the UCRC Inventory well popup so "Sample Types" appears first, "Core Boxes" second. "Attachments" stays last.

Split out of #491 per review feedback there, since it's an independent, purely cosmetic change on top of that PR's work.

## Changes

- src/routes/_map/subsurface/-data/layers/layers.tsx: reordered the two `relatedTables` entries. No code or functionality changes to either entry - same fields, same `rowsTransform`, same sort config. One comment ("above" -> "below") updated to match the new relative position.

## Base branch

This PR targets `feat/ucrc-samples-table` (#491), not `develop`, because the "Sample Types" table it reorders doesn't exist on `develop` yet. Once #491 merges, this can be re-targeted to `develop` and the diff will shrink to just the one commit.

## Testing

- tsc --noEmit: clean
- eslint: clean on touched file
- npm run build: clean (ran via pre-push hook)

ALL-4766