### PR TITLE
fix(common): resolve STAC layers via the items.json rollup

### DIFF
--- a/src/components/sidebar/dataset-downloads.tsx
+++ b/src/components/sidebar/dataset-downloads.tsx
@@ -9,7 +9,7 @@ import { useGetLayerConfigs } from '@/hooks/use-get-layer-configs';
 import { useGetCurrentPage } from '@/hooks/use-get-current-page';
 import { EXPORT_DISABLED_PAGES, MAPS_ASSETS_CDN_URL } from '@/lib/constants';
 import { isPMTilesLayer, isWMSLayer } from '@/lib/map/layer-utils';
-import { fetchStacItem, fetchStacItemIndex } from '@/lib/map/stac/stac-layer';
+import { fetchStacItemIndex } from '@/lib/map/stac/stac-layer';
 import type { LayerProps, RelatedTable } from '@/lib/types/mapping-types';
 
 interface DownloadableDataset {
@@ -60,13 +60,10 @@ export function DatasetDownloads() {
         queryKey: ['dataset-downloads-warehouse-parquet', stems],
         queryFn: async () => {
             const index = await fetchStacItemIndex();
-            const entries = await Promise.all(
-                stems.filter(s => index[s]).map(async s => {
-                    const item = await fetchStacItem(index[s]);
-                    return [s, item.assets?.data?.href] as const;
-                }),
-            );
-            return Object.fromEntries(entries.filter(([, href]) => href)) as Record<string, string>;
+            const entries = stems
+                .map(s => [s, index[s]?.assets?.data?.href] as const)
+                .filter((entry): entry is [string, string] => !!entry[1]);
+            return Object.fromEntries(entries);
         },
         enabled: stems.length > 0,
         staleTime: 30 * 60 * 1000,

--- a/src/hooks/use-stac-layers.ts
+++ b/src/hooks/use-stac-layers.ts
@@ -14,7 +14,6 @@
 import { useQuery } from '@tanstack/react-query';
 import type { PMTilesLayerProps } from '@/lib/types/mapping-types';
 import {
-    fetchStacItem,
     fetchStacItemIndex,
     resolveStacPMTilesLayer,
     type StacLayerAppConfig,
@@ -33,12 +32,11 @@ export function useStacPMTilesLayers(appConfigs: StacLayerAppConfig[]) {
         queryKey: ['stac', 'pmtiles-layers', [...ids].sort()],
         queryFn: async () => {
             const index = await fetchStacItemIndex();
-            return Promise.all(appConfigs.map(async (cfg) => {
-                const href = index[cfg.stacItemId];
-                if (!href) throw new Error(`STAC item '${cfg.stacItemId}' not found in serving-topics collection`);
-                const item = await fetchStacItem(href);
+            return appConfigs.map((cfg) => {
+                const item = index[cfg.stacItemId];
+                if (!item) throw new Error(`STAC item '${cfg.stacItemId}' not found in serving-topics index`);
                 return resolveStacPMTilesLayer(item, cfg);
-            }));
+            });
         },
         enabled: appConfigs.length > 0,
         staleTime: STAC_STALE_TIME,

--- a/src/lib/map/stac/stac-layer.ts
+++ b/src/lib/map/stac/stac-layer.ts
@@ -24,10 +24,11 @@ import type {
 } from '@/lib/types/mapping-types';
 import { toTitleCase } from '@/lib/utils';
 
-// Serving-topics collection — the vector layers the viewer can render. Items
-// live at `./<id>/<id>.json` relative to this URL.
-export const STAC_SERVING_TOPICS_COLLECTION =
-    'https://maps-assets.geology.utah.gov/warehouse/stac/ugs-serving-topics/collection.json';
+// Rollup of every serving-topics item, full body included (one fetch, no N+1).
+// `collection.json`'s item links are stale — they don't account for items now
+// nesting under `<schema>/<id>/<id>.json` — so use this instead.
+export const STAC_SERVING_TOPICS_ITEMS_URL =
+    'https://maps-assets.geology.utah.gov/warehouse/stac/ugs-serving-topics/items.json';
 
 /** One entry of a STAC item's `renders` extension (warehouse-attached). */
 export interface StacRenderEntry {
@@ -218,32 +219,20 @@ export function renderSelectOptions(layer: PMTilesLayerProps): Array<{ id: strin
 
 // ─── Catalog fetch + tree resolution ───────────────────────────────────────
 
-interface StacCollection {
-    links?: Array<{ rel: string; href: string; title?: string }>;
+interface StacItemsIndexDoc {
+    items?: StacItem[];
 }
 
-/**
- * Fetch the serving-topics collection and build `itemId → absolute item URL`
- * from its `item` links (relative hrefs resolved against the collection URL).
- */
-export async function fetchStacItemIndex(): Promise<Record<string, string>> {
-    const res = await fetch(STAC_SERVING_TOPICS_COLLECTION);
-    if (!res.ok) throw new Error(`STAC collection fetch failed: ${res.status}`);
-    const collection: StacCollection = await res.json();
-    const index: Record<string, string> = {};
-    for (const link of collection.links ?? []) {
-        if (link.rel !== 'item' || !link.href) continue;
-        const href = new URL(link.href, STAC_SERVING_TOPICS_COLLECTION).toString();
-        const id = href.split('/').pop()?.replace(/\.json$/, '');
-        if (id) index[id] = href;
+/** Fetch the serving-topics rollup, indexed by item id. */
+export async function fetchStacItemIndex(): Promise<Record<string, StacItem>> {
+    const res = await fetch(STAC_SERVING_TOPICS_ITEMS_URL);
+    if (!res.ok) throw new Error(`STAC items index fetch failed: ${res.status}`);
+    const doc: StacItemsIndexDoc = await res.json();
+    const index: Record<string, StacItem> = {};
+    for (const item of doc.items ?? []) {
+        if (item.id) index[item.id] = item;
     }
     return index;
-}
-
-export async function fetchStacItem(href: string): Promise<StacItem> {
-    const res = await fetch(href);
-    if (!res.ok) throw new Error(`STAC item fetch failed: ${res.status}`);
-    return res.json();
 }
 
 /**
@@ -253,10 +242,7 @@ export async function fetchStacItem(href: string): Promise<StacItem> {
  */
 export async function fetchStacAssetHref(stacItemId: string, assetKey: string): Promise<string | undefined> {
     const index = await fetchStacItemIndex();
-    const href = index[stacItemId];
-    if (!href) return undefined;
-    const item = await fetchStacItem(href);
-    return item.assets?.[assetKey]?.href;
+    return index[stacItemId]?.assets?.[assetKey]?.href;
 }
 
 /** Collect every `stacItemId` referenced in a (possibly nested) layer tree. */
@@ -306,15 +292,14 @@ export async function resolveStacLayerTree(layers: LayerProps[]): Promise<LayerP
 
     const index = await fetchStacItemIndex();
     const items = new Map<string, StacItem>();
-    await Promise.all([...ids].map(async (id) => {
-        try {
-            const href = index[id];
-            if (!href) throw new Error(`'${id}' not in serving-topics collection`);
-            items.set(id, await fetchStacItem(href));
-        } catch (err) {
-            console.error(`[resolveStacLayerTree] failed to resolve STAC item '${id}':`, err);
+    for (const id of ids) {
+        const item = index[id];
+        if (!item) {
+            console.error(`[resolveStacLayerTree] failed to resolve STAC item '${id}': not in serving-topics index`);
+            continue;
         }
-    }));
+        items.set(id, item);
+    }
 
     const mapTree = (list: LayerProps[]): LayerProps[] => {
         const out: LayerProps[] = [];


### PR DESCRIPTION
## What
- STAC-only layers (e.g. Power Plants) failed to resolve, 404ing on their item fetch.

## Why
- `ugs-serving-topics/collection.json` is stale from before the vector producer started nesting item storage by Postgres schema (`<schema>/<id>/<id>.json`).
- Its `rel:item` links still assume the old flat one-level layout, so every id 404s.
- The warehouse already publishes `items.json` — a rollup with full item bodies, immune to the nesting change, meant to replace the N+1 per-item fetch pattern.

## Fix
- `fetchStacItemIndex()` now reads `items.json` and returns `id -> StacItem` directly (was `id -> href`).
- Drops the now-unneeded second `fetchStacItem(href)` fetch in `resolveStacLayerTree`, `useStacPMTilesLayers`, and the Data Sources panel's warehouse-parquet upgrade lookup.

## Verified
- Playwright against the dev server: Power Plants layer now resolves and renders with zero console errors (previously 404 + dropped-layer warning on every load).

## Note
- Root cause is really on the warehouse side: `refresh_catalog()` doesn't clean up the orphaned flat `collection.json` once a top-level path becomes nested-only. Left as-is here (different repo); this PR just stops the viewer depending on that stale file.