### PR TITLE
fix(common): include PMTiles in area select, reset draw mode and clear old shapes

### DIFF
--- a/src/components/maps/__tests__/pmtiles-layer-source.test.ts
+++ b/src/components/maps/__tests__/pmtiles-layer-source.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { queryPmtilesLayersInScreenBbox } from '../pmtiles-layer-source'
+import type { PMTilesLayerProps } from '@/lib/types/mapping-types'
+
+const BBOX: [[number, number], [number, number]] = [[0, 0], [100, 100]]
+const layers = [{ title: 'UCRC Inventory' }] as PMTilesLayerProps[]
+
+/** Minimal MapLibre stand-in: two style sublayers of one PMTiles layer, plus an unrelated one. */
+function fakeMap(features: unknown[]) {
+    const styleLayers = [
+        { id: 'ucrc-circle', metadata: { pmtilesLayer: true, title: 'UCRC Inventory' } },
+        { id: 'ucrc-symbol', metadata: { pmtilesLayer: true, title: 'UCRC Inventory' } },
+        { id: 'basemap-roads', metadata: undefined },
+        { id: 'other-pmtiles', metadata: { pmtilesLayer: true, title: 'Power Plants' } },
+    ]
+    const queried: Array<string[] | undefined> = []
+    return {
+        queried,
+        getStyle: () => ({ layers: styleLayers }),
+        getLayer: (id: string) => styleLayers.find(l => l.id === id),
+        queryRenderedFeatures: (_bbox: unknown, opts: { layers?: string[] }) => {
+            queried.push(opts?.layers)
+            return features
+        },
+    } as never
+}
+
+const feat = (id: unknown, props: Record<string, unknown>, coords: number[] = [0, 0], layer = 'ucrc-circle') =>
+    ({ id, properties: props, geometry: { type: 'Point', coordinates: coords }, layer: { id: layer } })
+
+describe('queryPmtilesLayersInScreenBbox', () => {
+    it('returns nothing when no PMTiles layers are visible', () => {
+        expect(queryPmtilesLayersInScreenBbox(fakeMap([feat(1, {})]), BBOX, [])).toEqual([])
+    })
+
+    it('only queries style sublayers belonging to the visible layers', () => {
+        const map = fakeMap([])
+        queryPmtilesLayersInScreenBbox(map, BBOX, layers)
+        expect((map as unknown as { queried: string[][] }).queried[0]).toEqual(['ucrc-circle', 'ucrc-symbol'])
+    })
+
+    it('dedupes a feature returned once per tile and once per style sublayer', () => {
+        // Same feature id 42, three hits: two style sublayers plus a tile-boundary repeat.
+        const rows = queryPmtilesLayersInScreenBbox(fakeMap([
+            feat(42, { uwi: 'a' }, [0, 0], 'ucrc-circle'),
+            feat(42, { uwi: 'a' }, [0, 0], 'ucrc-symbol'),
+            feat(42, { uwi: 'a' }, [0, 0], 'ucrc-circle'),
+            feat(43, { uwi: 'b' }),
+        ]), BBOX, layers)
+        expect(rows.map(r => r.id)).toEqual([42, 43])
+        expect(rows[0].layerTitle).toBe('UCRC Inventory')
+    })
+
+    it('falls back to ogc_fid when the tile carries no feature id', () => {
+        const rows = queryPmtilesLayersInScreenBbox(fakeMap([
+            feat(undefined, { ogc_fid: 7 }),
+            feat(undefined, { ogc_fid: 7 }),
+        ]), BBOX, layers)
+        expect(rows).toHaveLength(1)
+        expect(rows[0].id).toBe(7)
+    })
+
+    it('keeps unkeyed features that share attributes but sit at different locations', () => {
+        // Without the geometry signature these two collapse into one — distinct wells with
+        // identical popup fields is exactly the case a properties-only key gets wrong.
+        const rows = queryPmtilesLayersInScreenBbox(fakeMap([
+            feat(undefined, { box_type: 'CORE' }, [-112.9, 39.0]),
+            feat(undefined, { box_type: 'CORE' }, [-111.5, 40.2]),
+            feat(undefined, { box_type: 'CORE' }, [-112.9, 39.0]),  // true duplicate
+        ]), BBOX, layers)
+        expect(rows).toHaveLength(2)
+    })
+})

--- a/src/components/maps/data-map.tsx
+++ b/src/components/maps/data-map.tsx
@@ -15,7 +15,7 @@ import { BoxSelectOverlay, ViewModeControl, MapToolsControl } from './controls'
 import { HighlightLayers, SpatialFilterLayer, ClickBufferLayer } from './layers'
 import { flattenDataLayersWithAncestors, resolveLeafVisibility, isWMSLayer, isWFSLayer, isArcGISMapServerLayer, isCOGLayer, isPMTilesLayer, buildWmsTileUrl, buildArcGisExportUrl, getWmsLayerName } from '@/lib/map/layer-utils'
 import { useLayerUrl } from '@/context/layer-url-provider'
-import { PMTilesLayerSource, usePMTilesStyleFragments, getPmtilesLayerId, queryPmtilesLayersAtPoint } from '@/components/maps/pmtiles-layer-source'
+import { PMTilesLayerSource, usePMTilesStyleFragments, getPmtilesLayerId, queryPmtilesLayersAtPoint, queryPmtilesLayersInScreenBbox } from '@/components/maps/pmtiles-layer-source'
 import type { WMSLayerProps, WFSLayerProps, ArcGISMapServerLayerProps, COGLayerProps, PMTilesLayerProps } from '@/lib/types/mapping-types'
 import type maplibregl from 'maplibre-gl'
 import type { FeatureCollection } from 'geojson'
@@ -480,27 +480,31 @@ export default function DataMap({
     const map = mapRef.current?.getMap()
     const wmsLayers = visibleWmsLayersRef.current
     const wfsLayers = visibleWfsLayersRef.current
+    const pmtilesLayers = visiblePmtilesLayersRef.current
 
-    // Query WFS layers client-side within polygon bbox
-    let wfsFeatures: WfsLayerFeature[] = []
-    if (map && wfsLayers.length > 0) {
+    // Query client-side vector layers within polygon bbox
+    let vectorFeatures: WfsLayerFeature[] = []
+    if (map && (wfsLayers.length > 0 || pmtilesLayers.length > 0)) {
       const [minX, minY, maxX, maxY] = turfBbox(filter.polygon)
       const sw = map.project([minX, minY])
       const ne = map.project([maxX, maxY])
       const screenBbox: [maplibregl.PointLike, maplibregl.PointLike] = [[sw.x, ne.y], [ne.x, sw.y]]
-      wfsFeatures = queryWfsLayersInScreenBbox(map, screenBbox, wfsLayers)
+      vectorFeatures = [
+        ...queryPmtilesLayersInScreenBbox(map, screenBbox, pmtilesLayers),
+        ...queryWfsLayersInScreenBbox(map, screenBbox, wfsLayers),
+      ]
     }
 
-    // If no WMS layers, just use WFS results directly
+    // If no WMS layers, just use the vector results directly
     if (wmsLayers.length === 0) {
-      if (wfsFeatures.length > 0 && onFeatureClick) {
-        onFeatureClick(wfsFeatures, { additive: false })
+      if (vectorFeatures.length > 0 && onFeatureClick) {
+        onFeatureClick(vectorFeatures, { additive: false })
       }
       return
     }
 
-    // Store WFS features for merging when WMS query completes
-    polygonWfsLayerFeaturesRef.current = wfsFeatures
+    // Store vector features for merging when WMS query completes
+    polygonWfsLayerFeaturesRef.current = vectorFeatures
 
     // Trigger WMS polygon query
     polygonQueryRef.current.mutate({
@@ -637,15 +641,18 @@ export default function DataMap({
       ne: [ne.lng, ne.lat] as [number, number]
     })
 
-    // Query WFS layers client-side in the box area, then merge with WMS results
+    // Query client-side vector layers in the box area, then merge with WMS results
     const screenBbox: [maplibregl.PointLike, maplibregl.PointLike] = [
       [centerX - halfBox, centerY - halfBox],
       [centerX + halfBox, centerY + halfBox]
     ]
-    const wfsFeatures = queryWfsLayersInScreenBbox(map, screenBbox, visibleWfsLayers)
+    const vectorFeatures = [
+      ...queryPmtilesLayersInScreenBbox(map, screenBbox, visiblePmtilesLayers),
+      ...queryWfsLayersInScreenBbox(map, screenBbox, visibleWfsLayers),
+    ]
 
     if (visibleWmsLayers.length === 0) {
-      dispatchFeatures(wfsFeatures, isAdditiveMode)
+      dispatchFeatures(vectorFeatures, isAdditiveMode)
       return
     }
 
@@ -661,12 +668,12 @@ export default function DataMap({
       },
       {
         onSuccess: ({ features: wmsFeatures, truncated }) => {
-          dispatchFeatures([...wmsFeatures, ...wfsFeatures], isAdditiveMode)
+          dispatchFeatures([...wmsFeatures, ...vectorFeatures], isAdditiveMode)
           if (truncated) notifyTruncated()
         },
       }
     )
-  }, [onBoxSelectConfirm, visibleWmsLayers, visibleWfsLayers, boxSelectQuery, wmsUrl, onFeatureClick, isAdditiveMode, layerFilters])
+  }, [onBoxSelectConfirm, visibleWmsLayers, visibleWfsLayers, visiblePmtilesLayers, boxSelectQuery, wmsUrl, onFeatureClick, isAdditiveMode, layerFilters])
 
   // Handle map load
   const handleLoad = useCallback(() => {

--- a/src/components/maps/generic-map-container.tsx
+++ b/src/components/maps/generic-map-container.tsx
@@ -452,14 +452,21 @@ export default function GenericMapContainer({
   const noOtherModeActive = activeDrawShape === 'off' && !boxSelectMode
   const isAdditiveMode = noOtherModeActive && (additiveModeToggled || isShiftHeld)
 
-  // Register callback so startDraw can clear conflicting container state
-  const prepareForDraw = useCallback(() => {
+  // Leftovers from whichever selection mode was active: the drawn filter shape, the frozen
+  // box-select bounds, additive toggle. Every mode transition clears all three — keep this the
+  // single list so the transitions below can't drift apart.
+  const clearSelectionState = useCallback(() => {
     setSpatialFilter(null)
-    setBoxSelectMode(false)
     setBoxSelectBounds(null)
     setAdditiveModeToggled(false)
-    setToolbarDrawShape('off')
   }, [])
+
+  // Register callback so startDraw can clear conflicting container state
+  const prepareForDraw = useCallback(() => {
+    clearSelectionState()
+    setBoxSelectMode(false)
+    setToolbarDrawShape('off')
+  }, [clearSelectionState])
 
   // Register once (safe - callback is stable)
   registerPrepareForDraw(prepareForDraw)
@@ -470,16 +477,15 @@ export default function GenericMapContainer({
   ) => {
     cancelDraw()
     setToolbarDrawShape('off')
+    clearSelectionState()
     setBoxSelectMode(mode === 'boxSelect')
-    if (mode !== 'boxSelect') setBoxSelectBounds(null)
     setAdditiveModeToggled(mode === 'additive')
-  }, [cancelDraw])
+  }, [cancelDraw, clearSelectionState])
 
   // Toolbar draw toggle — starts draw via context, tracks highlight locally
   const handleToolbarDrawToggle = useCallback((mode: DrawMode) => {
     setBoxSelectMode(false)
-    setBoxSelectBounds(null)
-    setAdditiveModeToggled(false)
+    clearSelectionState()
     if (mode === 'off') {
       cancelDraw()
       setToolbarDrawShape('off')
@@ -487,7 +493,7 @@ export default function GenericMapContainer({
       startDraw(mode, undefined, () => setToolbarDrawShape('off'))
       setToolbarDrawShape(mode)
     }
-  }, [cancelDraw, startDraw])
+  }, [cancelDraw, startDraw, clearSelectionState])
 
   // Called by useTerraDraw when drawing finishes (resets to 'off')
   const handleDrawReset = useCallback(() => {

--- a/src/components/maps/generic-map-container.tsx
+++ b/src/components/maps/generic-map-container.tsx
@@ -452,9 +452,7 @@ export default function GenericMapContainer({
   const noOtherModeActive = activeDrawShape === 'off' && !boxSelectMode
   const isAdditiveMode = noOtherModeActive && (additiveModeToggled || isShiftHeld)
 
-  // Leftovers from whichever selection mode was active: the drawn filter shape, the frozen
-  // box-select bounds, additive toggle. Every mode transition clears all three — keep this the
-  // single list so the transitions below can't drift apart.
+  // One list of per-mode leftovers — every transition below clears all three.
   const clearSelectionState = useCallback(() => {
     setSpatialFilter(null)
     setBoxSelectBounds(null)

--- a/src/components/maps/pmtiles-layer-source.tsx
+++ b/src/components/maps/pmtiles-layer-source.tsx
@@ -124,17 +124,24 @@ async function loadSpriteSheet(map: maplibregl.Map, base: string): Promise<void>
     }
 }
 
+/** Type + first coordinate — enough to tell co-located-attribute features apart when a source carries no ids. */
+function geometrySignature(geometry: GeoJSON.Geometry): string {
+    if (geometry.type === 'GeometryCollection') return `GeometryCollection:${geometry.geometries.length}`
+    let c: unknown = geometry.coordinates
+    while (Array.isArray(c) && Array.isArray(c[0])) c = c[0]
+    return `${geometry.type}:${Array.isArray(c) ? c.join(',') : ''}`
+}
+
 /**
- * Query rendered PMTiles features at a point (with screen tolerance), mapped to
- * the same `WfsLayerFeature` shape the popup pipeline consumes. Mirrors
- * `queryWfsLayersAtPoint`: it walks every rendered layer tagged
+ * Query rendered PMTiles features in a screen bbox, mapped to the same
+ * `WfsLayerFeature` shape the popup pipeline consumes. Mirrors
+ * `queryWfsLayersInScreenBbox`: it walks every rendered layer tagged
  * `metadata.pmtilesLayer` whose title is among the visible PMTiles layers (a
  * single layer may render as many style sublayers), then dedupes per layer.
  */
-export function queryPmtilesLayersAtPoint(
+export function queryPmtilesLayersInScreenBbox(
     map: maplibregl.Map,
-    point: { x: number; y: number },
-    tolerance: number,
+    bbox: [maplibregl.PointLike, maplibregl.PointLike],
     layers: PMTilesLayerProps[],
 ): WfsLayerFeature[] {
     if (layers.length === 0) return []
@@ -147,20 +154,40 @@ export function queryPmtilesLayersAtPoint(
         .map(l => l.id)
     if (ids.length === 0) return []
 
-    const bbox: [maplibregl.PointLike, maplibregl.PointLike] = [
-        [point.x - tolerance, point.y - tolerance],
-        [point.x + tolerance, point.y + tolerance],
-    ]
-    const features = map.queryRenderedFeatures(bbox, { layers: ids })
-    return features.map(f => {
+    const out: WfsLayerFeature[] = []
+    const seen = new Set<string>()
+    for (const f of map.queryRenderedFeatures(bbox, { layers: ids })) {
         const md = map.getLayer(f.layer.id)?.metadata as { title?: string } | undefined
-        return {
-            id: f.id ?? (f.properties?.ogc_fid as string | number | undefined) ?? 0,
+        const layerTitle = md?.title || 'Unknown Layer'
+        const id = f.id ?? (f.properties?.ogc_fid as string | number | undefined) ?? 0
+        // A single feature comes back many times over an area: once per tile it straddles,
+        // and once per style sublayer of the same layer. Dedupe on the best identity we have —
+        // an unkeyed source falls back to properties + a geometry signature, so two features
+        // that merely share attributes (same box type, different well) stay distinct.
+        const key = `${layerTitle}|${id || `${JSON.stringify(f.properties)}|${geometrySignature(f.geometry)}`}`
+        if (seen.has(key)) continue
+        seen.add(key)
+        out.push({
+            id,
             properties: f.properties as Record<string, unknown>,
             geometry: f.geometry,
-            layerTitle: md?.title || 'Unknown Layer',
-        }
-    })
+            layerTitle,
+        })
+    }
+    return out
+}
+
+/** Screen-tolerance box around a click point. See {@link queryPmtilesLayersInScreenBbox}. */
+export function queryPmtilesLayersAtPoint(
+    map: maplibregl.Map,
+    point: { x: number; y: number },
+    tolerance: number,
+    layers: PMTilesLayerProps[],
+): WfsLayerFeature[] {
+    return queryPmtilesLayersInScreenBbox(map, [
+        [point.x - tolerance, point.y - tolerance],
+        [point.x + tolerance, point.y + tolerance],
+    ], layers)
 }
 
 const OPACITY_PROP: Record<string, string> = {

--- a/src/hooks/use-terra-draw.ts
+++ b/src/hooks/use-terra-draw.ts
@@ -64,9 +64,7 @@ export function useTerraDraw({
     }
   }
 
-  // Helper to create, wire up, and start Terra Draw.
-  // Every instance must be built here — the 'finish' listener and mode sync are part of
-  // construction, so a rebuilt instance (basemap switch) can't come back deaf.
+  // Build every instance here — a rebuild that skips the 'finish' listener comes back deaf.
   const createTerraDraw = (mapInstance: maplibregl.Map) => {
     cleanupTerraDrawLayers(mapInstance)
 

--- a/src/hooks/use-terra-draw.ts
+++ b/src/hooks/use-terra-draw.ts
@@ -64,7 +64,9 @@ export function useTerraDraw({
     }
   }
 
-  // Helper to create and start Terra Draw
+  // Helper to create, wire up, and start Terra Draw.
+  // Every instance must be built here — the 'finish' listener and mode sync are part of
+  // construction, so a rebuilt instance (basemap switch) can't come back deaf.
   const createTerraDraw = (mapInstance: maplibregl.Map) => {
     cleanupTerraDrawLayers(mapInstance)
 
@@ -96,28 +98,6 @@ export function useTerraDraw({
       ],
     })
 
-    terraDraw.start()
-    return terraDraw
-  }
-
-  // Initialize Terra Draw when map + style are ready (stable deps only)
-  useEffect(() => {
-    if (!map || !styleLoaded) return
-
-    // Stop existing Terra Draw if present (handles style reloads)
-    if (terraDrawRef.current) {
-      try { terraDrawRef.current.stop() } catch { /* ignore */ }
-      terraDrawRef.current = null
-    }
-
-    const terraDraw = createTerraDraw(map)
-    terraDrawRef.current = terraDraw
-
-    // Sync to current draw mode immediately after initialization
-    if (activeDrawShape !== 'off') {
-      terraDraw.setMode(activeDrawShape)
-    }
-
     // Listen for drawing completion - emit polygon and reset
     terraDraw.on('finish', (id: string | number) => {
       const snapshot = terraDraw.getSnapshot()
@@ -132,6 +112,28 @@ export function useTerraDraw({
       onDrawResetRef.current?.()
     })
 
+    terraDraw.start()
+
+    // Sync to the current draw mode immediately after initialization
+    if (activeDrawShapeRef.current !== 'off') {
+      terraDraw.setMode(activeDrawShapeRef.current)
+    }
+
+    return terraDraw
+  }
+
+  // Initialize Terra Draw when map + style are ready (stable deps only)
+  useEffect(() => {
+    if (!map || !styleLoaded) return
+
+    // Stop existing Terra Draw if present (handles style reloads)
+    if (terraDrawRef.current) {
+      try { terraDrawRef.current.stop() } catch { /* ignore */ }
+      terraDrawRef.current = null
+    }
+
+    terraDrawRef.current = createTerraDraw(map)
+
     // Handle map style changes (basemap switches) - reinitialize Terra Draw
     const handleStyleData = () => {
       // Check if our Terra Draw layers still exist
@@ -141,13 +143,7 @@ export function useTerraDraw({
       // If style changed and we lost our layers, reinitialize
       if (!hasTdLayers && terraDrawRef.current) {
         try { terraDrawRef.current.stop() } catch { /* ignore */ }
-        const newTerraDraw = createTerraDraw(map)
-        terraDrawRef.current = newTerraDraw
-
-        // Restore current mode
-        if (activeDrawShapeRef.current !== 'off') {
-          newTerraDraw.setMode(activeDrawShapeRef.current)
-        }
+        terraDrawRef.current = createTerraDraw(map)
       }
     }
     map.on('styledata', handleStyleData)
@@ -155,7 +151,8 @@ export function useTerraDraw({
     return () => {
       map.off('styledata', handleStyleData)
       try {
-        terraDraw.stop()
+        // Ref, not the local — a style reload may have swapped in a newer instance
+        terraDrawRef.current?.stop()
       } catch {
         // Map may already be destroyed during HMR or unmount
       }


### PR DESCRIPTION
## What

Area drawing selected nothing, left the shape behind, and never reset the tool — so shapes stacked. Two causes.

**Area select skipped PMTiles** — only a point query existed, so box and polygon paths came back empty on warehouse layers.

**Terra Draw lost its `finish` listener on basemap switch** — a style swap rebuilds it from the `styledata` handler, which never re-attached it. No listener → nothing selected, no `clear()`, no reset.

Separately, `setActiveMode` never cleared `spatialFilter`, so draw → box select left the old polygon underneath.

## Changes

- `queryPmtilesLayersInScreenBbox` primary, point version delegates; wired into box select and polygon paths.
- Dedupe on layer + `id ?? ogc_fid` — `queryRenderedFeatures` repeats per tile and per style sublayer.
- `createTerraDraw` owns the `finish` listener and mode sync.
- Teardown stops `terraDrawRef.current`, not the captured local.
- `clearSelectionState()` — one leftover list, called by all three transitions.

## Verified

`tsc`/eslint clean, 5 new tests. `vitest` 336 passed / 12 failed — live-DB checks, red on develop too. Box select over UCRC Inventory: 46 features at z9, no duplicate UWIs; develop returns 0.

Draw-lifecycle fixes are not browser-tested and no test covers the mode state machine.
