### PR TITLE
fix(hazards): InSAR displacement/aquifer popup, legend & threshold refinements (ALL-5637 ALL-5638 ALL-5639 ALL-5640 ALL-5641 ALL-5642)

### DIFF
--- a/src/lib/__tests__/field-formatting.test.ts
+++ b/src/lib/__tests__/field-formatting.test.ts
@@ -6,6 +6,8 @@ import {
   formatWithDecimalPlaces,
   getNumberFieldTransform,
   formatFieldValue,
+  formatDate,
+  capitalizeFirst,
 } from '../field-formatting';
 import type {
   NumberPopupFieldConfig,
@@ -114,5 +116,48 @@ describe('formatFieldValue', () => {
 
     const noTransform: CustomPopupFieldConfig = { type: 'custom', field: 'computed' };
     expect(formatFieldValue(noTransform, 'ignored')).toBe('');
+  });
+});
+
+// ── formatDate: monthYear ────────────────────────────────────────────────
+
+describe('formatDate monthYear', () => {
+  it('formats an ISO datetime as MM-YYYY', () => {
+    expect(formatDate('2017-10-20T00:00:00Z', 'monthYear')).toBe('10-2017');
+  });
+
+  it('reads UTC so a UTC-midnight first-of-month stays in that month', () => {
+    // 2023-10-01T00:00:00Z is 2023-09-30 in local time west of UTC (e.g. Denver);
+    // it must still render as 10-2023, not 09-2023.
+    expect(formatDate('2023-10-01T00:00:00Z', 'monthYear')).toBe('10-2023');
+  });
+
+  it('zero-pads single-digit months', () => {
+    expect(formatDate('2024-01-15T00:00:00Z', 'monthYear')).toBe('01-2024');
+  });
+
+  it('returns empty for null/empty and echoes unparseable input', () => {
+    expect(formatDate(null, 'monthYear')).toBe('');
+    expect(formatDate('', 'monthYear')).toBe('');
+    expect(formatDate('not-a-date', 'monthYear')).toBe('not-a-date');
+  });
+});
+
+// ── capitalizeFirst ──────────────────────────────────────────────────────
+
+describe('capitalizeFirst', () => {
+  it('capitalizes only the first character', () => {
+    expect(capitalizeFirst('high')).toBe('High');
+    expect(capitalizeFirst('medium')).toBe('Medium');
+    expect(capitalizeFirst('very low')).toBe('Very low');
+  });
+
+  it('leaves already-capitalized input unchanged', () => {
+    expect(capitalizeFirst('Medium')).toBe('Medium');
+  });
+
+  it('passes through empty and null', () => {
+    expect(capitalizeFirst('')).toBe('');
+    expect(capitalizeFirst(null)).toBe(null);
   });
 });

--- a/src/lib/field-formatting.ts
+++ b/src/lib/field-formatting.ts
@@ -62,9 +62,23 @@ export const formatDate = (value: unknown, format: DatePopupFieldConfig['format'
       return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
     case 'long':
       return date.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+    case 'monthYear':
+      // MM-YYYY, read in UTC. The InSAR period dates arrive as UTC-midnight
+      // instants (e.g. 2023-10-01T00:00:00Z); using local time would slip a
+      // first-of-month reading back into the prior month west of UTC.
+      return `${String(date.getUTCMonth() + 1).padStart(2, '0')}-${date.getUTCFullYear()}`
     default:
       return date.toISOString().slice(0, 10)
   }
+}
+
+/**
+ * Capitalize only the first character of a string, leaving the rest as-is
+ * (so "very low" -> "Very low", not "Very Low"). Passes through empty/null.
+ */
+export const capitalizeFirst = (value: string | null): string | null => {
+  if (value === null || value === '') return value
+  return value.charAt(0).toUpperCase() + value.slice(1)
 }
 
 /**

--- a/src/lib/types/mapping-types.ts
+++ b/src/lib/types/mapping-types.ts
@@ -62,7 +62,7 @@ export interface NumberPopupFieldConfig extends BaseFieldConfig {
 // Date-specific field configuration
 export interface DatePopupFieldConfig extends BaseFieldConfig {
     type: 'date';
-    format?: 'iso' | 'short' | 'long';
+    format?: 'iso' | 'short' | 'long' | 'monthYear';
 }
 
 // Custom-specific field configuration

--- a/src/routes/_map/hazards-review/-components/popups/__tests__/displacement-layer-filters.test.ts
+++ b/src/routes/_map/hazards-review/-components/popups/__tests__/displacement-layer-filters.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { getPopulatedBinBoundaries } from '../displacement-layer-filters'
+import type { SldBin } from '../displacement-sld-legend'
+
+const bin = (min: number, max: number, isZero = false): SldBin => ({
+    name: '', title: '', min, max, color: '#000', isZero, include: [], exclude: [],
+})
+
+// Cumulative-shaped SLD mirroring hazards_insar_displacement_cumulative:
+// deadband [-1, 1]; subsidence classes run deeper (to <-13) than uplift (to >9),
+// so the magnitude edges reduce to {1,3,5,7,9,11,13} (11/13 come from the deeper
+// negative side).
+const cumulativeBins: SldBin[] = [
+    bin(-Infinity, -13), bin(-13, -11), bin(-11, -9), bin(-9, -7),
+    bin(-7, -5), bin(-5, -3), bin(-3, -1),
+    bin(-1, 1, true),
+    bin(1, 3), bin(3, 5), bin(5, 7), bin(7, 9), bin(9, Infinity),
+]
+
+describe('getPopulatedBinBoundaries', () => {
+    it('drops the empty 1-3 band for Cumulative so "1 in" no longer duplicates "3 in"', () => {
+        // Real Cumulative contours are odd inches and |1| is the deadband, so no
+        // feature falls in [1, 3) — the 1 edge is redundant with 3.
+        const magnitudes = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25]
+        const opts = getPopulatedBinBoundaries(cumulativeBins, magnitudes)
+        expect(opts).not.toContain(1)
+        expect(opts[0]).toBe(3)
+    })
+
+    it('keeps the 1 edge when a real feature sits in the 1-3 band above the deadband', () => {
+        // A |2| reading makes [1, 3) non-empty, so "1 in" now filters differently
+        // from "3 in" and is offered.
+        const magnitudes = [1, 2, 3, 5, 7, 9]
+        const opts = getPopulatedBinBoundaries(cumulativeBins, magnitudes)
+        expect(opts[0]).toBe(1)
+        expect(opts).toContain(3)
+    })
+
+    it('drops the open top edge when no feature reaches it', () => {
+        // Only |3| and |5| present, so the 7/9/11/13 edges' bands are empty.
+        expect(getPopulatedBinBoundaries(cumulativeBins, [1, 3, 5])).toEqual([3, 5])
+    })
+
+    it('offers nothing while feature magnitudes are still loading', () => {
+        expect(getPopulatedBinBoundaries(cumulativeBins, [])).toEqual([])
+    })
+
+    it('offers every populated edge when the style has no deadband (zeroBound 0)', () => {
+        const noDeadband: SldBin[] = [bin(1, 3), bin(3, 5), bin(5, Infinity)]
+        expect(getPopulatedBinBoundaries(noDeadband, [1, 3, 5])).toEqual([1, 3, 5])
+    })
+})

--- a/src/routes/_map/hazards-review/-components/popups/__tests__/displacement-sld-legend.test.ts
+++ b/src/routes/_map/hazards-review/-components/popups/__tests__/displacement-sld-legend.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { binMatches, parseRuleFilter, type SldBin } from '../displacement-sld-legend'
+import { binMatches, magnitudeLabel, parseRuleFilter, type SldBin } from '../displacement-sld-legend'
 
 const DEADBAND = "NOT (value_inches >= '-1' AND value_inches <= '1')"
 
@@ -46,5 +46,24 @@ describe('binMatches', () => {
 
     it('matches nothing when the filter did not parse', () => {
         expect(binMatches(bin([], []), 5)).toBe(false)
+    })
+})
+
+describe('magnitudeLabel', () => {
+    const b = (min: number, max: number): SldBin => ({
+        name: 'x', title: 'x', min, max, color: '#000', isZero: false, include: [], exclude: [],
+    })
+
+    it('renders a subsidence bin as an unsigned range (no "-5 – -3")', () => {
+        expect(magnitudeLabel(b(-5, -3))).toBe('3 – 5 in')
+    })
+
+    it('renders an uplift bin as a range', () => {
+        expect(magnitudeLabel(b(3, 5))).toBe('3 – 5 in')
+    })
+
+    it('renders an open tail with a > prefix, either sign', () => {
+        expect(magnitudeLabel(b(9, Infinity))).toBe('> 9 in')
+        expect(magnitudeLabel(b(-Infinity, -13))).toBe('> 13 in')
     })
 })

--- a/src/routes/_map/hazards-review/-components/popups/__tests__/displacement-thresholds.test.ts
+++ b/src/routes/_map/hazards-review/-components/popups/__tests__/displacement-thresholds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getPopulatedBinBoundaries } from '../displacement-layer-filters'
+import { getPopulatedBinBoundaries } from '../displacement-thresholds'
 import type { SldBin } from '../displacement-sld-legend'
 
 const bin = (min: number, max: number, isZero = false): SldBin => ({

--- a/src/routes/_map/hazards-review/-components/popups/displacement-filter-context.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-filter-context.tsx
@@ -9,7 +9,7 @@ import {
     type DisplacementLayerTitle,
     type DisplacementType,
 } from './displacement-layers'
-import { useDisplacementLatestYearByType, useDisplacementSldZeroBound } from './use-displacement-queries'
+import { useDisplacementDefaultThresholdForType, useDisplacementLatestYearByType, useDisplacementSldZeroBound } from './use-displacement-queries'
 
 // Re-export the type predicates + token sets so existing call sites keep
 // importing from this module — the canonical definitions now live in
@@ -263,18 +263,22 @@ export function useEffectiveYear(type: DisplacementType): string | null {
 
 /**
  * Resolve the effective threshold per charted type: the reviewer's override if
- * set, else the SLD's "Zero" deadband, else FALLBACK_THRESHOLD_IN while the SLD
- * loads. This single value drives the map cql, the stacked bar, AND the KPIs —
- * one honest knob, no visual-vs-audit split.
+ * set, else the per-type default — the smallest data-populated SLD edge, so the
+ * map, chart and dropdown agree and the map hides the deadband by default like
+ * the chart — else the SLD's "Zero" deadband, else FALLBACK_THRESHOLD_IN while
+ * things load. This single value drives the map cql, the stacked bar, AND the
+ * KPIs — one honest knob, no visual-vs-audit split.
  */
 export function useEffectiveThresholdsIn(): Record<ChartedType, number> {
     const { thresholdsIn } = useDisplacementFilters()
+    const cumulativeFloor = useDisplacementDefaultThresholdForType('Cumulative')
+    const yearlyFloor = useDisplacementDefaultThresholdForType('Yearly')
     const cumulativeSld = useDisplacementSldZeroBound('Cumulative')
     const yearlySld = useDisplacementSldZeroBound('Yearly')
     return useMemo(() => ({
-        'Cumulative': thresholdsIn['Cumulative'] ?? cumulativeSld ?? FALLBACK_THRESHOLD_IN['Cumulative'],
-        'Yearly': thresholdsIn['Yearly'] ?? yearlySld ?? FALLBACK_THRESHOLD_IN['Yearly'],
-    }), [thresholdsIn, cumulativeSld, yearlySld])
+        'Cumulative': thresholdsIn['Cumulative'] ?? cumulativeFloor ?? cumulativeSld ?? FALLBACK_THRESHOLD_IN['Cumulative'],
+        'Yearly': thresholdsIn['Yearly'] ?? yearlyFloor ?? yearlySld ?? FALLBACK_THRESHOLD_IN['Yearly'],
+    }), [thresholdsIn, cumulativeFloor, yearlyFloor, cumulativeSld, yearlySld])
 }
 
 /**

--- a/src/routes/_map/hazards-review/-components/popups/displacement-layer-charts.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-layer-charts.tsx
@@ -9,7 +9,7 @@ import type { LayerContentProps } from '@/components/maps/popups/types'
 import { useDisplacementFilters, useEffectiveThresholdsIn, useEffectiveYear } from './displacement-filter-context'
 import { useMap } from '@/hooks/use-map'
 import { DISPLACEMENT_LAYER_TYPES, getStyleNameForType, getUnitsLabelForType, isChartedType, isDisplacementLayerTitle, type ChartedType, type DisplacementType } from './displacement-layers'
-import { binMatches, getZeroBound, type SldBin } from './displacement-sld-legend'
+import { binMatches, getZeroBound, magnitudeLabel, type SldBin } from './displacement-sld-legend'
 import {
     getBucketYear,
     useDisplacementFeaturesByType,
@@ -472,6 +472,7 @@ function DisplacementLayerCharts({ typeValue }: { typeValue: ChartedType }) {
                 </div>
                 {(visibleUpliftBins.length > 0 || visibleSubsidenceBins.length > 0) && (
                     <div className="mt-2 flex flex-col gap-1 px-2">
+                        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Vertical Displacement</div>
                         <div className="flex items-baseline justify-between text-xs text-muted-foreground">
                             <span>
                                 {legendSpan ? <>Area by range · <span className="font-medium text-foreground">{legendSpan}</span>{!isRangeMode && hoveredYear ? ' (hovered)' : ''}</> : 'Area by range'}
@@ -773,7 +774,7 @@ function ChartLegendGroup({ label, bins, valueFor, secondaryValueFor }: { label:
     if (bins.length === 0) return null
     const items: LegendSwatchItem[] = bins.map(b => ({
         key: b.name,
-        label: b.title,
+        label: magnitudeLabel(b),
         color: b.color,
         value: valueFor?.(b.name),
         secondaryValue: secondaryValueFor?.(b.name),

--- a/src/routes/_map/hazards-review/-components/popups/displacement-layer-filters.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-layer-filters.tsx
@@ -24,7 +24,7 @@ function isDefaultDataQuals(excluded: ReadonlySet<string>): boolean {
         && DEFAULT_EXCLUDED_DATA_QUALS.every(q => excluded.has(q))
 }
 import { useDisplacementBasinsForType, useDisplacementBasinYearIndexForType, useDisplacementDataQualsForType, useDisplacementSldBins, useDisplacementValueMagnitudesForType, useDisplacementYearsForType } from './use-displacement-queries'
-import { getZeroBound, type SldBin } from './displacement-sld-legend'
+import { getPopulatedBinBoundaries } from './displacement-thresholds'
 
 // Label the year dropdown by type semantics: 'Water Year' for Yearly,
 // 'Period End Year' for Cumulative + Vertical Displacement Rate.
@@ -255,37 +255,6 @@ function DisplacementLayerFilters({ typeValue }: { typeValue: DisplacementType }
     )
 }
 
-// Positive SLD class edges (magnitudes), deduped + sorted ascending. These are
-// the structural boundaries from the style; `getPopulatedBinBoundaries` trims
-// them to the ones the data actually backs.
-function getBinBoundaries(bins: SldBin[]): number[] {
-    const edges = new Set<number>()
-    for (const b of bins) {
-        if (b.isZero) continue
-        for (const v of [b.min, b.max]) {
-            if (Number.isFinite(v)) edges.add(Math.abs(v))
-        }
-    }
-    return Array.from(edges).filter(v => v > 0).sort((a, b) => a - b)
-}
-
-// Threshold options: SLD class edges kept only when a real, non-deadband feature
-// sits in the band [edge, nextEdge). Two consecutive edges filter to the same
-// set unless some feature's |value| falls between them, so an SLD class the data
-// never fills would otherwise offer a redundant option. Concretely for
-// Cumulative, contours are odd inches and ±1 is the deadband, so the 1–3 in band
-// is empty and "1 in" would filter identically to "3 in" — this drops the 1.
-// `magnitudes` is the ascending distinct |value_inches| present for the type.
-export function getPopulatedBinBoundaries(bins: SldBin[], magnitudes: number[]): number[] {
-    const edges = getBinBoundaries(bins)
-    const zeroBound = getZeroBound(bins) ?? 0
-    const measured = magnitudes.filter(m => m > zeroBound)
-    return edges.filter((edge, i) => {
-        const next = edges[i + 1] ?? Infinity
-        return measured.some(m => m >= edge && m < next)
-    })
-}
-
 interface ThresholdSelectProps {
     typeValue: ChartedType
     currentThresholdIn: number
@@ -295,13 +264,12 @@ interface ThresholdSelectProps {
 
 // Threshold as a dropdown of the SLD bin edges the data actually fills (see
 // getPopulatedBinBoundaries — empty-band edges are dropped so no two options
-// filter to the same set). The first, smallest offered edge is marked
-// "· default"; picking it resets to the SLD default (the Zero-deadband bound),
-// which for the chart/stats collapses onto that edge. Larger edges tighten the
-// filter on |value| (both signs). Below-default values aren't offered — the
-// deadband is measurement noise, so reviewers can only raise the bar. (At the
-// default the map still draws the deadband band, since the map filters on the
-// effective bound, not this label — a pre-existing map/chart split.)
+// filter to the same set). The first, smallest offered edge is the per-type
+// default (marked "· default") and is exactly what the effective threshold
+// resolves to when unset, so the map, chart, and dropdown all agree. Picking it
+// resets to that default; larger edges tighten the filter on |value| (both
+// signs). Below the default isn't offered — that band is the measurement-noise
+// deadband, which the chart and (at the default) the map both exclude.
 function ThresholdSelect({ typeValue, currentThresholdIn, onChange, onReset }: ThresholdSelectProps) {
     const styleName = getStyleNameForType(typeValue) ?? ''
     const { data: sldBins = [] } = useDisplacementSldBins(styleName)
@@ -311,10 +279,10 @@ function ThresholdSelect({ typeValue, currentThresholdIn, onChange, onReset }: T
 
     const fmt = (n: number) => n.toFixed(1)
     const defaultThreshold = boundaries[0]
-    // The effective default is the SLD deadband bound, which can sit below the
-    // smallest offered edge (the deadband is excluded from the chart, so it
-    // collapses onto that edge). Clamp up so the control reflects the option
-    // actually in force instead of rendering blank against a value with no item.
+    // currentThresholdIn (the effective threshold) defaults to this same floor,
+    // so normally it equals defaultThreshold. Clamp up only so a stale sub-floor
+    // override (e.g. an old URL) can't render blank against options that start at
+    // the floor.
     const selected = fmt(Math.max(currentThresholdIn, defaultThreshold))
 
     return (

--- a/src/routes/_map/hazards-review/-components/popups/displacement-layer-filters.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-layer-filters.tsx
@@ -23,8 +23,8 @@ function isDefaultDataQuals(excluded: ReadonlySet<string>): boolean {
     return excluded.size === DEFAULT_EXCLUDED_DATA_QUALS.length
         && DEFAULT_EXCLUDED_DATA_QUALS.every(q => excluded.has(q))
 }
-import { useDisplacementBasinsForType, useDisplacementBasinYearIndexForType, useDisplacementDataQualsForType, useDisplacementSldBins, useDisplacementYearsForType } from './use-displacement-queries'
-import { type SldBin } from './displacement-sld-legend'
+import { useDisplacementBasinsForType, useDisplacementBasinYearIndexForType, useDisplacementDataQualsForType, useDisplacementSldBins, useDisplacementValueMagnitudesForType, useDisplacementYearsForType } from './use-displacement-queries'
+import { getZeroBound, type SldBin } from './displacement-sld-legend'
 
 // Label the year dropdown by type semantics: 'Water Year' for Yearly,
 // 'Period End Year' for Cumulative + Vertical Displacement Rate.
@@ -255,11 +255,9 @@ function DisplacementLayerFilters({ typeValue }: { typeValue: DisplacementType }
     )
 }
 
-// Positive bin edges from the SLD response, deduped + sorted ascending. These
-// are the only meaningful threshold values (any |value_inches| between two edges
-// yields the same filtered set). The smallest edge is the SLD's "Zero" deadband
-// bound, so every option is >= the deadband by construction — the UI can't drop
-// the threshold below the uncertainty band.
+// Positive SLD class edges (magnitudes), deduped + sorted ascending. These are
+// the structural boundaries from the style; `getPopulatedBinBoundaries` trims
+// them to the ones the data actually backs.
 function getBinBoundaries(bins: SldBin[]): number[] {
     const edges = new Set<number>()
     for (const b of bins) {
@@ -271,6 +269,23 @@ function getBinBoundaries(bins: SldBin[]): number[] {
     return Array.from(edges).filter(v => v > 0).sort((a, b) => a - b)
 }
 
+// Threshold options: SLD class edges kept only when a real, non-deadband feature
+// sits in the band [edge, nextEdge). Two consecutive edges filter to the same
+// set unless some feature's |value| falls between them, so an SLD class the data
+// never fills would otherwise offer a redundant option. Concretely for
+// Cumulative, contours are odd inches and ±1 is the deadband, so the 1–3 in band
+// is empty and "1 in" would filter identically to "3 in" — this drops the 1.
+// `magnitudes` is the ascending distinct |value_inches| present for the type.
+export function getPopulatedBinBoundaries(bins: SldBin[], magnitudes: number[]): number[] {
+    const edges = getBinBoundaries(bins)
+    const zeroBound = getZeroBound(bins) ?? 0
+    const measured = magnitudes.filter(m => m > zeroBound)
+    return edges.filter((edge, i) => {
+        const next = edges[i + 1] ?? Infinity
+        return measured.some(m => m >= edge && m < next)
+    })
+}
+
 interface ThresholdSelectProps {
     typeValue: ChartedType
     currentThresholdIn: number
@@ -278,20 +293,29 @@ interface ThresholdSelectProps {
     onReset: () => void
 }
 
-// Threshold as a predefined dropdown of SLD bin edges. The first option is the
-// SLD default (the Zero-deadband bound); selecting it resets to default.
-// Selecting a larger edge tightens the filter on |value| (both signs) across the
-// map, chart, and stats. Below-default values aren't offered — the deadband is
-// measurement noise, so reviewers can only raise the bar, not lower it.
+// Threshold as a dropdown of the SLD bin edges the data actually fills (see
+// getPopulatedBinBoundaries — empty-band edges are dropped so no two options
+// filter to the same set). The first, smallest offered edge is marked
+// "· default"; picking it resets to the SLD default (the Zero-deadband bound),
+// which for the chart/stats collapses onto that edge. Larger edges tighten the
+// filter on |value| (both signs). Below-default values aren't offered — the
+// deadband is measurement noise, so reviewers can only raise the bar. (At the
+// default the map still draws the deadband band, since the map filters on the
+// effective bound, not this label — a pre-existing map/chart split.)
 function ThresholdSelect({ typeValue, currentThresholdIn, onChange, onReset }: ThresholdSelectProps) {
     const styleName = getStyleNameForType(typeValue) ?? ''
     const { data: sldBins = [] } = useDisplacementSldBins(styleName)
-    const boundaries = useMemo(() => getBinBoundaries(sldBins), [sldBins])
+    const magnitudes = useDisplacementValueMagnitudesForType(typeValue)
+    const boundaries = useMemo(() => getPopulatedBinBoundaries(sldBins, magnitudes), [sldBins, magnitudes])
     if (boundaries.length === 0) return null
 
     const fmt = (n: number) => n.toFixed(1)
     const defaultThreshold = boundaries[0]
-    const selected = fmt(currentThresholdIn)
+    // The effective default is the SLD deadband bound, which can sit below the
+    // smallest offered edge (the deadband is excluded from the chart, so it
+    // collapses onto that edge). Clamp up so the control reflects the option
+    // actually in force instead of rendering blank against a value with no item.
+    const selected = fmt(Math.max(currentThresholdIn, defaultThreshold))
 
     return (
         <div className="flex flex-col gap-1 rounded border border-dashed border-border p-2">

--- a/src/routes/_map/hazards-review/-components/popups/displacement-legend.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-legend.tsx
@@ -9,7 +9,7 @@ import {
     isDisplacementLayerTitle,
     type DisplacementType,
 } from './displacement-layers'
-import { type SldBin } from './displacement-sld-legend'
+import { magnitudeLabel, type SldBin } from './displacement-sld-legend'
 
 /**
  * `layerLegendRender` for the hazards-review layer list. Replaces the default
@@ -25,8 +25,8 @@ export function renderDisplacementLegend(layer: LayerProps): React.ReactNode {
     return <DisplacementLegend typeValue={typeValue} />
 }
 
-function toSwatchItems(bins: SldBin[]) {
-    return bins.map(b => ({ key: b.name, label: b.title, color: b.color }))
+function toSwatchItems(bins: SldBin[], label: (b: SldBin) => string = b => b.title) {
+    return bins.map(b => ({ key: b.name, label: label(b), color: b.color }))
 }
 
 function LegendGroup({ label, bins }: { label: string; bins: SldBin[] }) {
@@ -34,7 +34,7 @@ function LegendGroup({ label, bins }: { label: string; bins: SldBin[] }) {
     return (
         <div className="flex flex-col gap-1 min-w-0">
             <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</div>
-            <LegendSwatchGrid items={toSwatchItems(bins)} columns="single" />
+            <LegendSwatchGrid items={toSwatchItems(bins, magnitudeLabel)} columns="single" />
         </div>
     )
 }

--- a/src/routes/_map/hazards-review/-components/popups/displacement-legend.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-legend.tsx
@@ -60,9 +60,10 @@ function DisplacementLegend({ typeValue }: { typeValue: DisplacementType }) {
 
     return (
         <div className="flex flex-col gap-2 px-1 py-1">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Vertical Displacement</div>
             <div className="grid grid-cols-2 gap-x-3 text-xs text-foreground">
-                <LegendGroup label="Uplift (above zero)" bins={upliftBins} />
-                <LegendGroup label="Subsidence (below zero)" bins={subsidenceBins} />
+                <LegendGroup label="Uplift" bins={upliftBins} />
+                <LegendGroup label="Subsidence" bins={subsidenceBins} />
             </div>
             {zeroBin && (
                 <div className="border-t border-border/60 pt-1.5">

--- a/src/routes/_map/hazards-review/-components/popups/displacement-sld-legend.ts
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-sld-legend.ts
@@ -122,3 +122,15 @@ export function getZeroBound(bins: SldBin[]): number | null {
     if (!zero) return null
     return Math.max(Math.abs(zero.min), Math.abs(zero.max))
 }
+
+// Unsigned-magnitude label for a non-deadband bin, so a subsidence bin reads
+// "3 – 5 in" (how deep it subsided) instead of "-5 – -3 in". Direction is already
+// carried by the Uplift/Subsidence column and the color, so the sign is redundant
+// and "negative subsidence" is confusing. Derived from the bin's own bounds, so it
+// tracks the SLD. Not meaningful for the deadband bin, which keeps its own title.
+export function magnitudeLabel(bin: SldBin): string {
+    const lo = Math.min(Math.abs(bin.min), Math.abs(bin.max))
+    const hi = Math.max(Math.abs(bin.min), Math.abs(bin.max))
+    if (!Number.isFinite(hi)) return `> ${lo} in`
+    return `${lo} – ${hi} in`
+}

--- a/src/routes/_map/hazards-review/-components/popups/displacement-thresholds.ts
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-thresholds.ts
@@ -1,0 +1,34 @@
+import { getZeroBound, type SldBin } from './displacement-sld-legend'
+
+// Positive SLD class edges (magnitudes), deduped + sorted ascending. These are
+// the structural boundaries from the style; getPopulatedBinBoundaries trims them
+// to the ones the data actually backs.
+export function getBinBoundaries(bins: SldBin[]): number[] {
+    const edges = new Set<number>()
+    for (const b of bins) {
+        if (b.isZero) continue
+        for (const v of [b.min, b.max]) {
+            if (Number.isFinite(v)) edges.add(Math.abs(v))
+        }
+    }
+    return Array.from(edges).filter(v => v > 0).sort((a, b) => a - b)
+}
+
+// Threshold options: SLD class edges kept only when a real, non-deadband feature
+// sits in the band [edge, nextEdge). Two consecutive edges filter to the same set
+// unless some feature's |value| falls between them, so an SLD class the data never
+// fills would otherwise offer a redundant option. Concretely for Cumulative,
+// contours are odd inches and ±1 is the deadband, so the 1–3 in band is empty and
+// "1 in" would filter identically to "3 in" — this drops the 1. `magnitudes` is
+// the ascending distinct |value_inches| present for the type. The first element
+// is the smallest meaningful threshold, and is used as the per-type default so the
+// map, chart, and dropdown all agree.
+export function getPopulatedBinBoundaries(bins: SldBin[], magnitudes: number[]): number[] {
+    const edges = getBinBoundaries(bins)
+    const zeroBound = getZeroBound(bins) ?? 0
+    const measured = magnitudes.filter(m => m > zeroBound)
+    return edges.filter((edge, i) => {
+        const next = edges[i + 1] ?? Infinity
+        return measured.some(m => m >= edge && m < next)
+    })
+}

--- a/src/routes/_map/hazards-review/-components/popups/use-displacement-queries.ts
+++ b/src/routes/_map/hazards-review/-components/popups/use-displacement-queries.ts
@@ -1,5 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { queryOptions, useQuery } from '@tanstack/react-query'
+import { getPopulatedBinBoundaries } from './displacement-thresholds'
 import type { Feature, Polygon, MultiPolygon } from 'geojson'
 import { PROD_GEOSERVER_URL } from '@/lib/constants'
 import { queryKeys } from '@/lib/query-keys'
@@ -201,6 +202,21 @@ export function useDisplacementValueMagnitudesForType(type: DisplacementType): n
     }, [type])
     const { data = [] } = useQuery({ ...displacementFeaturesQueryOptions(), select })
     return data
+}
+
+// The per-type default threshold: the smallest data-populated SLD edge (see
+// getPopulatedBinBoundaries). Used as the effective default so the map, chart and
+// threshold dropdown all agree, and so the map hides the measurement-noise
+// deadband by default the way the chart already does. null until both the SLD and
+// features have loaded — callers fall back to the SLD deadband, then a constant.
+export function useDisplacementDefaultThresholdForType(type: DisplacementType): number | null {
+    const styleName = getStyleNameForType(type) ?? ''
+    const { data: bins = [] } = useDisplacementSldBins(styleName)
+    const magnitudes = useDisplacementValueMagnitudesForType(type)
+    return useMemo(() => {
+        const edges = getPopulatedBinBoundaries(bins, magnitudes)
+        return edges.length > 0 ? edges[0] : null
+    }, [bins, magnitudes])
 }
 
 // Latest year present for a given type — Yearly uses water year, period-keyed

--- a/src/routes/_map/hazards-review/-components/popups/use-displacement-queries.ts
+++ b/src/routes/_map/hazards-review/-components/popups/use-displacement-queries.ts
@@ -184,6 +184,25 @@ export function useDisplacementDataQualsForType(type: DisplacementType): string[
     return useDistinctByType(type, extractDataQual, sortByDataQualOrder)
 }
 
+// Distinct |value_inches| magnitudes present for a type, ascending. Backs the
+// threshold dropdown: an edge only earns a slot when real features sit in the
+// band above it, so an SLD class the data never fills (e.g. Cumulative's
+// 1–3 in band) doesn't yield a redundant option that filters identically to the
+// next one.
+export function useDisplacementValueMagnitudesForType(type: DisplacementType): number[] {
+    const select = useCallback((features: DisplacementFeature[]) => {
+        const set = new Set<number>()
+        for (const f of features) {
+            if (f.properties.type !== type) continue
+            const v = f.properties.value_inches
+            if (typeof v === 'number' && Number.isFinite(v)) set.add(Math.abs(v))
+        }
+        return Array.from(set).sort((a, b) => a - b)
+    }, [type])
+    const { data = [] } = useQuery({ ...displacementFeaturesQueryOptions(), select })
+    return data
+}
+
 // Latest year present for a given type — Yearly uses water year, period-keyed
 // types use end_date year. Drives the default selection when no explicit
 // override is in place (the year filter is mandatory: no "all years" sentinel

--- a/src/routes/_map/hazards-review/-data/layers/layers.tsx
+++ b/src/routes/_map/hazards-review/-data/layers/layers.tsx
@@ -1,11 +1,13 @@
 import { PROD_GEOSERVER_URL, HAZARDS_WORKSPACE, PROD_POSTGREST_URL, GEN_GIS_WORKSPACE } from "@/lib/constants";
-import { LayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
+import { FieldConfig, LayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
+import { capitalizeFirst } from "@/lib/field-formatting";
 import {
     DISPLACEMENT_LAYERS,
     DISPLACEMENT_TYPE_NAME,
     LAND_SUBSIDENCE_GROUP_TITLE,
     getUnitsLabelForType,
     type DisplacementLayerTitle,
+    type DisplacementType,
 } from "../../-components/popups/displacement-layers";
 import GeoJSON from "geojson";
 
@@ -991,8 +993,6 @@ const aquifersCombinedConfig: WMSLayerProps = {
             queryable: true,
             popupFields: {
                 'Name': { field: 'name', type: 'string' },
-                'Publication': { field: 'publication', type: 'string' },
-                'DOI': { field: 'doi', type: 'string' },
                 'Office': { field: 'office_1', type: 'string' },
                 'HUC 1': { field: 'huc_1', type: 'string' },
                 'HUC 2': { field: 'huc_2', type: 'string' },
@@ -1005,16 +1005,24 @@ const aquifersCombinedConfig: WMSLayerProps = {
 // The registry already provides the workspace-qualified type name and per-title
 // type + style metadata, so layer configs just look up what they need.
 const DISPLACEMENT_CONTOURS_LAYER = DISPLACEMENT_TYPE_NAME;
-const displacementPopupFields = {
-    'Location': { field: 'location', type: 'string' },
-    'Type': { field: 'type', type: 'string' },
-    'Year': { field: 'year', type: 'string' },
-    'Period Start': { field: 'start_date', type: 'string' },
-    'Period End': { field: 'end_date', type: 'string' },
-    'Displacement (in)': { field: 'value_inches', type: 'number', format: 'oneDecimal' },
-    'Data Quality': { field: 'data_qual', type: 'string' },
-    'Valid Pixels (%)': { field: 'pct_valid', type: 'number', format: 'oneDecimal' },
-} as const;
+
+// Popup fields for the displacement layers, built per type. The Displacement
+// unit reflects the reading — Vertical Displacement Rate is in/year, Cumulative
+// and Yearly are an amount in inches. Year is intentionally omitted: the period
+// (Period Start → Period End, rendered MM-YYYY) already carries the timeframe.
+// Data Quality is normalized to first-letter caps ("high" -> "High").
+function makeDisplacementPopupFields(typeValue: DisplacementType): Record<string, FieldConfig> {
+    const displacementUnit = typeValue === 'Vertical Displacement Rate' ? 'in/year' : 'in';
+    return {
+        'Location': { field: 'location', type: 'string' },
+        'Type': { field: 'type', type: 'string' },
+        'Period Start': { field: 'start_date', type: 'date', format: 'monthYear' },
+        'Period End': { field: 'end_date', type: 'date', format: 'monthYear' },
+        [`Displacement (${displacementUnit})`]: { field: 'value_inches', type: 'number' },
+        'Data Quality': { field: 'data_qual', type: 'string', transform: capitalizeFirst },
+        'Valid Pixels (%)': { field: 'pct_valid', type: 'number' },
+    };
+}
 
 function makeDisplacementContoursConfig(title: DisplacementLayerTitle): WMSLayerProps {
     const { type: typeValue, styleName } = DISPLACEMENT_LAYERS[title];
@@ -1031,7 +1039,7 @@ function makeDisplacementContoursConfig(title: DisplacementLayerTitle): WMSLayer
                 name: DISPLACEMENT_CONTOURS_LAYER,
                 popupEnabled: true,
                 queryable: true,
-                popupFields: displacementPopupFields,
+                popupFields: makeDisplacementPopupFields(typeValue),
             },
         ],
     };


### PR DESCRIPTION
**TL;DR** — InSAR viewer refinements stacked on #426: popup cleanups, MM-YYYY dates, capitalized Data Quality, magnitude-based legends under a "Vertical Displacement" heading, in/year on the rate popup, and a fix for the Cumulative chart's duplicate 1″/3″ threshold that also makes the map, chart, and dropdown agree. Based on `feat/data-reviewer-insights-dashboard` because the InSAR code only lives there.

**What's here** (issue → change)
- #520 — aquifer popup drops DOI + Publication.
- #521 — displacement popups drop the Year row; Period Start/End render MM-YYYY (UTC, so a `…-10-01T00:00:00Z` end date stays `10-YYYY` instead of slipping to `09`).
- #522 — Data Quality first-letter-capitalized (`high` → `High`), viewer-side so it's robust to raw casing.
- #523 — legends now sit under a **Vertical Displacement** heading with **Uplift / Subsidence** columns, and show **unsigned magnitudes** (Subsidence reads `3 – 5 in`, not `-5 – -3 in` — no more "negative subsidence"; direction is carried by the column + color). Applies to all 3 map legends and both chart legends; labels derive from each bin's bounds so they track the SLD.
- #524 — rate popup unit → **in/year**; Cumulative/Yearly stay `in`.
- #525 — the 1″/3″ options were identical (Cumulative contours are odd inches and the deadband is [−1, 1], so the 1–3″ band is empty). The threshold dropdown is now **data-driven** (only offers edges the data fills), and the effective default is the **smallest populated edge**, so the **map, chart, and dropdown all agree** and the map hides the ±deadband "uncertainty" band by default (matching the chart). Fully dynamic — nothing hard-coded; new data reshapes the options and default at runtime. Chart/KPIs are unchanged; only the map tightens.

**Not in scope** — SLD symbology tickets #526 (aquifer hollow + inward hatch + per-basin color) and #527 (cumulative + rate ramp) are GeoServer-side; handled separately.

**Notes**
- **Valid Pixels shows `0` for null `pct_valid`** (~34 features: Cumulative 19, Rate 3, Yearly 12). Confirmed acceptable — left as-is per request.
- Minor: on a cold first load the threshold briefly resolves through a lower fallback before the data-driven floor settles (sub-second, self-correcting; fully removing it would require hardcoding the floor).

**Verified** — `tsc` clean, `vite build` passes, eslint clean on the changed files (no new warnings), unit tests for the date / capitalize / magnitude-label / threshold logic. No new suite failures (the red `layer-config-consistency` DB tests are pre-existing, #495).

Resolves ALL-5637, ALL-5638, ALL-5639, ALL-5640, ALL-5641, ALL-5642 — these go Done when #426 lands on `develop`.
