### PR TITLE
fix(hazards): stats panel ResizeObserver feedback loop freezes the map

### DIFF
--- a/src/components/maps/layer-controls.tsx
+++ b/src/components/maps/layer-controls.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { LegendAccordion } from '@/components/maps/legend-accordion';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Toggle } from '@/components/ui/toggle';
 import { LayerDescriptionAccordion } from '@/components/maps/layer-description-accordion';
 import { useQuery } from '@tanstack/react-query';
@@ -40,26 +40,19 @@ interface LayerControlsProps {
     styleName?: string;
 }
 
-// Tracks its content's real height via ResizeObserver instead of a guessed
-// max-height cap, so the collapse/expand transition never clips taller content.
+// Animates to content's real height via a CSS grid-rows trick (0fr <-> 1fr) instead of a
+// guessed max-height cap, so the collapse/expand transition never clips taller content.
+// Deliberately NOT ResizeObserver-measured: content here can include a Recharts
+// ResponsiveContainer, which runs its own internal ResizeObserver on the same node — a JS
+// height-measurement + animated-state loop on top of that fed back into itself every transition
+// frame and froze the map (see #500). Pure CSS has no measurement step, so there's nothing to loop.
 function AutoHeightCollapse({ open, children }: { open: boolean; children: React.ReactNode }) {
-    const innerRef = useRef<HTMLDivElement>(null);
-    const [height, setHeight] = useState(0);
-
-    useEffect(() => {
-        const el = innerRef.current;
-        if (!el) return;
-        const observer = new ResizeObserver(([entry]) => setHeight(entry.contentRect.height));
-        observer.observe(el);
-        return () => observer.disconnect();
-    }, []);
-
     return (
         <div
-            className="overflow-hidden transition-[max-height] duration-200 ease-out"
-            style={{ maxHeight: open ? height : 0 }}
+            className="grid transition-[grid-template-rows] duration-200 ease-out"
+            style={{ gridTemplateRows: open ? '1fr' : '0fr' }}
         >
-            <div ref={innerRef}>{children}</div>
+            <div className="overflow-hidden">{children}</div>
         </div>
     );
 }


### PR DESCRIPTION
Fixes #500

## What
Replaces `AutoHeightCollapse`'s `ResizeObserver`-measured, React-state-driven `max-height` animation with a pure CSS `grid-template-rows: 0fr -> 1fr` transition.

## Why
`AutoHeightCollapse` (added in #426) measures its content's height with a `ResizeObserver` and stores it in state to animate `max-height`. Its content can include a Recharts `<ResponsiveContainer>`, which runs its **own internal ResizeObserver** on the same DOM node (to track width).

During the 200ms CSS transition, the box height changes on every compositor frame, re-triggering `AutoHeightCollapse`'s observer, re-triggering `setHeight`, ad infinitum. Recharts re-rendering its SVG on its own resize adds a second oscillation source. Because the sidebar and the map are layout siblings, the thrash perturbs the map container's box size every frame too — MapLibre's own built-in `ResizeObserver` can't keep up:

```
Uncaught Error: Attempting to run(), but is already running.
    at Nc.run (maplibre-*.js)
    at k.Map._render (maplibre-*.js)
```

Eventually a state update fires on every thrash frame, exceeding React's re-render budget:

```
Uncaught Error: Minified React error #185 (Maximum update depth exceeded)
```

...freezing the tab. Reproduced on the PR #426 dev preview channel opening the Stats panel.

## Fix
No JS measurement step at all \u2014 `grid-template-rows` animates `0fr -> 1fr` natively, sizing to content automatically. There's nothing left to feed back into itself.

## Verified
- `tsc --noEmit` clean.
- `npm run build` succeeds.
- Diff is minimal: one component, no behavior change to the collapse/expand UX itself, just how the height is derived.

## Note
A separate, unrelated console warning (`Expected value to be of type number, but found null instead`) was also observed on the same preview \u2014 a null field hitting a numeric MapLibre paint expression in ugs-styles' `hazards_displacement_contours/cumulative.ts`. Not the freeze cause; worth its own follow-up.