### PR TITLE
feat: add sections PMTiles layer to subsurface and carbonstorage

### DIFF
--- a/src/routes/_map/carbonstorage/-data/layers/layers.tsx
+++ b/src/routes/_map/carbonstorage/-data/layers/layers.tsx
@@ -1195,6 +1195,29 @@ const utTownshipRangesConfig: WMSLayerProps = {
     }],
 };
 
+// Sections — STAC-driven: pmtilesUrl, sourceLayer, and renders come from the
+// warehouse item `enmin_plss_sections`. Sits just below Township & Range
+// (same PLSS/UGRC source) in both the layer list and the map stack.
+const sectionsLayerName = 'enmin_plss_sections';
+export const sectionsTitle = 'Sections';
+const sectionsConfig: PMTilesLayerProps = {
+    type: 'pmtiles',
+    stacItemId: sectionsLayerName,
+    pmtilesUrl: '',
+    sourceLayer: sectionsLayerName,
+    title: sectionsTitle,
+    visible: false,
+    opacity: 1,
+    visibleZoomRange: [11, 22],
+    sourceAgency: 'UGRC',
+    sourceUrl: 'https://gis.utah.gov/products/sgid/cadastre/plss-sections/',
+    sublayers: [{
+        name: sectionsLayerName,
+        popupEnabled: false,
+        queryable: false,
+    }],
+};
+
 
 // Non Petroleum Wells Layer
 const nonpetrolWellsLayerName = 'nwpd_nonpetroleumwellcatalogwells';
@@ -1396,6 +1419,7 @@ const infrastructureAndLandUseConfig: LayerProps = {
         SITLAConfig,
         utCountiesConfig,
         utTownshipRangesConfig,
+        sectionsConfig,
     ]
 }
 

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -136,6 +136,29 @@ const utTownshipRangesConfig: WMSLayerProps = {
     }],
 };
 
+// Sections — STAC-driven: pmtilesUrl, sourceLayer, and renders come from the
+// warehouse item `enmin_plss_sections`. Sits just below Township & Range
+// (same PLSS/UGRC source) in both the layer list and the map stack.
+const sectionsLayerName = 'enmin_plss_sections';
+export const sectionsTitle = 'Sections';
+const sectionsConfig: PMTilesLayerProps = {
+    type: 'pmtiles',
+    stacItemId: sectionsLayerName,
+    pmtilesUrl: '',
+    sourceLayer: sectionsLayerName,
+    title: sectionsTitle,
+    visible: false,
+    opacity: 1,
+    visibleZoomRange: [11, 22],
+    sourceAgency: 'UGRC',
+    sourceUrl: 'https://gis.utah.gov/products/sgid/cadastre/plss-sections/',
+    sublayers: [{
+        name: sectionsLayerName,
+        popupEnabled: false,
+        queryable: false,
+    }],
+};
+
 
 
 // Oil and Gas Fields WMS Layer
@@ -603,6 +626,7 @@ const infrastructureAndLandUseConfig: LayerProps = {
         pipelinesWMSConfig,
         utCountiesConfig,
         utTownshipRangesConfig,
+        sectionsConfig,
     ]
 }
 


### PR DESCRIPTION
ALL-4950

## Summary
Adds a new 'Sections' PLSS layer, placed just below the existing 'Utah Township & Ranges' layer, in the two submaps that actually have a Township & Range layer: subsurface and carbonstorage. (geophysics was mentioned as a guess in the ticket but has no Township & Range layer to sit below, so it was left out.)

## Implementation
- STAC-driven PMTiles config (`stacItemId: 'enmin_plss_sections'`), patterned after the existing STAC-driven PMTiles layers already in each submap's layers.tsx (e.g. `powerplantsConfig`, `ucrcWellsWFSConfig`). `pmtilesUrl`/`sourceLayer`/`renders` resolve automatically from the warehouse STAC item at render time via `resolveStacLayerTree` — nothing hardcoded, consistent with house rules (catalog is the source of truth).
- Non-queryable/simple, matching the existing Township & Range layer's simplicity (`popupEnabled: false, queryable: false`).
- Same `sourceAgency`/`sourceUrl`/`visibleZoomRange` as Township & Range (same PLSS/UGRC source).
- Inserted immediately after `utTownshipRangesConfig` in each submap's `infrastructureAndLandUseConfig.layers` array, which places it directly below Township & Range in both the sidebar layer list and the map z-stack (confirmed: array order = list order = stacking order, first = top).

## Known follow-up (not in scope of this PR)
carbonstorage has a live DB-consistency test (`layer-config-consistency.test.ts`) that checks every layer title against the `ccuslayerinfo` Postgres table. That table is already out of sync with the code for ~9 other titles (Power Plants, Utah Township & Ranges, Utah Counties, etc.) on develop today — confirmed pre-existing via git stash before this change. Adding 'Sections' adds one more expected row to that same pre-existing gap; someone with DB access will need to insert a 'Sections' row into `ccuslayerinfo` for that test to fully pass again.

## Testing
- `tsc --noEmit`: no new errors (2 pre-existing unrelated errors in gdal-export.ts also present on develop)
- `eslint`: clean on both changed files
- `vitest run` on carbonstorage/subsurface: no new failures beyond the pre-existing DB-consistency gap noted above
