### PR TITLE
fix(hazards): correct geom field and CRS overrides for SFR layer

### DIFF
--- a/src/routes/_report/-data/hazard-unit-map.ts
+++ b/src/routes/_report/-data/hazard-unit-map.ts
@@ -42,12 +42,18 @@ export const hazardLayerNameMap = {
 // TODO: All layers will eventually migrate to 'geom'
 const geometryFieldOverrides: Record<string, string> = {
     [quaternaryFaultsHazardCode]: 'geom',
+    'SFR': 'geom',
 };
 
 // Native CRS per layer (default is EPSG:26912, override where different)
-// TODO: All layers will eventually migrate to EPSG:3857
+// EPSG:3857 here is GeoServer's current migrated state for these layers, NOT
+// the final target. The ugs-warehouse vector producer normalizes all
+// geometries to EPSG:4326 (see vector/transform.py TARGET_SRS). Once this
+// report reads from the warehouse (STAC/GeoParquet/DuckLake) instead of
+// hitting GeoServer WFS directly, this whole overrides map goes away.
 const crsOverrides: Record<string, string> = {
     [quaternaryFaultsHazardCode]: 'EPSG:3857',
+    'SFR': 'EPSG:3857',
 };
 
 /**


### PR DESCRIPTION
## Problem
Surface fault rupture (SFR) hazard layer never returned results on the hazards
report page. The AOI polygon INTERSECTS query silently returned 0 features for
every request — no error, just empty.

## Root cause
Two config gaps in `hazard-unit-map.ts`, both defaulting to legacy GeoServer
conventions the SFR layer had already moved past:

1. `getGeometryField('SFR')` returned `'shape'` — the layer's actual geometry
   column is `geom`.
2. `getLayerCRS('SFR')` returned `'EPSG:26912'` — the layer's native storage
   CRS is actually `EPSG:3857`.

GeoServer's CQL `INTERSECTS` filter evaluates against the layer's native
storage CRS (the `srsName` param only reprojects output, not the filter
geometry), so the app was comparing UTM coordinates against Web Mercator
geometries — numerically disjoint, hence always 0 matches.

Verified against GeoServer directly: `DescribeFeatureType` confirms the geom
column name, and a raw feature query confirms
`urn:ogc:def:crs:EPSG::3857`. Re-querying the reported AOI with the corrected
field/CRS returns the expected 9 `SSZsfr` features.

## Fix
Added `SFR` to both `geometryFieldOverrides` (`geom`) and `crsOverrides`
(`EPSG:3857`), matching the QFF layer's already-correct override.

Also corrected a stale comment claiming `EPSG:3857` is the eventual migration
target — confirmed against `ugs-warehouse/src/ugs_warehouse/vector/transform.py`
that the real target is `EPSG:4326` (`TARGET_SRS = 4326`). `EPSG:3857` is just
GeoServer's current intermediate state for already-migrated layers.