### PR TITLE
feat(common): shapefile, geopackage, geodatabase and flatgeobuf downloads via gdal3.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "embla-carousel-react": "^8.3.0",
         "fflate": "^0.8.2",
         "firebase": "^12.3.0",
+        "gdal3.js": "^2.8.1",
         "hyparquet": "^1.25.6",
         "jspdf": "^4.2.0",
         "lucide-react": "^0.544.0",
@@ -8552,6 +8553,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -9862,6 +9869,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gdal3.js": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/gdal3.js/-/gdal3.js-2.8.1.tgz",
+      "integrity": "sha512-Zg3T0vyDAPJ7kyyhyjhmG2OvUg7Xpn+Uh9+hTMIKXj4JDrJPERTrA8Q9wpthtqX9yvaftg7aS9YIrot4p7cNLA==",
+      "license": "LGPL-2.1-or-later",
+      "dependencies": {
+        "detect-node": "^2.1.0",
+        "xml-js": "^1.6.11"
       }
     },
     "node_modules/gensync": {
@@ -15113,6 +15130,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -18111,6 +18137,18 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "embla-carousel-react": "^8.3.0",
     "fflate": "^0.8.2",
     "firebase": "^12.3.0",
+    "gdal3.js": "^2.8.1",
     "hyparquet": "^1.25.6",
     "jspdf": "^4.2.0",
     "lucide-react": "^0.544.0",

--- a/src/components/data-table/query-results-table.tsx
+++ b/src/components/data-table/query-results-table.tsx
@@ -46,7 +46,8 @@ import type { HighlightFeature } from '@/components/maps/types';
 import { useZoomToFeature } from '@/hooks/use-zoom-to-feature';
 import { cn } from '@/lib/utils';
 import { useBulkRelatedTable } from '@/hooks/use-bulk-related-table';
-import { exportTableData } from './table-export-utils';
+import { exportTableData, type TableExportFormat } from './table-export-utils';
+import { EXPORT_FORMATS, GDAL_FORMATS } from '@/lib/export-formats';
 import { ExpandedRelatedTable } from './expanded-related-table';
 import { useTableColumns } from './use-table-columns';
 import { useTableData } from './use-table-data';
@@ -65,6 +66,15 @@ interface QueryResultsTableProps {
 }
 
 const EMPTY_COLUMN_FILTERS: { id: string; value: string }[] = [];
+
+
+// Labels/hints come from the shared export registry so the table menu and the parquet
+// download menu can't drift apart.
+const GDAL_TABLE_FORMATS = GDAL_FORMATS.map(format => ({
+    format,
+    label: EXPORT_FORMATS[format].label,
+    hint: EXPORT_FORMATS[format].hint,
+}));
 
 export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeChange, selectedFeatureRefs = [], onSelectedFeaturesChange, onHighlightChange, disableExport = false }: QueryResultsTableProps) {
     const { zoomTo, zoomToAll } = useZoomToFeature({ onHighlightChange });
@@ -255,7 +265,7 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
 
     // Export emits all feature properties (not just popupFields/visible columns).
     // Filter state determines row scope; column visibility is UI-only.
-    const handleExport = useCallback((format: 'csv' | 'geojson') => {
+    const handleExport = useCallback((format: TableExportFormat) => {
         const filteredRows = table.getFilteredRowModel().rows.map(r => r.original);
         exportTableData({
             format,
@@ -424,6 +434,12 @@ export function QueryResultsTable({ layerContent, onClose, viewMode, onViewModeC
                             <DropdownMenuItem onClick={() => handleExport('geojson')}>
                                 GeoJSON
                             </DropdownMenuItem>
+                            {GDAL_TABLE_FORMATS.map(({ format, label, hint }) => (
+                                <DropdownMenuItem key={format} onClick={() => handleExport(format)}>
+                                    {label}
+                                    <span className="ml-auto text-xs text-muted-foreground">{hint}</span>
+                                </DropdownMenuItem>
+                            ))}
                             {hasRelatedTables && (
                                 <>
                                     <DropdownMenuSeparator />

--- a/src/components/data-table/table-export-utils.ts
+++ b/src/components/data-table/table-export-utils.ts
@@ -2,6 +2,7 @@ import { isValidElement } from 'react';
 import type { RelatedTable, FieldConfig } from '@/lib/types/mapping-types';
 import type { RelatedDataMap } from '@/hooks/use-bulk-related-table';
 import { buildCSV, downloadCsvString, downloadGeoJSON, downloadZip, geojsonToWKT } from '@/lib/download-utils';
+import { isInternalColumn } from '@/lib/export-fields';
 import { formatFieldValue } from '@/lib/field-formatting';
 import { formatNumeric } from '@/lib/utils';
 import type { RowData, ColumnConfig } from './types';
@@ -29,7 +30,8 @@ function safeName(s: string): string {
 
 // Union of all property keys across rows, merged with configured labels/formatting.
 // Configured (popupField) columns come first in their declared order; remaining raw
-// property keys are appended alphabetically. Internal/_-prefixed keys are dropped.
+// property keys are appended alphabetically. Warehouse bookkeeping keys are dropped —
+// the same list the parquet downloads use, so both agree on a dataset's fields.
 function buildMainColumns(data: RowData[], columnConfigs: ColumnConfig[]): MainColumn[] {
     const cols: MainColumn[] = [];
     const seen = new Set<string>();
@@ -37,6 +39,7 @@ function buildMainColumns(data: RowData[], columnConfigs: ColumnConfig[]): MainC
     for (const cfg of columnConfigs) {
         if (cfg.fieldConfig?.type === 'custom') continue;
         if (seen.has(cfg.field)) continue;
+        if (isInternalColumn(cfg.field)) continue;
         seen.add(cfg.field);
         cols.push({ field: cfg.field, label: cfg.label, fieldConfig: cfg.fieldConfig });
     }
@@ -45,7 +48,7 @@ function buildMainColumns(data: RowData[], columnConfigs: ColumnConfig[]): MainC
     for (const row of data) {
         for (const key of Object.keys(row.properties)) {
             if (seen.has(key)) continue;
-            if (key === 'geometry' || key === 'bbox' || key.startsWith('_')) continue;
+            if (isInternalColumn(key)) continue;
             seen.add(key);
             extras.push(key);
         }

--- a/src/components/data-table/table-export-utils.ts
+++ b/src/components/data-table/table-export-utils.ts
@@ -1,7 +1,7 @@
 import { isValidElement } from 'react';
 import type { RelatedTable, FieldConfig } from '@/lib/types/mapping-types';
 import type { RelatedDataMap } from '@/hooks/use-bulk-related-table';
-import { buildCSV, downloadCsvString, downloadGeoJSON, downloadZip, geojsonToWKT } from '@/lib/download-utils';
+import { buildCSV, downloadBytes, downloadCsvString, downloadGeoJSON, downloadZip, geojsonToWKT } from '@/lib/download-utils';
 import { isInternalColumn } from '@/lib/export-fields';
 import { formatFieldValue } from '@/lib/field-formatting';
 import { formatNumeric } from '@/lib/utils';
@@ -13,8 +13,11 @@ interface MainColumn {
     fieldConfig?: FieldConfig;
 }
 
+/** Formats the table can emit. The gdal ones go through gdal3.js, same as parquet downloads. */
+export type TableExportFormat = 'csv' | 'geojson' | 'gpkg' | 'shp' | 'gdb' | 'fgb';
+
 export interface TableExportParams {
-    format: 'csv' | 'geojson';
+    format: TableExportFormat;
     dataToExport: RowData[];
     layerTitle: string;
     columnConfigs: ColumnConfig[];
@@ -79,9 +82,59 @@ export function exportTableData({
 
     if (format === 'csv') {
         exportAsCSV(dataToExport, filename, mainColumns, effectiveRelated, effectiveDataMaps);
-    } else {
+    } else if (format === 'geojson') {
         exportAsGeoJSON(dataToExport, filename, mainColumns, effectiveRelated, effectiveDataMaps);
+    } else {
+        // Fire and forget: gdal3.js loads lazily, so this resolves after the click.
+        void exportViaGdal(format, dataToExport, filename, mainColumns, effectiveRelated, effectiveDataMaps);
     }
+}
+
+/**
+ * GPKG / SHP / GDB / FGB via gdal3.js. Flat formats can't hold the nested `related`
+ * object the GeoJSON export uses, so related rows ride along as sibling CSVs in a zip.
+ */
+async function exportViaGdal(
+    format: Exclude<TableExportFormat, 'csv' | 'geojson'>,
+    dataToExport: RowData[],
+    filename: string,
+    mainColumns: MainColumn[],
+    relatedTables: RelatedTable[],
+    relatedDataMaps: RelatedDataMap[],
+): Promise<void> {
+    const fields = mainColumns.map(c => c.field);
+    const features = dataToExport.map(row => {
+        const properties: Record<string, unknown> = {};
+        for (const field of fields) {
+            if (field in row.properties) properties[field] = row.properties[field];
+        }
+        return { type: 'Feature' as const, geometry: row.feature.geometry, properties };
+    });
+    const geojson = JSON.stringify({ type: 'FeatureCollection', features });
+
+    // No declared types here (unlike parquet), so a column counts as float only when some
+    // value actually has a fractional part — otherwise GDAL reads it as Integer.
+    const floatCols = fields.filter(field =>
+        dataToExport.some(row => {
+            const v = row.properties[field];
+            return typeof v === 'number' && !Number.isInteger(v);
+        }),
+    );
+
+    const { convertGeoJSON, GDAL_TARGETS } = await import('@/lib/gdal-export');
+    const { bytes, filename: outName } = await convertGeoJSON(geojson, filename, GDAL_TARGETS[format], 4326, fields, floatCols);
+
+    const relatedFiles: Record<string, string> = {};
+    relatedTables.forEach((table, idx) => {
+        const name = safeName(table.fieldLabel || `table-${idx + 1}`);
+        relatedFiles[`related-${name}.csv`] = buildRelatedCsv(dataToExport, table, relatedDataMaps[idx]);
+    });
+
+    if (Object.keys(relatedFiles).length === 0) {
+        downloadBytes(bytes, outName);
+        return;
+    }
+    downloadZip({ [outName]: bytes, ...relatedFiles }, filename);
 }
 
 const FEATURE_KEY_HEADER = '_feature_key';

--- a/src/components/maps/parquet-download-menu.tsx
+++ b/src/components/maps/parquet-download-menu.tsx
@@ -32,8 +32,12 @@ interface ParquetDownloadMenuProps {
 export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parquetUrl, layerTitle, relatedTables, compact = false }) => {
     // Schema probe (a small range request) waits for the menu to actually open, so
     // rendering a list of these doesn't fire a network request per row up front.
+    // `enabled` (not the query key) gates the fetch — selecting a DropdownMenuItem
+    // auto-closes the menu, and closing sets `open` false right as the mutation
+    // fires; if that also blanked the query key, the just-fetched geometryColumn
+    // would vanish mid-export and every geometry format would fail.
     const [open, setOpen] = useState(false);
-    const { data: schema, isLoading: schemaLoading, isError: schemaError } = useParquetSchema(open ? parquetUrl : undefined);
+    const { data: schema, isLoading: schemaLoading, isError: schemaError } = useParquetSchema(parquetUrl, open);
     const [includeRelated, setIncludeRelated] = useState(true);
     const hasRelatedTables = (relatedTables?.length ?? 0) > 0;
 

--- a/src/components/maps/parquet-download-menu.tsx
+++ b/src/components/maps/parquet-download-menu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Download, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -14,6 +14,7 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useParquetSchema } from '@/hooks/use-parquet-schema';
 import { EXPORT_FORMATS, availableFormats, type ExportFormat } from '@/lib/export-formats';
+import { shapefileFieldChecks } from '@/lib/gdal-export';
 import type { RelatedTable } from '@/lib/types/mapping-types';
 
 interface ParquetDownloadMenuProps {
@@ -36,8 +37,31 @@ export const ParquetDownloadMenu: React.FC<ParquetDownloadMenuProps> = ({ parque
     const [includeRelated, setIncludeRelated] = useState(true);
     const hasRelatedTables = (relatedTables?.length ?? 0) > 0;
 
+    // Shapefile silently truncates field names past 10 chars and drops columns whose
+    // truncations collide. Warned up front from the schema we already have — the user
+    // can still proceed, but not unknowingly.
+    const shapefileIssues = useMemo(() => {
+        if (!schema) return null;
+        const attrs = schema.columns.filter(c => c !== schema.geometryColumn);
+        const { longNames, collisions, tooManyFields, fieldCount } = shapefileFieldChecks(attrs);
+        if (!longNames.length && !collisions.length && !tooManyFields) return null;
+        return { longNames, collisions, tooManyFields, fieldCount };
+    }, [schema]);
+
     const download = useMutation({
         mutationFn: async (format: ExportFormat) => {
+            if (format === 'shp' && shapefileIssues) {
+                const parts = [
+                    shapefileIssues.collisions.length
+                        ? `${shapefileIssues.collisions.length} column name(s) collide after truncation and will be dropped`
+                        : null,
+                    shapefileIssues.longNames.length
+                        ? `${shapefileIssues.longNames.length} name(s) shortened to 10 characters`
+                        : null,
+                    shapefileIssues.tooManyFields ? `${shapefileIssues.fieldCount} fields exceeds the 255 limit` : null,
+                ].filter(Boolean);
+                toast.warning('Shapefile format limits', { description: parts.join('; ') });
+            }
             const { exportParquet, safeFilename } = await import('@/lib/duckdb-export');
             await exportParquet({
                 parquetUrl,

--- a/src/hooks/use-parquet-schema.ts
+++ b/src/hooks/use-parquet-schema.ts
@@ -24,12 +24,21 @@ const fetchSchema = async (url: string): Promise<ParquetSchema> => {
     return { columns, geometryColumn, hasGeometry: !!geometryColumn, rowCount };
 };
 
-/** Probe a parquet URL's schema once, cache forever. Runs on mount when url is set. */
-export const useParquetSchema = (url: string | undefined) => {
+/**
+ * Probe a parquet URL's schema once, cache forever.
+ *
+ * `enabled` gates *fetching* only — the query key is always keyed on `url`, never
+ * blanked out. That matters for callers like the download menu that want to defer
+ * the fetch until first opened (`enabled: open`) but then close the menu right as
+ * a download starts: blanking the key on close would re-key to an empty-string
+ * cache slot and lose the just-fetched `geometryColumn` mid-export. Keeping the
+ * key stable means the cached result survives regardless of `enabled` toggling.
+ */
+export const useParquetSchema = (url: string | undefined, enabled = true) => {
     return useQuery({
         queryKey: queryKeys.modules.parquetSchema(url ?? ''),
         queryFn: () => fetchSchema(url!),
-        enabled: !!url,
+        enabled: !!url && enabled,
         staleTime: Infinity,
         retry: 1,
     });

--- a/src/lib/download-utils.ts
+++ b/src/lib/download-utils.ts
@@ -171,6 +171,14 @@ export function toGeoJSON<T extends Record<string, unknown>>(
   return { type: 'FeatureCollection', features }
 }
 
+/** Save raw bytes under `filename` — for binary formats built elsewhere (e.g. gdal3.js). */
+export function downloadBytes(bytes: Uint8Array, filename: string, mimeType = 'application/octet-stream'): void {
+  // Copy into a fresh ArrayBuffer so the Blob constructor accepts it whatever backs the view.
+  const copy = new Uint8Array(bytes.byteLength)
+  copy.set(bytes)
+  triggerDownload(new Blob([copy], { type: mimeType }), filename)
+}
+
 /**
  * Download data as GeoJSON file
  */

--- a/src/lib/duckdb-export.ts
+++ b/src/lib/duckdb-export.ts
@@ -79,25 +79,16 @@ interface GeoJSONBuild {
     floatCols: string[];
 }
 
-// Builds the FeatureCollection in JS: duckdb-wasm's GDAL GeoJSON writer crashes
-// ("Cannot write feature"), so we read geometry back as GeoJSON text plus property
-// columns and assemble it here. Reprojects to 4326 for RFC 7946 — source is hardcoded
-// EPSG:3857 (our current pipeline output); once parquets publish as 4326 this transform
-// must go, else it double-projects. always_xy keeps lon/lat ordering; Force2D drops the
-// spurious Z=0 the source carries on otherwise-2D geometry.
-//
-// Also the input to every gdal3.js conversion, which is why it reports column types:
-// GDAL's GeoJSON reader infers Integer for a float column whose values happen to be
-// whole, silently downcasting depth/elevation fields.
+// Assembled in JS because duckdb-wasm's GDAL GeoJSON writer crashes. Output is 4326
+// per RFC 7946, and is also the input to every gdal3.js conversion — hence the column
+// types, which stop GDAL downcasting whole-valued floats to Integer.
 const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnection(async (conn) => {
     if (!opts.geometryColumn) {
         throw new Error('This format requires a geometry column');
     }
     await loadSpatial(conn);
-    // Warehouse GeoParquet carries CRS metadata that spatial's GeoParquet reader chokes
-    // on ("stoi: no conversion"), which otherwise fails the read outright. Disabling the
-    // conversion hands us the raw WKB blob instead — and unlike reading before LOAD
-    // spatial, it works no matter what already loaded the extension.
+    // Warehouse CRS metadata makes spatial's GeoParquet reader throw "stoi: no conversion".
+    // Disabling it yields raw WKB, and works whatever already loaded the extension.
     await conn.query(`SET enable_geoparquet_conversion = false`);
 
     const escaped = escapeSql(opts.parquetUrl);
@@ -120,17 +111,15 @@ const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnect
     }
     const geom = geomIsBlob ? `ST_GeomFromWKB(${geomCol})` : geomCol;
 
-    // Source CRS varies: legacy CDN parquets are EPSG:3857 (metres), warehouse ones are
-    // OGC:CRS84 (degrees). Sniff rather than hardcode — transforming an already-4326
-    // source double-projects it into the ocean. Longitude never exceeds 180, Web
-    // Mercator easting is ~1e7, so the magnitude separates them unambiguously.
+    // CDN parquets are 3857, warehouse ones already 4326 — transforming the latter
+    // double-projects. Longitude caps at 180; Mercator easting is ~1e7, so magnitude tells.
     const probe = await conn.query(`
         SELECT max(abs(ST_X(ST_Centroid(${geom})))) AS max_x
         FROM (SELECT ${geomCol} FROM read_parquet('${escaped}') WHERE ${geomCol} IS NOT NULL LIMIT 100)
     `);
     const maxX = Number((probe.toArray()[0]?.toJSON() as Record<string, unknown>)?.max_x ?? 0);
     const needsTransform = maxX > 180;
-    // always_xy keeps lon/lat ordering; Force2D drops the spurious Z=0 some sources carry.
+    // always_xy keeps lon/lat order; Force2D drops the spurious Z=0 some sources carry.
     const geom4326 = needsTransform
         ? `ST_Force2D(ST_Transform(${geom}, 'EPSG:3857', 'EPSG:4326', true))`
         : `ST_Force2D(${geom})`;
@@ -152,9 +141,8 @@ const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnect
     return { geojson: `{"type":"FeatureCollection","features":[${features.join(',')}]}`, cols, floatCols };
 });
 
-// gpkg / shp / gdb / fgb all take the same route: DuckDB builds the GeoJSON, gdal3.js
-// writes the real format. The ~40MB GDAL payload is imported here so it only downloads
-// when one of these is picked, and is memoized after the first use.
+// DuckDB builds the GeoJSON, gdal3.js writes the real format. Imported here so its
+// ~40MB only downloads when one of these formats is picked.
 const gdalHandler = (format: ExportFormat): Handler => async (opts) => {
     opts.onProgress?.({ stage: 'converting', message: 'Reading features…' });
     const { geojson, cols, floatCols } = await buildGeoJSON(opts);

--- a/src/lib/duckdb-export.ts
+++ b/src/lib/duckdb-export.ts
@@ -32,6 +32,8 @@ export interface ExportOptions {
     format: ExportFormat;
     /** Geometry column name if present, else null — discovered via useParquetSchema */
     geometryColumn: string | null;
+    /** Output CRS for the gdal formats (shp/gpkg/gdb/fgb). Defaults to 4326. */
+    epsg?: number;
     /** Related tables configured on the layer (formation tops, geochemistry, etc). When
      * present + non-empty, `exportParquet` bundles them alongside the main file as a zip. */
     relatedTables?: RelatedTable[];
@@ -69,6 +71,110 @@ const bufferToBlob = async (
 
 type Handler = (opts: ExportOptions) => Promise<Blob>;
 
+interface GeoJSONBuild {
+    geojson: string;
+    /** Non-geometry column names, in parquet order. */
+    cols: string[];
+    /** The subset of `cols` typed DOUBLE/FLOAT/REAL/DECIMAL in the source. */
+    floatCols: string[];
+}
+
+// Builds the FeatureCollection in JS: duckdb-wasm's GDAL GeoJSON writer crashes
+// ("Cannot write feature"), so we read geometry back as GeoJSON text plus property
+// columns and assemble it here. Reprojects to 4326 for RFC 7946 — source is hardcoded
+// EPSG:3857 (our current pipeline output); once parquets publish as 4326 this transform
+// must go, else it double-projects. always_xy keeps lon/lat ordering; Force2D drops the
+// spurious Z=0 the source carries on otherwise-2D geometry.
+//
+// Also the input to every gdal3.js conversion, which is why it reports column types:
+// GDAL's GeoJSON reader infers Integer for a float column whose values happen to be
+// whole, silently downcasting depth/elevation fields.
+const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnection(async (conn) => {
+    if (!opts.geometryColumn) {
+        throw new Error('This format requires a geometry column');
+    }
+    await loadSpatial(conn);
+    // Warehouse GeoParquet carries CRS metadata that spatial's GeoParquet reader chokes
+    // on ("stoi: no conversion"), which otherwise fails the read outright. Disabling the
+    // conversion hands us the raw WKB blob instead — and unlike reading before LOAD
+    // spatial, it works no matter what already loaded the extension.
+    await conn.query(`SET enable_geoparquet_conversion = false`);
+
+    const escaped = escapeSql(opts.parquetUrl);
+    const geomCol = opts.geometryColumn;
+
+    const described = await conn.query(`DESCRIBE SELECT * FROM read_parquet('${escaped}')`);
+    const cols: string[] = [];
+    const floatCols: string[] = [];
+    let geomIsBlob = false;
+    for (const row of described.toArray()) {
+        const { column_name: name, column_type: type } = row.toJSON() as Record<string, unknown>;
+        const col = String(name);
+        const colType = String(type).toUpperCase();
+        if (col === geomCol) {
+            geomIsBlob = colType.includes('BLOB');
+            continue;
+        }
+        cols.push(col);
+        if (/DOUBLE|FLOAT|REAL|DECIMAL|NUMERIC/.test(colType)) floatCols.push(col);
+    }
+    const geom = geomIsBlob ? `ST_GeomFromWKB(${geomCol})` : geomCol;
+
+    // Source CRS varies: legacy CDN parquets are EPSG:3857 (metres), warehouse ones are
+    // OGC:CRS84 (degrees). Sniff rather than hardcode — transforming an already-4326
+    // source double-projects it into the ocean. Longitude never exceeds 180, Web
+    // Mercator easting is ~1e7, so the magnitude separates them unambiguously.
+    const probe = await conn.query(`
+        SELECT max(abs(ST_X(ST_Centroid(${geom})))) AS max_x
+        FROM (SELECT ${geomCol} FROM read_parquet('${escaped}') WHERE ${geomCol} IS NOT NULL LIMIT 100)
+    `);
+    const maxX = Number((probe.toArray()[0]?.toJSON() as Record<string, unknown>)?.max_x ?? 0);
+    const needsTransform = maxX > 180;
+    // always_xy keeps lon/lat ordering; Force2D drops the spurious Z=0 some sources carry.
+    const geom4326 = needsTransform
+        ? `ST_Force2D(ST_Transform(${geom}, 'EPSG:3857', 'EPSG:4326', true))`
+        : `ST_Force2D(${geom})`;
+
+    const result = await conn.query(`
+        SELECT
+            ST_AsGeoJSON(${geom4326}) AS __g,
+            * EXCLUDE (${geomCol})
+        FROM read_parquet('${escaped}')
+    `);
+
+    const features: string[] = [];
+    for (const row of result.toArray()) {
+        const obj = row.toJSON() as Record<string, unknown>;
+        const geomJson = obj.__g;
+        delete obj.__g;
+        features.push(`{"type":"Feature","geometry":${geomJson},"properties":${JSON.stringify(obj, jsonReplacer)}}`);
+    }
+    return { geojson: `{"type":"FeatureCollection","features":[${features.join(',')}]}`, cols, floatCols };
+});
+
+// gpkg / shp / gdb / fgb all take the same route: DuckDB builds the GeoJSON, gdal3.js
+// writes the real format. The ~40MB GDAL payload is imported here so it only downloads
+// when one of these is picked, and is memoized after the first use.
+const gdalHandler = (format: ExportFormat): Handler => async (opts) => {
+    opts.onProgress?.({ stage: 'converting', message: 'Reading features…' });
+    const { geojson, cols, floatCols } = await buildGeoJSON(opts);
+
+    opts.onProgress?.({ stage: 'converting', message: `Writing ${EXPORT_FORMATS[format].label}…` });
+    const { convertGeoJSON, GDAL_TARGETS } = await import('@/lib/gdal-export');
+    const { bytes, mime } = await convertGeoJSON(
+        geojson,
+        opts.filename,
+        GDAL_TARGETS[format],
+        opts.epsg ?? 4326,
+        cols,
+        floatCols,
+    );
+    // Copy into a fresh ArrayBuffer so Blob accepts it regardless of the underlying buffer kind.
+    const copy = new Uint8Array(bytes.byteLength);
+    copy.set(bytes);
+    return new Blob([copy], { type: mime });
+};
+
 const handlers: Record<ExportFormat, Handler> = {
     // Direct pass-through — no DuckDB needed.
     parquet: async (opts) => {
@@ -78,39 +184,11 @@ const handlers: Record<ExportFormat, Handler> = {
         return res.blob();
     },
 
-    // Build FeatureCollection in JS — duckdb-wasm's spatial GDAL GeoJSON writer
-    // crashes ("Cannot write feature"), so we read rows back as geometry-as-GeoJSON
-    // text plus property columns and assemble the FC manually. Reprojects to 4326
-    // for RFC 7946. Source is hardcoded EPSG:3857 (our current pipeline output);
-    // once parquets are published as 4326 this transform must be dropped, else it
-    // double-projects. always_xy keeps lon/lat ordering; Force2D drops the
-    // spurious Z=0 the source carries on otherwise-2D geometry.
-    geojson: (opts) => withConnection(async (conn) => {
-        if (!opts.geometryColumn) {
-            throw new Error('GeoJSON requires a geometry column');
-        }
-        await loadSpatial(conn);
-
+    geojson: async (opts) => {
         opts.onProgress?.({ stage: 'converting', message: 'Writing GeoJSON…' });
-        const escaped = escapeSql(opts.parquetUrl);
-        const geom = opts.geometryColumn;
-        const result = await conn.query(`
-            SELECT
-                ST_AsGeoJSON(ST_Force2D(ST_Transform(${geom}, 'EPSG:3857', 'EPSG:4326', true))) AS __g,
-                * EXCLUDE (${geom})
-            FROM read_parquet('${escaped}')
-        `);
-
-        const features: string[] = [];
-        for (const row of result.toArray()) {
-            const obj = row.toJSON() as Record<string, unknown>;
-            const geomJson = obj.__g;
-            delete obj.__g;
-            features.push(`{"type":"Feature","geometry":${geomJson},"properties":${JSON.stringify(obj, jsonReplacer)}}`);
-        }
-        const fc = `{"type":"FeatureCollection","features":[${features.join(',')}]}`;
-        return new Blob([fc], { type: EXPORT_FORMATS.geojson.mimeType });
-    }),
+        const { geojson } = await buildGeoJSON(opts);
+        return new Blob([geojson], { type: EXPORT_FORMATS.geojson.mimeType });
+    },
 
     csv: (opts) => withConnection(async (conn, db) => {
         const escaped = escapeSql(opts.parquetUrl);
@@ -128,6 +206,10 @@ const handlers: Record<ExportFormat, Handler> = {
         return bufferToBlob(db, virtualPath, EXPORT_FORMATS.csv.mimeType);
     }),
 
+    gpkg: gdalHandler('gpkg'),
+    shp: gdalHandler('shp'),
+    gdb: gdalHandler('gdb'),
+    fgb: gdalHandler('fgb'),
 };
 
 // BIGINT columns arrive as JS bigint; JSON.stringify rejects them. Convert to

--- a/src/lib/duckdb-export.ts
+++ b/src/lib/duckdb-export.ts
@@ -12,7 +12,7 @@
 
 import * as duckdb from '@duckdb/duckdb-wasm';
 import { EXPORT_FORMATS, type ExportFormat } from '@/lib/export-formats';
-import { withConnection, loadSpatial, escapeSql, queryParquetDistinctValues } from '@/lib/duckdb/client';
+import { withConnection, loadSpatial, escapeSql, quoteIdent, queryParquetDistinctValues } from '@/lib/duckdb/client';
 import { downloadZip } from '@/lib/download-utils';
 import { fetchRelatedRowsBulk, relatedRowsToCsv } from '@/lib/related-table-fetch';
 import type { RelatedTable } from '@/lib/types/mapping-types';
@@ -71,6 +71,14 @@ const bufferToBlob = async (
 
 type Handler = (opts: ExportOptions) => Promise<Blob>;
 
+// Internal columns the table export drops too (see table-export-utils buildMainColumns),
+// so both downloads carry the same fields.
+const isInternalColumn = (col: string): boolean => col === 'bbox' || col.startsWith('_');
+
+/** `EXCLUDE (...)` list for a parquet's geometry + internal columns, or '' when there's nothing to drop. */
+const excludeClause = (dropped: string[]): string =>
+    dropped.length ? ` EXCLUDE (${dropped.map(quoteIdent).join(', ')})` : '';
+
 interface GeoJSONBuild {
     geojson: string;
     /** Non-geometry column names, in parquet order. */
@@ -97,6 +105,7 @@ const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnect
     const described = await conn.query(`DESCRIBE SELECT * FROM read_parquet('${escaped}')`);
     const cols: string[] = [];
     const floatCols: string[] = [];
+    const dropped: string[] = [geomCol];
     let geomIsBlob = false;
     for (const row of described.toArray()) {
         const { column_name: name, column_type: type } = row.toJSON() as Record<string, unknown>;
@@ -104,6 +113,10 @@ const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnect
         const colType = String(type).toUpperCase();
         if (col === geomCol) {
             geomIsBlob = colType.includes('BLOB');
+            continue;
+        }
+        if (isInternalColumn(col)) {
+            dropped.push(col);
             continue;
         }
         cols.push(col);
@@ -127,7 +140,7 @@ const buildGeoJSON = (opts: ExportOptions): Promise<GeoJSONBuild> => withConnect
     const result = await conn.query(`
         SELECT
             ST_AsGeoJSON(${geom4326}) AS __g,
-            * EXCLUDE (${geomCol})
+            *${excludeClause(dropped)}
         FROM read_parquet('${escaped}')
     `);
 
@@ -180,12 +193,16 @@ const handlers: Record<ExportFormat, Handler> = {
 
     csv: (opts) => withConnection(async (conn, db) => {
         const escaped = escapeSql(opts.parquetUrl);
-        const selectClause = opts.geometryColumn ? `* EXCLUDE (${opts.geometryColumn})` : '*';
 
         opts.onProgress?.({ stage: 'downloading', message: 'Fetching parquet…' });
+        const described = await conn.query(`DESCRIBE SELECT * FROM read_parquet('${escaped}')`);
+        const dropped = described.toArray()
+            .map(row => String((row.toJSON() as Record<string, unknown>).column_name))
+            .filter(col => col === opts.geometryColumn || isInternalColumn(col));
+
         await conn.query(`
             CREATE OR REPLACE VIEW export_view AS
-            SELECT ${selectClause} FROM read_parquet('${escaped}')
+            SELECT *${excludeClause(dropped)} FROM read_parquet('${escaped}')
         `);
 
         opts.onProgress?.({ stage: 'converting', message: 'Writing CSV…' });

--- a/src/lib/duckdb-export.ts
+++ b/src/lib/duckdb-export.ts
@@ -14,6 +14,7 @@ import * as duckdb from '@duckdb/duckdb-wasm';
 import { EXPORT_FORMATS, type ExportFormat } from '@/lib/export-formats';
 import { withConnection, loadSpatial, escapeSql, quoteIdent, queryParquetDistinctValues } from '@/lib/duckdb/client';
 import { downloadZip } from '@/lib/download-utils';
+import { isInternalColumn } from '@/lib/export-fields';
 import { fetchRelatedRowsBulk, relatedRowsToCsv } from '@/lib/related-table-fetch';
 import type { RelatedTable } from '@/lib/types/mapping-types';
 
@@ -70,10 +71,6 @@ const bufferToBlob = async (
 // ── Per-format handlers ──────────────────────────────────────────────────────
 
 type Handler = (opts: ExportOptions) => Promise<Blob>;
-
-// Internal columns the table export drops too (see table-export-utils buildMainColumns),
-// so both downloads carry the same fields.
-const isInternalColumn = (col: string): boolean => col === 'bbox' || col.startsWith('_');
 
 /** `EXCLUDE (...)` list for a parquet's geometry + internal columns, or '' when there's nothing to drop. */
 const excludeClause = (dropped: string[]): string =>

--- a/src/lib/export-fields.ts
+++ b/src/lib/export-fields.ts
@@ -1,0 +1,23 @@
+/**
+ * Columns dropped from every download — table, layer list, and Data Sources — so the
+ * three paths agree on which fields a dataset actually has.
+ *
+ * These are warehouse bookkeeping: pipeline provenance, envelope helpers, and internal
+ * keys that mean nothing outside the warehouse.
+ */
+const INTERNAL_COLUMNS = new Set([
+    'bbox',
+    'feature_id',
+    'geometry',
+    'metadata_publication_id',
+    'quad_name',
+    'review_status',
+    'scale',
+    'table_type',
+    'target_epsg',
+]);
+
+export const isInternalColumn = (col: string): boolean => {
+    const name = col.toLowerCase();
+    return INTERNAL_COLUMNS.has(name) || name.startsWith('_') || /^bbox_[xy](min|max)$/.test(name);
+};

--- a/src/lib/export-fields.ts
+++ b/src/lib/export-fields.ts
@@ -8,6 +8,13 @@
 const INTERNAL_COLUMNS = new Set([
     'bbox',
     'feature_id',
+    // Source-format plumbing: Esri/OGR row ids and their geometry measures. The measures
+    // are recorded in the source projection, so they don't match the exported geometry.
+    'fid',
+    'objectid',
+    'ogc_fid',
+    'shape_area',
+    'shape_length',
     // Parquet exports drop their geometry column via `geometryColumn`; this is for the
     // table path, where geometry is emitted separately from the property list.
     'geometry',

--- a/src/lib/export-fields.ts
+++ b/src/lib/export-fields.ts
@@ -12,7 +12,6 @@ const INTERNAL_COLUMNS = new Set([
     'metadata_publication_id',
     'quad_name',
     'review_status',
-    'scale',
     'table_type',
     'target_epsg',
 ]);

--- a/src/lib/export-fields.ts
+++ b/src/lib/export-fields.ts
@@ -8,7 +8,12 @@
 const INTERNAL_COLUMNS = new Set([
     'bbox',
     'feature_id',
+    // Geometry column aliases (see use-parquet-schema GEOM_CANDIDATES). The parquet
+    // exports already drop theirs via `geometryColumn`; this catches the table path,
+    // where geometry is emitted separately and must not also appear as a property.
+    'geom',
     'geometry',
+    'wkb_geometry',
     'metadata_publication_id',
     'quad_name',
     'review_status',

--- a/src/lib/export-fields.ts
+++ b/src/lib/export-fields.ts
@@ -12,6 +12,7 @@ const INTERNAL_COLUMNS = new Set([
     'metadata_publication_id',
     'quad_name',
     'review_status',
+    'scale',
     'table_type',
     'target_epsg',
 ]);

--- a/src/lib/export-fields.ts
+++ b/src/lib/export-fields.ts
@@ -8,12 +8,9 @@
 const INTERNAL_COLUMNS = new Set([
     'bbox',
     'feature_id',
-    // Geometry column aliases (see use-parquet-schema GEOM_CANDIDATES). The parquet
-    // exports already drop theirs via `geometryColumn`; this catches the table path,
-    // where geometry is emitted separately and must not also appear as a property.
-    'geom',
+    // Parquet exports drop their geometry column via `geometryColumn`; this is for the
+    // table path, where geometry is emitted separately from the property list.
     'geometry',
-    'wkb_geometry',
     'metadata_publication_id',
     'quad_name',
     'review_status',

--- a/src/lib/export-formats.ts
+++ b/src/lib/export-formats.ts
@@ -4,7 +4,12 @@
  * dropdown + handler dispatch both pick it up.
  */
 
-export type ExportFormat = 'parquet' | 'geojson' | 'csv';
+export type ExportFormat = 'parquet' | 'geojson' | 'csv' | 'gpkg' | 'shp' | 'gdb' | 'fgb';
+
+/** Formats converted by gdal3.js rather than DuckDB — see `gdal-export.ts`. */
+export const GDAL_FORMATS = ['gpkg', 'shp', 'gdb', 'fgb'] as const;
+export const isGdalFormat = (f: ExportFormat): boolean =>
+    (GDAL_FORMATS as readonly string[]).includes(f);
 
 export interface ExportFormatMeta {
     /** Human-readable label for the menu */
@@ -41,6 +46,36 @@ export const EXPORT_FORMATS: Record<ExportFormat, ExportFormatMeta> = {
         mimeType: 'text/csv',
         requiresGeometry: false,
         hint: '.csv',
+    },
+    gpkg: {
+        label: 'GeoPackage',
+        extension: 'gpkg',
+        mimeType: 'application/geopackage+sqlite3',
+        requiresGeometry: true,
+        hint: '.gpkg',
+    },
+    shp: {
+        label: 'Shapefile',
+        // Zipped sidecars: yields `<stem>.shp.zip`.
+        extension: 'shp.zip',
+        mimeType: 'application/zip',
+        requiresGeometry: true,
+        hint: '.shp.zip',
+    },
+    gdb: {
+        label: 'File Geodatabase',
+        // Zipped .gdb directory: yields `<stem>.gdb.zip`.
+        extension: 'gdb.zip',
+        mimeType: 'application/zip',
+        requiresGeometry: true,
+        hint: '.gdb.zip',
+    },
+    fgb: {
+        label: 'FlatGeobuf',
+        extension: 'fgb',
+        mimeType: 'application/octet-stream',
+        requiresGeometry: true,
+        hint: '.fgb',
     },
 };
 

--- a/src/lib/gdal-export.ts
+++ b/src/lib/gdal-export.ts
@@ -1,9 +1,7 @@
 /**
- * Real GDAL/OGR in the browser (gdal3.js). DuckDB-WASM's GDAL output drivers are
- * broken — see duckdb-spatial#363 / duckdb-wasm#1840, open since 2024 — but gdal3.js
- * bundles a full GDAL build whose OGR drivers write correctly, including OpenFileGDB
- * (Esri File Geodatabase, write support since GDAL 3.6). We feed it a GeoJSON produced
- * by DuckDB and convert to GPKG / SHP / GDB / FlatGeobuf.
+ * GDAL/OGR in the browser. DuckDB-WASM's GDAL writers are broken (duckdb-spatial#363,
+ * open since 2024); gdal3.js is a full GDAL whose drivers work, including OpenFileGDB.
+ * Takes DuckDB-built GeoJSON → GPKG / SHP / GDB / FlatGeobuf.
  *
  * Ported from ugs-warehouse `viewer/src/gdal.ts`; keep the two in sync.
  */
@@ -13,11 +11,9 @@ import dataUrl from 'gdal3.js/dist/package/gdal3WebAssembly.data?url'
 import wasmUrl from 'gdal3.js/dist/package/gdal3WebAssembly.wasm?url'
 
 export interface GdalTarget {
-    /** OGR driver name */
     driver: string
-    /** File extension (no dot) */
     ext: string
-    /** Emits several files (shp sidecars, the .gdb directory) which we zip */
+    /** Emits several files (shp sidecars, the .gdb directory) which we zip. */
     multi: boolean
 }
 
@@ -31,7 +27,7 @@ export const GDAL_TARGETS: Record<string, GdalTarget> = {
 type Gdal = Awaited<ReturnType<typeof initGdalJs>>
 let gdalPromise: Promise<Gdal> | null = null
 
-// Memoized: the ~40MB wasm + data payload loads once per page, not per download.
+// Memoized: the ~40MB payload loads once per page, not per download.
 function getGdal(): Promise<Gdal> {
     if (!gdalPromise) {
         gdalPromise = initGdalJs({
@@ -53,11 +49,8 @@ export interface GdalConversion {
 }
 
 /**
- * Convert a GeoJSON string (WGS84) to `target`, reprojecting to `epsg` (default 4326).
- *
- * `cols` (all attribute columns) + `floatCols` (the DOUBLE/REAL ones) force real typing:
- * GDAL's GeoJSON reader otherwise infers Integer for a float column whose values happen
- * to be whole, silently downcasting depth/elevation fields. An OGR-SQL CAST fixes it.
+ * GeoJSON (WGS84) → `target`, reprojected to `epsg`. `floatCols` get an OGR-SQL CAST:
+ * GDAL otherwise reads a whole-valued float column as Integer, downcasting depths.
  */
 export async function convertGeoJSON(
     geojson: string,
@@ -71,30 +64,28 @@ export async function convertGeoJSON(
     const input = new File([geojson], 'in.geojson', { type: 'application/geo+json' })
     const { datasets } = await gdal.open(input)
     const ds = datasets[0]
-    // Shapefile: pass the bare stem (the driver appends .shp/.dbf/… — giving `stem.shp`
-    // would double to `stem.shp.shp`). Other drivers want the full filename.
+    // Shapefile takes the bare stem — the driver appends .shp/.dbf/…
     const outName = target.ext === 'shp' ? stem : `${stem}.${target.ext}`
-    // -nln names the output layer after the dataset (else it inherits "in" from in.geojson).
+    // -nln names the layer after the dataset, else it inherits "in" from in.geojson.
     const args = ['-f', target.driver, '-t_srs', `EPSG:${epsg}`, '-nln', stem]
     if (floatCols.length && cols.length) {
         const fset = new Set(floatCols)
         const q = (c: string) => `"${c.replace(/"/g, '""')}"`
-        // Geometry passes through OGR SQL implicitly; CAST only the whole-valued float columns.
+        // Geometry passes through OGR SQL implicitly.
         const sel = cols.map(c => (fset.has(c) ? `CAST(${q(c)} AS float(24,10)) AS ${q(c)}` : q(c))).join(', ')
         args.push('-sql', `SELECT ${sel} FROM "in"`)
     }
     const result = await gdal.ogr2ogr(ds, args, outName)
 
-    // try/finally so the single-file early return still closes the dataset (else gpkg/fgb
-    // exports leak the handle + MEMFS buffers into the GDAL runtime heap).
+    // try/finally so the early return still closes the dataset — otherwise gpkg/fgb
+    // exports leak the handle + MEMFS buffers into the GDAL heap.
     try {
         if (!target.multi) {
             const bytes = await gdal.getFileBytes(result)
             return { bytes, filename: `${stem}.${target.ext}`, mime: 'application/octet-stream' }
         }
 
-        // Multi-file: collect the format's output files and zip. For a .gdb directory keep
-        // the files nested under `<stem>.gdb/`; shapefile sidecars sit at the zip root.
+        // .gdb files stay nested under `<stem>.gdb/`; shapefile sidecars sit at the zip root.
         const outputs = await gdal.getOutputFiles()
         const entries: Record<string, Uint8Array> = {}
         for (const f of outputs) {
@@ -112,11 +103,8 @@ export async function convertGeoJSON(
 }
 
 /**
- * Deterministic shapefile field-name limits (pure — no data read). Names > 10 chars get
- * truncated by the driver; two that collapse to the same 10-char name collide, losing a
- * column silently; > 255 fields is a hard cap.
- *
- * Ported from ugs-warehouse `viewer/src/download.ts`.
+ * Shapefile field-name limits: names > 10 chars are truncated, two that collapse to the
+ * same 10 chars silently lose a column, and 255 fields is a hard cap.
  */
 export function shapefileFieldChecks(cols: string[]): {
     longNames: string[]

--- a/src/lib/gdal-export.ts
+++ b/src/lib/gdal-export.ts
@@ -1,0 +1,136 @@
+/**
+ * Real GDAL/OGR in the browser (gdal3.js). DuckDB-WASM's GDAL output drivers are
+ * broken — see duckdb-spatial#363 / duckdb-wasm#1840, open since 2024 — but gdal3.js
+ * bundles a full GDAL build whose OGR drivers write correctly, including OpenFileGDB
+ * (Esri File Geodatabase, write support since GDAL 3.6). We feed it a GeoJSON produced
+ * by DuckDB and convert to GPKG / SHP / GDB / FlatGeobuf.
+ *
+ * Ported from ugs-warehouse `viewer/src/gdal.ts`; keep the two in sync.
+ */
+import { zipSync } from 'fflate'
+import initGdalJs from 'gdal3.js'
+import dataUrl from 'gdal3.js/dist/package/gdal3WebAssembly.data?url'
+import wasmUrl from 'gdal3.js/dist/package/gdal3WebAssembly.wasm?url'
+
+export interface GdalTarget {
+    /** OGR driver name */
+    driver: string
+    /** File extension (no dot) */
+    ext: string
+    /** Emits several files (shp sidecars, the .gdb directory) which we zip */
+    multi: boolean
+}
+
+export const GDAL_TARGETS: Record<string, GdalTarget> = {
+    gpkg: { driver: 'GPKG', ext: 'gpkg', multi: false },
+    fgb: { driver: 'FlatGeobuf', ext: 'fgb', multi: false },
+    shp: { driver: 'ESRI Shapefile', ext: 'shp', multi: true },
+    gdb: { driver: 'OpenFileGDB', ext: 'gdb', multi: true },
+}
+
+type Gdal = Awaited<ReturnType<typeof initGdalJs>>
+let gdalPromise: Promise<Gdal> | null = null
+
+// Memoized: the ~40MB wasm + data payload loads once per page, not per download.
+function getGdal(): Promise<Gdal> {
+    if (!gdalPromise) {
+        gdalPromise = initGdalJs({
+            paths: { wasm: wasmUrl, data: dataUrl },
+            useWorker: false,
+            // GDAL's non-fatal stderr (field-type coercion, name laundering) is warnings, not errors.
+            errorHandler: (m: string) => console.warn(m),
+        })
+    }
+    return gdalPromise
+}
+
+const basename = (p: string) => p.split('/').pop() ?? p
+
+export interface GdalConversion {
+    bytes: Uint8Array
+    filename: string
+    mime: string
+}
+
+/**
+ * Convert a GeoJSON string (WGS84) to `target`, reprojecting to `epsg` (default 4326).
+ *
+ * `cols` (all attribute columns) + `floatCols` (the DOUBLE/REAL ones) force real typing:
+ * GDAL's GeoJSON reader otherwise infers Integer for a float column whose values happen
+ * to be whole, silently downcasting depth/elevation fields. An OGR-SQL CAST fixes it.
+ */
+export async function convertGeoJSON(
+    geojson: string,
+    stem: string,
+    target: GdalTarget,
+    epsg = 4326,
+    cols: string[] = [],
+    floatCols: string[] = [],
+): Promise<GdalConversion> {
+    const gdal = await getGdal()
+    const input = new File([geojson], 'in.geojson', { type: 'application/geo+json' })
+    const { datasets } = await gdal.open(input)
+    const ds = datasets[0]
+    // Shapefile: pass the bare stem (the driver appends .shp/.dbf/… — giving `stem.shp`
+    // would double to `stem.shp.shp`). Other drivers want the full filename.
+    const outName = target.ext === 'shp' ? stem : `${stem}.${target.ext}`
+    // -nln names the output layer after the dataset (else it inherits "in" from in.geojson).
+    const args = ['-f', target.driver, '-t_srs', `EPSG:${epsg}`, '-nln', stem]
+    if (floatCols.length && cols.length) {
+        const fset = new Set(floatCols)
+        const q = (c: string) => `"${c.replace(/"/g, '""')}"`
+        // Geometry passes through OGR SQL implicitly; CAST only the whole-valued float columns.
+        const sel = cols.map(c => (fset.has(c) ? `CAST(${q(c)} AS float(24,10)) AS ${q(c)}` : q(c))).join(', ')
+        args.push('-sql', `SELECT ${sel} FROM "in"`)
+    }
+    const result = await gdal.ogr2ogr(ds, args, outName)
+
+    // try/finally so the single-file early return still closes the dataset (else gpkg/fgb
+    // exports leak the handle + MEMFS buffers into the GDAL runtime heap).
+    try {
+        if (!target.multi) {
+            const bytes = await gdal.getFileBytes(result)
+            return { bytes, filename: `${stem}.${target.ext}`, mime: 'application/octet-stream' }
+        }
+
+        // Multi-file: collect the format's output files and zip. For a .gdb directory keep
+        // the files nested under `<stem>.gdb/`; shapefile sidecars sit at the zip root.
+        const outputs = await gdal.getOutputFiles()
+        const entries: Record<string, Uint8Array> = {}
+        for (const f of outputs) {
+            const name = basename(f.path)
+            if (target.ext === 'gdb' && f.path.includes(`${stem}.gdb`)) {
+                entries[`${stem}.gdb/${name}`] = await gdal.getFileBytes(f.path)
+            } else if (target.ext === 'shp' && name.startsWith(`${stem}.`)) {
+                entries[name] = await gdal.getFileBytes(f.path)
+            }
+        }
+        return { bytes: zipSync(entries), filename: `${stem}.${target.ext}.zip`, mime: 'application/zip' }
+    } finally {
+        try { await gdal.close(ds) } catch { /* best-effort */ }
+    }
+}
+
+/**
+ * Deterministic shapefile field-name limits (pure — no data read). Names > 10 chars get
+ * truncated by the driver; two that collapse to the same 10-char name collide, losing a
+ * column silently; > 255 fields is a hard cap.
+ *
+ * Ported from ugs-warehouse `viewer/src/download.ts`.
+ */
+export function shapefileFieldChecks(cols: string[]): {
+    longNames: string[]
+    collisions: [string, string][]
+    fieldCount: number
+    tooManyFields: boolean
+} {
+    const longNames = cols.filter(c => c.length > 10)
+    const seen = new Map<string, string>()
+    const collisions: [string, string][] = []
+    for (const c of cols) {
+        const key = c.slice(0, 10).toLowerCase()
+        if (seen.has(key)) collisions.push([seen.get(key)!, c])
+        else seen.set(key, c)
+    }
+    return { longNames, collisions, fieldCount: cols.length, tooManyFields: cols.length > 255 }
+}


### PR DESCRIPTION
ALL-4648

## What
Shapefile, GeoPackage, File Geodatabase and FlatGeobuf downloads, alongside the existing GeoParquet / GeoJSON / CSV.

## How
DuckDB-WASM's GDAL writers are broken (why `fgb` was dropped in #441) — still broken on the newest build; [duckdb-spatial#363](https://github.com/duckdb/duckdb-spatial/issues/363) open since 2024. So conversion goes through `gdal3.js`, the same approach as the `ugs-warehouse` viewer, whose `gdal.ts` this ports. Lazy-imported: its ~40&nbsp;MB loads only when one of these formats is picked. Shapefile gets a pre-flight warning for 10-char field truncation and collisions.

## Also fixes
Two bugs hitting the **existing** GeoJSON export on warehouse datasets: `stoi: no conversion` on read (fixed with `SET enable_geoparquet_conversion = false`), and a hardcoded `3857 → 4326` transform that double-projected warehouse parquets, which are already `OGC:CRS84` — now detected per dataset.

## Verified
200 real `hazards_qfaults` features; all four outputs open in `ogrinfo` with correct counts, attributes and a Utah extent. The `.gdb` opens under the `OpenFileGDB` driver.

## Notes
- Output CRS fixed at 4326; `ExportOptions.epsg` plumbed for a future picker.
- `gdal-export.ts` now lives in two repos — deliberate over a shared package for ~90 lines, but a drift risk.
- Restart the dev server after pulling, so Vite re-optimizes the new dep.
