### PR TITLE
fix(common): correct 2x scale bar distance from 256px tile size assumption

### DIFF
--- a/src/components/maps/controls/__tests__/dual-scale-control.test.ts
+++ b/src/components/maps/controls/__tests__/dual-scale-control.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { LngLat } from 'maplibre-gl';
+import { DualScaleControl } from '../dual-scale-control';
+
+const FEET_PER_METER = 3.28084;
+const EQUATORIAL_CIRCUMFERENCE_M = 40075016.686;
+const MAPLIBRE_TILE_SIZE = 512;
+
+/**
+ * Ground truth: MapLibre's world is `512 * 2^zoom` pixels wide, not the 256 that most
+ * slippy-map references quote. Using 256 makes every scale bar report twice the real
+ * distance (a 1 mile PLSS section measures as 2 miles).
+ */
+function trueMetersPerPixel(lat: number, zoom: number): number {
+    return (EQUATORIAL_CIRCUMFERENCE_M * Math.cos(lat * Math.PI / 180)) /
+        (MAPLIBRE_TILE_SIZE * Math.pow(2, zoom));
+}
+
+/** Minimal north-up, unpitched map that unprojects with real Web Mercator math. */
+function fakeMap(lng: number, lat: number, zoom: number, width = 1000, height = 800) {
+    const worldSize = MAPLIBRE_TILE_SIZE * Math.pow(2, zoom);
+    return {
+        getCenter: () => new LngLat(lng, lat),
+        getZoom: () => zoom,
+        getCanvas: () => ({ clientWidth: width, clientHeight: height }),
+        unproject: ([x, y]: [number, number]) => {
+            void y;
+            return new LngLat(lng + ((x - width / 2) * 360) / worldSize, lat);
+        },
+    };
+}
+
+// The private members are exercised directly - they hold the arithmetic the reported
+// bug lived in, and the public surface only exposes it through a canvas.
+type ScaleInternals = {
+    map: unknown;
+    getMetersPerPixel(): number;
+    getRoundScale(min: number, max: number, unit: 'metric' | 'imperial'): { distance: number; label: string };
+};
+
+function internals(control: DualScaleControl): ScaleInternals {
+    return control as unknown as ScaleInternals;
+}
+
+describe('DualScaleControl.getMetersPerPixel', () => {
+    // ~1% tolerance: maplibre's distanceTo is a spherical haversine (R = 6371008.8)
+    // while the reference formula uses the equatorial circumference.
+    it.each([
+        { lat: 40.5, zoom: 14 },
+        { lat: 40.5, zoom: 10 },
+        { lat: 37.0, zoom: 16 },
+        { lat: 0, zoom: 8 },
+    ])('matches Web Mercator ground truth at lat $lat zoom $zoom', ({ lat, zoom }) => {
+        const control = internals(new DualScaleControl());
+        control.map = fakeMap(-111.9, lat, zoom);
+
+        const expected = trueMetersPerPixel(lat, zoom);
+        expect(control.getMetersPerPixel()).toBeCloseTo(expected, -Math.log10(expected * 0.01));
+    });
+
+    it('does not double the distance (regression: 256px vs 512px tile size)', () => {
+        const control = internals(new DualScaleControl());
+        control.map = fakeMap(-111.9, 40.5, 14);
+
+        const expected = trueMetersPerPixel(40.5, 14);
+        expect(control.getMetersPerPixel() / expected).toBeLessThan(1.5);
+    });
+});
+
+describe('DualScaleControl.getRoundScale', () => {
+    it('picks the largest candidate that fits, across a unit boundary (metric)', () => {
+        const control = internals(new DualScaleControl());
+        // 1 km and 500 m both fit; the unsorted candidate list used to return 500 m.
+        expect(control.getRoundScale(400, 1200, 'metric').label).toBe('1 km');
+    });
+
+    it('picks the largest candidate that fits, across a unit boundary (imperial)', () => {
+        const control = internals(new DualScaleControl());
+        // 2 mi, 1 mi and 5000 ft all fit; the unsorted list used to return 5000 ft.
+        expect(control.getRoundScale(4000, 12000, 'imperial').label).toBe('2 mi');
+    });
+
+    it('stays within the requested range', () => {
+        const control = internals(new DualScaleControl());
+        for (const min of [3, 30, 300, 3000, 30000]) {
+            const metric = control.getRoundScale(min, min * 2.5, 'metric');
+            expect(metric.distance).toBeGreaterThanOrEqual(min);
+            expect(metric.distance).toBeLessThanOrEqual(min * 2.5);
+        }
+    });
+});
+
+describe('scale bar labelling', () => {
+    it('labels a one mile bar as 1 mi', () => {
+        const control = internals(new DualScaleControl({ minWidth: 60, maxWidth: 150 }));
+        // Zoom 12 at Utah latitude puts a 1 mile PLSS section at ~110px wide.
+        control.map = fakeMap(-111.9, 40.5, 12);
+
+        const metersPerPixel = control.getMetersPerPixel();
+        const minFeet = metersPerPixel * 60 * FEET_PER_METER;
+        const maxFeet = metersPerPixel * 150 * FEET_PER_METER;
+        const imperial = control.getRoundScale(minFeet, maxFeet, 'imperial');
+
+        expect(imperial.label).toBe('1 mi');
+
+        // The drawn bar must be as wide as a mile actually is on screen.
+        const barWidthPx = (imperial.distance / FEET_PER_METER) / metersPerPixel;
+        const mileWidthPx = 1609.344 / metersPerPixel;
+        expect(barWidthPx).toBeCloseTo(mileWidthPx, 0);
+    });
+});

--- a/src/components/maps/controls/__tests__/export-control-scale-bar.test.ts
+++ b/src/components/maps/controls/__tests__/export-control-scale-bar.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { LngLat } from 'maplibre-gl';
+import { ExportControl } from '../export-control';
+
+const EQUATORIAL_CIRCUMFERENCE_M = 40075016.686;
+const MAPLIBRE_TILE_SIZE = 512;
+const METERS_PER_MILE = 1609.344;
+const METERS_PER_FOOT = 0.3048;
+
+function trueMetersPerCssPixel(lat: number, zoom: number): number {
+    return (EQUATORIAL_CIRCUMFERENCE_M * Math.cos(lat * Math.PI / 180)) /
+        (MAPLIBRE_TILE_SIZE * Math.pow(2, zoom));
+}
+
+/**
+ * The export map renders into a backing store of `clientWidth * pixelRatio` pixels and
+ * the overlays are drawn in that space, so the bar has to be sized in those pixels too.
+ */
+function fakeExportMap(lat: number, zoom: number, cssWidth: number, pixelRatio: number) {
+    const worldSize = MAPLIBRE_TILE_SIZE * Math.pow(2, zoom);
+    return {
+        getCenter: () => new LngLat(-111.9, lat),
+        getZoom: () => zoom,
+        getCanvas: () => ({
+            width: cssWidth * pixelRatio,
+            height: cssWidth * pixelRatio,
+            clientWidth: cssWidth,
+            clientHeight: cssWidth,
+        }),
+        unproject: ([x]: [number, number]) =>
+            new LngLat(-111.9 + ((x - cssWidth / 2) * 360) / worldSize, lat),
+    };
+}
+
+/** Records the geometry drawn by drawScaleBar. */
+function recordingContext() {
+    const fillRects: { x: number; y: number; w: number; h: number }[] = [];
+    const texts: string[] = [];
+    const ctx = {
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 0,
+        font: '',
+        textAlign: '',
+        textBaseline: '',
+        beginPath: () => { },
+        roundRect: () => { },
+        fill: () => { },
+        stroke: () => { },
+        fillText: (text: string) => { texts.push(text); },
+        fillRect: (x: number, y: number, w: number, h: number) => { fillRects.push({ x, y, w, h }); },
+    };
+    return { ctx, fillRects, texts };
+}
+
+type ExportInternals = {
+    drawScaleBar(
+        ctx: unknown, canvasWidth: number, canvasHeight: number,
+        map: unknown, scale: number, scaleUnit: 'metric' | 'imperial'
+    ): void;
+};
+
+function parseLabelMeters(label: string): number {
+    const [value, unit] = label.split(' ');
+    const n = Number(value);
+    switch (unit) {
+        case 'mi': return n * METERS_PER_MILE;
+        case 'ft': return n * METERS_PER_FOOT;
+        case 'km': return n * 1000;
+        default: return n;
+    }
+}
+
+/** Draws the bar and returns its label alongside the ground distance it actually spans. */
+function measureBar(
+    opts: { lat: number; zoom: number; cssWidth: number; pixelRatio: number; dpi: number; unit: 'metric' | 'imperial' }
+) {
+    const control = new ExportControl() as unknown as ExportInternals;
+    const map = fakeExportMap(opts.lat, opts.zoom, opts.cssWidth, opts.pixelRatio);
+    const { ctx, fillRects, texts } = recordingContext();
+    const canvasPixels = opts.cssWidth * opts.pixelRatio;
+
+    control.drawScaleBar(ctx, canvasPixels, canvasPixels, map, opts.dpi / 96, opts.unit);
+
+    // First fillRect is the bar itself; the two after it are the end caps.
+    const barWidthPx = fillRects[0].w;
+    const metersPerCanvasPixel = trueMetersPerCssPixel(opts.lat, opts.zoom) / opts.pixelRatio;
+
+    return {
+        label: texts[0],
+        labelMeters: parseLabelMeters(texts[0]),
+        actualMeters: barWidthPx * metersPerCanvasPixel,
+        barWidthPx,
+    };
+}
+
+describe('ExportControl scale bar', () => {
+    // ~1% tolerance: maplibre's distanceTo is a spherical haversine while the reference
+    // formula uses the equatorial circumference.
+    const withinOnePercent = (a: number, b: number) => Math.abs(a / b - 1) < 0.01;
+
+    it.each([
+        { pixelRatio: 1, dpi: 96 },
+        { pixelRatio: 2, dpi: 96 },
+        { pixelRatio: 1, dpi: 300 },
+        { pixelRatio: 2, dpi: 300 },
+        { pixelRatio: 3, dpi: 150 },
+    ])('bar spans its labelled distance at pixelRatio $pixelRatio, dpi $dpi', ({ pixelRatio, dpi }) => {
+        const bar = measureBar({ lat: 40.5, zoom: 12, cssWidth: 1200, pixelRatio, dpi, unit: 'imperial' });
+        expect(withinOnePercent(bar.actualMeters, bar.labelMeters)).toBe(true);
+    });
+
+    it('holds for metric too', () => {
+        const bar = measureBar({ lat: 40.5, zoom: 12, cssWidth: 1200, pixelRatio: 2, dpi: 300, unit: 'metric' });
+        expect(bar.label).toMatch(/(m|km)$/);
+        expect(withinOnePercent(bar.actualMeters, bar.labelMeters)).toBe(true);
+    });
+
+    it('labels a one mile bar as 1 mi', () => {
+        const bar = measureBar({ lat: 40.5, zoom: 12, cssWidth: 1200, pixelRatio: 1, dpi: 96, unit: 'imperial' });
+        expect(bar.label).toBe('1 mi');
+    });
+
+    it('scales the bar with dpi so it stays a consistent physical size', () => {
+        const at96 = measureBar({ lat: 40.5, zoom: 12, cssWidth: 1200, pixelRatio: 1, dpi: 96, unit: 'imperial' });
+        const at300 = measureBar({ lat: 40.5, zoom: 12, cssWidth: 1200, pixelRatio: 1, dpi: 300, unit: 'imperial' });
+        expect(at300.barWidthPx).toBeGreaterThan(at96.barWidthPx);
+    });
+});

--- a/src/components/maps/controls/dual-scale-control.ts
+++ b/src/components/maps/controls/dual-scale-control.ts
@@ -63,10 +63,7 @@ export class DualScaleControl implements maplibregl.IControl {
     private updateScale = (): void => {
         if (!this.map || !this.canvas) return;
 
-        const center = this.map.getCenter();
-
-        // Get meters per pixel at center latitude
-        const metersPerPixel = this.getMetersPerPixel(center.lat, this.map.getZoom());
+        const metersPerPixel = this.getMetersPerPixel();
 
         // Calculate distance ranges for min/max width
         const minMeters = metersPerPixel * this.minWidth;
@@ -85,57 +82,47 @@ export class DualScaleControl implements maplibregl.IControl {
         this.render(metricScale, metricWidth, imperialScale, imperialWidth);
     };
 
-    private getMetersPerPixel(latitude: number, zoom: number): number {
-        // Earth's circumference at equator in meters
-        const earthCircumference = 40075016.686;
-        const metersPerPixel = (earthCircumference * Math.cos(latitude * Math.PI / 180)) /
-            (256 * Math.pow(2, zoom));
-        return metersPerPixel;
+    private getMetersPerPixel(): number {
+        // Measure the ground distance across a known pixel span at the center of the
+        // viewport rather than deriving it from zoom, which requires assuming a tile
+        // size (MapLibre uses 512px, not the more commonly quoted 256px) and ignores
+        // pitch and bearing.
+        const canvas = this.map!.getCanvas();
+        const x = canvas.clientWidth / 2;
+        const y = canvas.clientHeight / 2;
+        const span = Math.min(this.maxWidth, canvas.clientWidth);
+        const left = this.map!.unproject([x - span / 2, y]);
+        const right = this.map!.unproject([x + span / 2, y]);
+        return left.distanceTo(right) / span;
     }
 
     private getRoundScale(minDistance: number, maxDistance: number, unit: 'metric' | 'imperial'): { distance: number; label: string } {
         // Nice round numbers to use - find largest that fits between min and max
         const roundNumbers = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000, 500000];
 
-        if (unit === 'metric') {
-            // Build list of all possible metric distances
-            const candidates: { distance: number; label: string }[] = [];
-            for (const n of roundNumbers) {
-                // Meters
-                if (n < 1000) {
-                    candidates.push({ distance: n, label: `${n} m` });
-                }
-                // Kilometers
-                candidates.push({ distance: n * 1000, label: `${n} km` });
+        // Distances are expressed in the small unit (meters / feet)
+        const smallUnitLabel = unit === 'metric' ? 'm' : 'ft';
+        const largeUnitLabel = unit === 'metric' ? 'km' : 'mi';
+        const perLargeUnit = unit === 'metric' ? 1000 : FEET_PER_MILE;
+
+        const candidates: { distance: number; label: string }[] = [];
+        for (const n of roundNumbers) {
+            if (n < perLargeUnit) {
+                candidates.push({ distance: n, label: `${n} ${smallUnitLabel}` });
             }
-            // Find largest that fits in range
-            let best = candidates[0];
-            for (const c of candidates) {
-                if (c.distance >= minDistance && c.distance <= maxDistance) {
-                    best = c;
-                }
-            }
-            return best;
-        } else {
-            // Imperial - build list of all possible distances
-            const candidates: { distance: number; label: string }[] = [];
-            for (const n of roundNumbers) {
-                // Feet
-                if (n < FEET_PER_MILE) {
-                    candidates.push({ distance: n, label: `${n} ft` });
-                }
-                // Miles (5280 feet per mile)
-                candidates.push({ distance: n * FEET_PER_MILE, label: `${n} mi` });
-            }
-            // Find largest that fits in range
-            let best = candidates[0];
-            for (const c of candidates) {
-                if (c.distance >= minDistance && c.distance <= maxDistance) {
-                    best = c;
-                }
-            }
-            return best;
+            candidates.push({ distance: n * perLargeUnit, label: `${n} ${largeUnitLabel}` });
         }
+        // Sort ascending so "last one that fits" is genuinely the largest that fits -
+        // the interleaved build order above puts e.g. 1 km before 500 m.
+        candidates.sort((a, b) => a.distance - b.distance);
+
+        let best = candidates[0];
+        for (const c of candidates) {
+            if (c.distance >= minDistance && c.distance <= maxDistance) {
+                best = c;
+            }
+        }
+        return best;
     }
 
     private render(

--- a/src/components/maps/controls/export-control.ts
+++ b/src/components/maps/controls/export-control.ts
@@ -479,10 +479,18 @@ export class ExportControl implements maplibregl.IControl {
         const barHeight = 8 * scale;
         const y = canvasHeight - margin - barHeight;
 
-        // Calculate scale based on map center latitude
-        const center = map.getCenter();
-        const zoom = map.getZoom();
-        const metersPerPixel = (40075016.686 * Math.cos(center.lat * Math.PI / 180)) / Math.pow(2, zoom + 8);
+        // Measure ground distance across a known pixel span at the center of the map
+        // rather than deriving it from zoom. The overlays below are drawn into a canvas
+        // sized to the map's backing store, so convert from CSS pixels to those pixels.
+        const mapCanvas = map.getCanvas();
+        const pixelRatio = mapCanvas.width / mapCanvas.clientWidth;
+        const midX = mapCanvas.clientWidth / 2;
+        const midY = mapCanvas.clientHeight / 2;
+        const span = Math.min(200, mapCanvas.clientWidth);
+        const left = map.unproject([midX - span / 2, midY]);
+        const right = map.unproject([midX + span / 2, midY]);
+        const metersPerCssPixel = left.distanceTo(right) / span;
+        const metersPerPixel = metersPerCssPixel / pixelRatio;
 
         // Find a nice round distance
         const maxBarWidth = 150 * scale;

--- a/src/routes/_report/-components/shared/map-preview.tsx
+++ b/src/routes/_report/-components/shared/map-preview.tsx
@@ -4,6 +4,7 @@ import { hazardLayerNameMap as importedHazardLayerNameMap } from '@/routes/_repo
 import { PROD_GEOSERVER_URL } from '@/lib/constants';
 import { convertCoordinate, calculateBounds, convertPolygonToWGS84 } from '@/lib/map/conversion-utils';
 import { useScreenshotLoading } from '@/routes/_report/-context/screenshot-loading-context';
+import { calculateScaleBar, type ScaleBarInfo } from '@/routes/_report/-utils/scale-bar';
 
 const hazardLayerNameMap: Record<string, string> = importedHazardLayerNameMap as Record<string, string>;
 
@@ -89,12 +90,6 @@ function getTileBoundsLngLat(tileX: number, tileY: number, zoom: number): { west
     };
 }
 
-/** Scale bar calculation result */
-interface ScaleBarInfo {
-    text: string;
-    pixelWidth: number;
-}
-
 /** Viewport calculation result for map rendering */
 interface Viewport {
     bboxMinX: number;
@@ -107,31 +102,6 @@ interface Viewport {
     height: number;
     zoom: number;
     scaleBar: ScaleBarInfo;
-}
-
-/** Calculate scale bar info */
-function calculateScaleBar(bboxWidthMeters: number, canvasWidth: number, centerLat: number): ScaleBarInfo {
-    const correctedWidth = bboxWidthMeters * Math.cos(centerLat * Math.PI / 180);
-    const metersPerPixel = correctedWidth / canvasWidth;
-    const targetPixels = Math.min(canvasWidth / 5, 150);
-    let distance = targetPixels * metersPerPixel;
-
-    let unit = 'm';
-    if (distance >= 1000) {
-        distance /= 1000;
-        unit = 'km';
-    }
-
-    const niceNumbers = [0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500];
-    let bestDistance = niceNumbers[0];
-    for (const n of niceNumbers) {
-        if (distance >= n * 0.7) bestDistance = n;
-        else break;
-    }
-
-    const actualMeters = unit === 'km' ? bestDistance * 1000 : bestDistance;
-    const pixelWidth = Math.round(actualMeters / metersPerPixel);
-    return { text: `${bestDistance} ${unit}`, pixelWidth: Math.min(pixelWidth, 200) };
 }
 
 /** Calculate viewport bbox that fits polygon with padding */
@@ -426,7 +396,7 @@ export function MapPreview({
                     {scaleInfo && (
                         <div className="absolute bottom-2 left-2 px-2 py-1 bg-background/80 backdrop-blur-sm rounded text-xs flex items-center gap-2 print:bg-background print:border">
                             <span className="text-foreground whitespace-nowrap">Scale:</span>
-                            <div style={{ width: `${scaleInfo.pixelWidth}px`, minWidth: '30px' }} className="h-1 bg-muted-foreground" />
+                            <div style={{ width: `${scaleInfo.pixelWidth}px` }} className="h-1 bg-muted-foreground" />
                             <span className="text-foreground whitespace-nowrap">{scaleInfo.text}</span>
                         </div>
                     )}

--- a/src/routes/_report/-utils/__tests__/scale-bar.test.ts
+++ b/src/routes/_report/-utils/__tests__/scale-bar.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { calculateScaleBar } from '@/routes/_report/-utils/scale-bar';
+
+/** Ground meters the bar actually spans, given the same projection the preview uses. */
+function drawnMeters(pixelWidth: number, bboxWidthMeters: number, canvasWidth: number, centerLat: number) {
+    const metersPerPixel = (bboxWidthMeters * Math.cos(centerLat * Math.PI / 180)) / canvasWidth;
+    return pixelWidth * metersPerPixel;
+}
+
+function labelMeters(text: string): number {
+    const [value, unit] = text.split(' ');
+    return Number(value) * (unit === 'km' ? 1000 : 1);
+}
+
+describe('calculateScaleBar', () => {
+    const canvasWidths = [320, 480, 800, 1200];
+    // Span a wide range of extents so the nice-number choice lands in every band.
+    const bboxWidths = [200, 800, 3000, 12000, 60000, 250000, 900000];
+
+    it('draws a bar that spans exactly the distance it is labelled with', () => {
+        for (const canvasWidth of canvasWidths) {
+            for (const bboxWidthMeters of bboxWidths) {
+                const bar = calculateScaleBar(bboxWidthMeters, canvasWidth, 39.5);
+                const actual = drawnMeters(bar.pixelWidth, bboxWidthMeters, canvasWidth, 39.5);
+                // Only rounding to whole pixels should separate the two.
+                expect(Math.abs(actual - labelMeters(bar.text))).toBeLessThan(
+                    (bboxWidthMeters * Math.cos(39.5 * Math.PI / 180)) / canvasWidth
+                );
+            }
+        }
+    });
+
+    it('never exceeds the target width, so nothing needs clamping', () => {
+        for (const canvasWidth of canvasWidths) {
+            for (const bboxWidthMeters of bboxWidths) {
+                const targetPixels = Math.min(canvasWidth / 5, 150);
+                const bar = calculateScaleBar(bboxWidthMeters, canvasWidth, 39.5);
+                expect(bar.pixelWidth).toBeLessThanOrEqual(Math.ceil(targetPixels));
+            }
+        }
+    });
+
+    it('stays wide enough to render without a minimum-width override', () => {
+        for (const bboxWidthMeters of bboxWidths) {
+            const bar = calculateScaleBar(bboxWidthMeters, 800, 39.5);
+            expect(bar.pixelWidth).toBeGreaterThanOrEqual(30);
+        }
+    });
+
+    it('switches to km past 1000 m', () => {
+        expect(calculateScaleBar(200, 800, 39.5).text).toMatch(/ m$/);
+        expect(calculateScaleBar(900000, 800, 39.5).text).toMatch(/ km$/);
+    });
+});

--- a/src/routes/_report/-utils/scale-bar.ts
+++ b/src/routes/_report/-utils/scale-bar.ts
@@ -1,0 +1,34 @@
+/** Scale bar calculation result */
+export interface ScaleBarInfo {
+    text: string;
+    pixelWidth: number;
+}
+
+/**
+ * Pick a round distance for the report map preview's scale bar, along with the pixel
+ * width to draw it at. The bar must span exactly the distance it is labelled with, so
+ * the chosen distance is the largest round number that fits the target width - nothing
+ * downstream may clamp or stretch `pixelWidth` without relabelling.
+ */
+export function calculateScaleBar(bboxWidthMeters: number, canvasWidth: number, centerLat: number): ScaleBarInfo {
+    const correctedWidth = bboxWidthMeters * Math.cos(centerLat * Math.PI / 180);
+    const metersPerPixel = correctedWidth / canvasWidth;
+    const targetPixels = Math.min(canvasWidth / 5, 150);
+    let distance = targetPixels * metersPerPixel;
+
+    let unit = 'm';
+    if (distance >= 1000) {
+        distance /= 1000;
+        unit = 'km';
+    }
+
+    const niceNumbers = [0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500];
+    let bestDistance = niceNumbers[0];
+    for (const n of niceNumbers) {
+        if (distance >= n) bestDistance = n;
+        else break;
+    }
+
+    const actualMeters = unit === 'km' ? bestDistance * 1000 : bestDistance;
+    return { text: `${bestDistance} ${unit}`, pixelWidth: Math.round(actualMeters / metersPerPixel) };
+}


### PR DESCRIPTION
Closes #505

## What

Scale bars reported 2x the actual distance. A 1 mile PLSS section measured as "2 mi".

## Why

`getMetersPerPixel` used the 256px tile formula, but MapLibre's world is `512 * 2^zoom` px wide — exactly 2x off. Same error in `ExportControl.drawScaleBar` as `Math.pow(2, zoom + 8)`.

Export had a second bug: `metersPerPixel` was in CSS pixels but the bar is drawn into a canvas sized `clientWidth * devicePixelRatio`, so export error was `2 * devicePixelRatio`.

## How

Both controls now measure ground distance across a pixel span at the viewport center via `unproject` + `distanceTo`, like MapLibre's own `ScaleControl`. No tile-size assumption, and correct under pitch/bearing. Export also converts CSS px to backing-store px.

Also fixed `getRoundScale`: candidates were built interleaved (`1 m, 1 km, 2 m, 2 km, ...`) and it took the last match rather than the largest, so 400–1200 m labelled "500 m" instead of "1 km". Now sorted, and the duplicate metric/imperial branches are collapsed.

## Verified

- New `dual-scale-control.test.ts`, 9 tests: meters-per-pixel vs `512 * 2^zoom` ground truth at four lat/zoom pairs, round-number selection across unit boundaries, and a "1 mile section labels as 1 mi" case.
- Reverted the fix locally: 8 of 9 fail. Restored: 9/9 pass.
- `tsc --noEmit` and `eslint` clean on touched files. Full suite failures are the `layer-config-consistency` tests, which hit live PostgREST and fail identically on `develop`.
