### PR TITLE
chore(common): trim right-click menu to actions the map can't already do

### DIFF
--- a/src/components/maps/data-map.tsx
+++ b/src/components/maps/data-map.tsx
@@ -726,49 +726,13 @@ export default function DataMap({
     }
   }, [styleLoaded]) // Re-run when style loads (map is ready)
 
-  const handleQueryHere = useCallback((coords: { lng: number; lat: number }) => {
-    const map = mapRef.current?.getMap()
-    if (!map || !onFeatureClick || !hasClickableLayers) return
-
-    const point = map.project([coords.lng, coords.lat])
-
-    // Calculate click buffer bbox for visualization
-    const sw = map.unproject([point.x - clickTolerance, point.y + clickTolerance])
-    const ne = map.unproject([point.x + clickTolerance, point.y - clickTolerance])
-    onClickBufferChange?.({ sw: [sw.lng, sw.lat], ne: [ne.lng, ne.lat] })
-
-    queryAtPoint(map, point, clickTolerance, false)
-  }, [hasClickableLayers, clickTolerance, clickQuery, wmsUrl, onFeatureClick, onClickBufferChange, layerFilters])
-
-  const handleZoomIn = useCallback((coords: { lng: number; lat: number }) => {
-    const map = mapRef.current?.getMap()
-    if (!map) return
-    map.flyTo({ center: [coords.lng, coords.lat], zoom: map.getZoom() + 2 })
-  }, [])
-
-  const handleZoomOut = useCallback((coords: { lng: number; lat: number }) => {
-    const map = mapRef.current?.getMap()
-    if (!map) return
-    map.flyTo({ center: [coords.lng, coords.lat], zoom: Math.max(0, map.getZoom() - 2) })
-  }, [])
-
-  const handleCenterHere = useCallback((coords: { lng: number; lat: number }) => {
-    const map = mapRef.current?.getMap()
-    if (!map) return
-    map.flyTo({ center: [coords.lng, coords.lat] })
-  }, [])
-
   return (
     <>
       <MapContextMenu
         open={contextMenuOpen}
         onOpenChange={setContextMenuOpen}
         coords={contextMenuCoords}
-        onQueryHere={onFeatureClick ? handleQueryHere : undefined}
         onClearSelection={onClearSelection}
-        onZoomIn={handleZoomIn}
-        onZoomOut={handleZoomOut}
-        onCenterHere={handleCenterHere}
         onPinLocation={onPinChange ? (coords) => onPinChange(coords) : undefined}
         hasSelection={highlightFeatures.length > 0 || !!pinCoords}
         currentZoom={currentZoomRef.current}

--- a/src/components/maps/map-context-menu.tsx
+++ b/src/components/maps/map-context-menu.tsx
@@ -10,16 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useToast } from '@/hooks/use-toast'
 import { convertDDToDMS } from '@/lib/map/conversion-utils'
-import {
-  Link,
-  Search,
-  ZoomIn,
-  ZoomOut,
-  Crosshair,
-  Trash2,
-  MapPin,
-  Navigation,
-} from 'lucide-react'
+import { Link, Trash2, MapPin, Navigation } from 'lucide-react'
 
 // Half Esri's LOD 0 scale: their world is 256px at zoom 0, MapLibre's is 512px, so zoom z is Esri level z+1.
 const ESRI_SCALE_CONSTANT = 295828763.8
@@ -32,15 +23,13 @@ export interface ContextMenuCoords {
   screenY: number
 }
 
+// Limited to what the map can't already do. Query/center/zoom at a point live on left-click,
+// drag, scroll, and the NavigationControl.
 interface MapContextMenuProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   coords: ContextMenuCoords | null
-  onQueryHere?: (coords: { lng: number; lat: number }) => void
   onClearSelection?: () => void
-  onZoomIn?: (coords: { lng: number; lat: number }) => void
-  onZoomOut?: (coords: { lng: number; lat: number }) => void
-  onCenterHere?: (coords: { lng: number; lat: number }) => void
   onPinLocation?: (coords: { lat: number; lon: number }) => void
   hasSelection?: boolean
   currentZoom?: number
@@ -50,11 +39,7 @@ export function MapContextMenu({
   open,
   onOpenChange,
   coords,
-  onQueryHere,
   onClearSelection,
-  onZoomIn,
-  onZoomOut,
-  onCenterHere,
   onPinLocation,
   hasSelection = false,
   currentZoom = 10,
@@ -111,46 +96,18 @@ export function MapContextMenu({
   }, [coords, currentZoom, toast, onOpenChange, onPinLocation])
 
   // Open in external map services
-  const handleOpenInMaps = useCallback((service: 'google' | 'apple' | 'osm' | 'bing' | 'ugs') => {
+  const handleOpenInMaps = useCallback((service: 'google' | 'osm' | 'ugs') => {
     if (!coords) return
     const { lat, lng } = coords
     const urls = {
       google: `https://www.google.com/maps?q=${lat},${lng}`,
-      apple: `https://maps.apple.com/?ll=${lat},${lng}&q=${lat},${lng}`,
       osm: `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lng}&zoom=${Math.round(currentZoom)}`,
-      bing: `https://www.bing.com/maps?cp=${lat}~${lng}&lvl=${Math.round(currentZoom)}`,
       // 2D MapView uses scale, not zoom. Explicit `layers` — the portal only defaults it in 3D.
       ugs: `https://geomap.geology.utah.gov/?lat=${lat}&lng=${lng}&view=map&scale=${zoomToScale(currentZoom)}&layers=100k,reference`,
     }
     window.open(urls[service], '_blank')
     onOpenChange(false)
   }, [coords, currentZoom, onOpenChange])
-
-  // Query features at this location
-  const handleQueryHere = useCallback(() => {
-    if (!coords || !onQueryHere) return
-    onQueryHere({ lng: coords.lng, lat: coords.lat })
-    onOpenChange(false)
-  }, [coords, onQueryHere, onOpenChange])
-
-  // Zoom controls
-  const handleZoomIn = useCallback(() => {
-    if (!coords || !onZoomIn) return
-    onZoomIn({ lng: coords.lng, lat: coords.lat })
-    onOpenChange(false)
-  }, [coords, onZoomIn, onOpenChange])
-
-  const handleZoomOut = useCallback(() => {
-    if (!coords || !onZoomOut) return
-    onZoomOut({ lng: coords.lng, lat: coords.lat })
-    onOpenChange(false)
-  }, [coords, onZoomOut, onOpenChange])
-
-  const handleCenterHere = useCallback(() => {
-    if (!coords || !onCenterHere) return
-    onCenterHere({ lng: coords.lng, lat: coords.lat })
-    onOpenChange(false)
-  }, [coords, onCenterHere, onOpenChange])
 
   const handleClearSelection = useCallback(() => {
     onClearSelection?.()
@@ -200,38 +157,6 @@ export function MapContextMenu({
 
             <DropdownMenuSeparator />
 
-            {/* Query section */}
-            {onQueryHere && (
-              <DropdownMenuItem onClick={handleQueryHere}>
-                <Search className="mr-2 h-4 w-4" />
-                Query Features Here
-              </DropdownMenuItem>
-            )}
-
-            {/* Navigation section */}
-            <DropdownMenuSeparator />
-
-            {onCenterHere && (
-              <DropdownMenuItem onClick={handleCenterHere}>
-                <Crosshair className="mr-2 h-4 w-4" />
-                Center Map Here
-              </DropdownMenuItem>
-            )}
-
-            {onZoomIn && (
-              <DropdownMenuItem onClick={handleZoomIn}>
-                <ZoomIn className="mr-2 h-4 w-4" />
-                Zoom In Here
-              </DropdownMenuItem>
-            )}
-
-            {onZoomOut && (
-              <DropdownMenuItem onClick={handleZoomOut}>
-                <ZoomOut className="mr-2 h-4 w-4" />
-                Zoom Out Here
-              </DropdownMenuItem>
-            )}
-
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <Navigation className="mr-2 h-4 w-4" />
@@ -241,14 +166,8 @@ export function MapContextMenu({
                 <DropdownMenuItem onClick={() => handleOpenInMaps('google')}>
                   Google Maps
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleOpenInMaps('apple')}>
-                  Apple Maps
-                </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => handleOpenInMaps('osm')}>
                   OpenStreetMap
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handleOpenInMaps('bing')}>
-                  Bing Maps
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={() => handleOpenInMaps('ugs')}>


### PR DESCRIPTION
> Stacked on #513 — merge that first. Base is `fix/geomap-link-scale`, not develop.

## What

Users reported too many choices. The menu was 8–9 top-level rows and 15 actions, most of them restating the map: `Query Features Here` duplicates left-click, `Zoom In/Out Here` duplicates the scroll wheel and `NavigationControl`, `Center Map Here` duplicates drag.

## Changes

Cut to what only the context menu can do:

```
Copy Coordinates  ▸  DD / DMS
Copy Link to Location
─────
Open in           ▸  Google Maps / OpenStreetMap / UGS Geologic Map
─────
Clear Selection      (only when there's a selection)
```

Removed Query Features Here, Center Map Here, Zoom In/Out Here, Apple Maps, Bing Maps — nothing becomes unreachable. Dead handlers dropped from `data-map.tsx`; net −113 lines.

## Verified

`tsc`/eslint clean. `vitest` 337 passed / 12 failed — live-DB checks, red on develop too. No test covers this component; worth a click-through on the preview build.

Judgment call, not measurement — Firebase Analytics only fires `app_initialized`, so there's no per-item usage data.
