### PR TITLE
[ALL-4953] fix: zoom-to does nothing on Geologic Units (500k) — workspace-scoped WMS endpoint

### DIFF
--- a/src/routes/_map/__tests__/wms-extent-endpoint.test.ts
+++ b/src/routes/_map/__tests__/wms-extent-endpoint.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression guard for ALL-4953 — "zoom to" silently did nothing on the
+ * "Geologic Units (500k)" layer in the layer list.
+ *
+ * The layer-extent lookup (src/hooks/use-layer-extent.ts) fetches WMS
+ * GetCapabilities from a layer's `url` and searches it for that layer's
+ * *workspace-qualified* sublayer name (e.g. `mapping:mapping_geolunits_500k`).
+ * GeoServer only lists layers under their qualified names in the GLOBAL `/wms`
+ * capabilities document; a workspace-scoped virtual service such as
+ * `/mapping/wms` lists them UNqualified (`mapping_geolunits_500k`). So when a
+ * config points at `/mapping/wms`, the qualified name is never found, the
+ * extent resolves to null, and `map.fitBounds` is never called — zoom-to
+ * no-ops with no error surfaced.
+ *
+ * Invariant (checked across EVERY map route's config, not just the ones that
+ * carried the bug): a WMS layer served by our GeoServer must
+ *   1. use the global `/wms` endpoint, never a workspace-scoped `/{ws}/wms`, and
+ *   2. carry workspace-qualified sublayer names — the qualified name is what the
+ *      global GetCapabilities lists, so an unqualified name would break the same
+ *      lookup even on the correct endpoint.
+ *
+ * Route configs are discovered dynamically, so a newly added route (or a fresh
+ * `/mapping/wms` slip in an existing one) is covered automatically.
+ */
+import { describe, it, expect } from 'vitest'
+import { PROD_GEOSERVER_URL } from '@/lib/constants'
+import { flattenWmsLayers } from '@/lib/map/layer-utils'
+import type { LayerProps, WMSLayerProps } from '@/lib/types/mapping-types'
+
+const GLOBAL_WMS = `${PROD_GEOSERVER_URL}/wms`
+
+// Every layer-config module across the map routes, resolved at build time.
+const configModules = import.meta.glob('../*/-data/layers/*.tsx', {
+  eager: true,
+  import: 'default',
+}) as Record<string, unknown>
+
+const routeOf = (path: string) => path.match(/([^/]+)\/-data\//)?.[1] ?? path
+
+const wmsCases: [route: string, title: string, layer: WMSLayerProps][] =
+  Object.entries(configModules).flatMap(([path, config]) =>
+    Array.isArray(config)
+      ? flattenWmsLayers(config as LayerProps[]).map(
+          (layer) =>
+            [routeOf(path), layer.title, layer] as [
+              string,
+              string,
+              WMSLayerProps,
+            ]
+        )
+      : []
+  )
+
+// Only WMS layers served by our own GeoServer are subject to the invariant.
+const geoserverCases = wmsCases.filter(
+  ([, , layer]) => !!layer.url && layer.url.startsWith(PROD_GEOSERVER_URL)
+)
+
+describe('GeoServer WMS layers resolve extents via the global /wms endpoint (ALL-4953)', () => {
+  it('discovers WMS layer configs across the map routes', () => {
+    // Guards against a broken glob pattern silently turning this suite into a no-op.
+    const routes = new Set(wmsCases.map(([route]) => route))
+    expect(routes).toContain('subsurface')
+    expect(routes).toContain('geophysics')
+    expect(geoserverCases.length).toBeGreaterThan(0)
+  })
+
+  it.each(geoserverCases)(
+    '%s / %s uses the global /wms endpoint',
+    (_route, _title, layer) => {
+      expect(layer.url).toBe(GLOBAL_WMS)
+    }
+  )
+
+  it.each(geoserverCases)(
+    '%s / %s carries workspace-qualified sublayer names',
+    (_route, _title, layer) => {
+      for (const sublayer of layer.sublayers ?? []) {
+        if (sublayer.name) expect(sublayer.name).toContain(':')
+      }
+    }
+  )
+})

--- a/src/routes/_map/__tests__/wms-extent-endpoint.test.ts
+++ b/src/routes/_map/__tests__/wms-extent-endpoint.test.ts
@@ -1,26 +1,12 @@
 /**
- * Regression guard for ALL-4953 — "zoom to" silently did nothing on the
- * "Geologic Units (500k)" layer in the layer list.
+ * Regression guard for ALL-4953: "zoom to" silently no-ops on a GeoServer WMS
+ * layer whose config uses a workspace-scoped `/{ws}/wms`. The extent lookup
+ * searches GetCapabilities for the qualified sublayer name
+ * (`mapping:mapping_geolunits_500k`), which only the global `/wms` lists — a
+ * workspace service lists it unqualified, so the extent resolves null.
  *
- * The layer-extent lookup (src/hooks/use-layer-extent.ts) fetches WMS
- * GetCapabilities from a layer's `url` and searches it for that layer's
- * *workspace-qualified* sublayer name (e.g. `mapping:mapping_geolunits_500k`).
- * GeoServer only lists layers under their qualified names in the GLOBAL `/wms`
- * capabilities document; a workspace-scoped virtual service such as
- * `/mapping/wms` lists them UNqualified (`mapping_geolunits_500k`). So when a
- * config points at `/mapping/wms`, the qualified name is never found, the
- * extent resolves to null, and `map.fitBounds` is never called — zoom-to
- * no-ops with no error surfaced.
- *
- * Invariant (checked across EVERY map route's config, not just the ones that
- * carried the bug): a WMS layer served by our GeoServer must
- *   1. use the global `/wms` endpoint, never a workspace-scoped `/{ws}/wms`, and
- *   2. carry workspace-qualified sublayer names — the qualified name is what the
- *      global GetCapabilities lists, so an unqualified name would break the same
- *      lookup even on the correct endpoint.
- *
- * Route configs are discovered dynamically, so a newly added route (or a fresh
- * `/mapping/wms` slip in an existing one) is covered automatically.
+ * Invariant, checked across every map route's config: a GeoServer WMS layer
+ * uses the global `/wms` endpoint and carries qualified (`ws:name`) sublayers.
  */
 import { describe, it, expect } from 'vitest'
 import { PROD_GEOSERVER_URL } from '@/lib/constants'

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -74,7 +74,11 @@ const seamlessGeolunitsLayerName = 'mapping_geolunits_500k'
 const seamlessGeolunitsWMSTitle = 'Geologic Units (500k)';
 const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     type: 'wms',
-    url: `${PROD_GEOSERVER_URL}/mapping/wms`,
+    // Global /wms endpoint: extent/zoom-to lookups match the workspace-qualified
+    // sublayer name (mapping:mapping_geolunits_500k), which only appears in the
+    // global GetCapabilities — the workspace-scoped /mapping/wms lists it
+    // unqualified, so zoom-to silently no-ops (ALL-4953).
+    url: `${PROD_GEOSERVER_URL}/wms`,
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,
     visible: false,

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -74,10 +74,8 @@ const seamlessGeolunitsLayerName = 'mapping_geolunits_500k'
 const seamlessGeolunitsWMSTitle = 'Geologic Units (500k)';
 const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     type: 'wms',
-    // Global /wms endpoint: extent/zoom-to lookups match the workspace-qualified
-    // sublayer name (mapping:mapping_geolunits_500k), which only appears in the
-    // global GetCapabilities — the workspace-scoped /mapping/wms lists it
-    // unqualified, so zoom-to silently no-ops (ALL-4953).
+    // Global /wms, not /mapping/wms: only the global GetCapabilities lists the
+    // qualified sublayer name the zoom-to extent lookup matches (ALL-4953).
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,

--- a/src/routes/_map/geophysics/-data/layers/layers.tsx
+++ b/src/routes/_map/geophysics/-data/layers/layers.tsx
@@ -74,8 +74,6 @@ const seamlessGeolunitsLayerName = 'mapping_geolunits_500k'
 const seamlessGeolunitsWMSTitle = 'Geologic Units (500k)';
 const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     type: 'wms',
-    // Global /wms, not /mapping/wms: only the global GetCapabilities lists the
-    // qualified sublayer name the zoom-to extent lookup matches (ALL-4953).
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -405,10 +405,8 @@ const seamlessGeolunitsLayerName = 'mapping_geolunits_500k';
 export const seamlessGeolunitsWMSTitle = 'Geologic Units (500k)';
 const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     type: 'wms',
-    // Global /wms endpoint: extent/zoom-to lookups match the workspace-qualified
-    // sublayer name (mapping:mapping_geolunits_500k), which only appears in the
-    // global GetCapabilities — the workspace-scoped /mapping/wms lists it
-    // unqualified, so zoom-to silently no-ops (ALL-4953).
+    // Global /wms, not /mapping/wms: only the global GetCapabilities lists the
+    // qualified sublayer name the zoom-to extent lookup matches (ALL-4953).
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -405,8 +405,6 @@ const seamlessGeolunitsLayerName = 'mapping_geolunits_500k';
 export const seamlessGeolunitsWMSTitle = 'Geologic Units (500k)';
 const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     type: 'wms',
-    // Global /wms, not /mapping/wms: only the global GetCapabilities lists the
-    // qualified sublayer name the zoom-to extent lookup matches (ALL-4953).
     url: `${PROD_GEOSERVER_URL}/wms`,
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,

--- a/src/routes/_map/subsurface/-data/layers/layers.tsx
+++ b/src/routes/_map/subsurface/-data/layers/layers.tsx
@@ -405,7 +405,11 @@ const seamlessGeolunitsLayerName = 'mapping_geolunits_500k';
 export const seamlessGeolunitsWMSTitle = 'Geologic Units (500k)';
 const seamlessGeolunitsWMSConfig: WMSLayerProps = {
     type: 'wms',
-    url: `${PROD_GEOSERVER_URL}/mapping/wms`,
+    // Global /wms endpoint: extent/zoom-to lookups match the workspace-qualified
+    // sublayer name (mapping:mapping_geolunits_500k), which only appears in the
+    // global GetCapabilities — the workspace-scoped /mapping/wms lists it
+    // unqualified, so zoom-to silently no-ops (ALL-4953).
+    url: `${PROD_GEOSERVER_URL}/wms`,
     title: seamlessGeolunitsWMSTitle,
     opacity: 0.5,
     visible: false,


### PR DESCRIPTION
**TL;DR** — "Zoom to" on the Geologic Units (500k) layer did nothing. Two layer configs pointed the WMS extent lookup at GeoServer's workspace-scoped `/mapping/wms`, which lists layers *unqualified* — but the lookup searches for the qualified name (`mapping:mapping_geolunits_500k`), so it found nothing, got a null extent, and never called `fitBounds`. Fix: point those configs at the global `/wms` like every other layer (carbonstorage already did, for this same layer).

**What changed**
- `subsurface` + `geophysics` geolunits configs: `/mapping/wms` → `/wms` (one line each).
- New regression test that walks every map route's layer config and asserts GeoServer WMS layers use the global endpoint with qualified sublayer names — so a future `/mapping/wms` slip in any route fails CI.

**Verified**
- 319 assertions green (endpoint + qualified-name invariant across all routes); existing parser tests still pass; `tsc` and the production build are clean.
- Ran locally: zoom-to now recenters the map to Utah, extent request hits `/geoserver/wms` → 200, tiles/legend still render.

**Reviews** — code-correctness and geospatial/GeoServer domain passes, both cleared: no runtime regression. GetMap tiles, GetLegendGraphic, GetFeatureInfo, and the WFS identify path all send the qualified name, which the global endpoint serves; carbonstorage is the in-prod precedent. `crs` is dead config for WMS layers and is unaffected.

**Follow-up (separate ticket)** — the underlying footgun is that `handleZoomToLayer` silently no-ops on a null extent (no toast/warn), so PMTiles/ArcGIS/WFS layers could fail zoom-to invisibly the same way. Worth a fail-loud follow-up.
