### PR TITLE
[ALL-5649] feat(hazards): render GraphicStroke border ticks in polygon WMS legends

### DIFF
--- a/src/lib/legend/symbolizers/__tests__/polygon.test.ts
+++ b/src/lib/legend/symbolizers/__tests__/polygon.test.ts
@@ -3,27 +3,38 @@ import { describe, it, expect } from 'vitest';
 import { createPolygonSymbol } from '../polygon';
 import type { Symbolizer } from '../../../types/geoserver-types';
 
+const borderSymbolizer: Symbolizer = { Polygon: { stroke: '#5B6470', 'stroke-width': '1.2' } };
+const graphicStrokeSymbolizer = (mark: string): Symbolizer => ({
+    Polygon: { 'graphic-stroke': { size: '6', graphics: [{ mark, stroke: '#5B6470', 'stroke-width': '1' }] } },
+});
+
 describe('createPolygonSymbol', () => {
-    it('renders inward perpendicular border ticks for a polygon graphic-stroke (closed-basin hachures)', () => {
-        // Mirrors GetLegendGraphic JSON: a solid border symbolizer + a graphic-stroke symbolizer.
-        const symbolizers: Symbolizer[] = [
-            { Polygon: { stroke: '#5B6470', 'stroke-width': '1.2' } },
-            { Polygon: { 'graphic-stroke': { size: '6', graphics: [{ mark: 'shape://vertline', stroke: '#5B6470', 'stroke-width': '1' }] } } },
-        ];
+    it('draws inward ticks on all four edges for a vertline graphic-stroke (closed-basin symbol)', () => {
+        const svg = createPolygonSymbol([borderSymbolizer, graphicStrokeSymbolizer('shape://vertline')]);
+        expect(svg.querySelectorAll('rect')).toHaveLength(1);
 
-        const svg = createPolygonSymbol(symbolizers);
+        const lines = Array.from(svg.querySelectorAll('line'));
+        expect(lines).toHaveLength(18); // 6 top + 6 bottom + 3 left + 3 right on the 28x14 rect
 
-        expect(svg.querySelectorAll('rect')).toHaveLength(1); // the hollow box
-        const lines = svg.querySelectorAll('line');
-        expect(lines.length).toBeGreaterThan(8); // ticks on all four edges
+        // every tick meets one of the four rect edges (top y=3, bottom y=17, left x=2, right x=30)
+        const onTop = lines.filter(l => l.getAttribute('y1') === '3').length;
+        const onBottom = lines.filter(l => l.getAttribute('y1') === '17').length;
+        const onLeft = lines.filter(l => l.getAttribute('x1') === '2').length;
+        const onRight = lines.filter(l => l.getAttribute('x1') === '30').length;
+        expect([onTop, onBottom, onLeft, onRight].every(n => n > 0)).toBe(true);
+        expect(onTop + onBottom + onLeft + onRight).toBe(18);
 
-        // ticks are styled from the graphic mark, and each meets a rect edge (x in {2,30} or y in {3,17})
-        const edges = new Set(['2', '30', '3', '17']);
-        lines.forEach(line => {
-            expect(line.getAttribute('stroke')).toBe('#5B6470');
-            const onEdge = edges.has(line.getAttribute('x1')!) || edges.has(line.getAttribute('y1')!);
-            expect(onEdge).toBe(true);
+        // styled from the graphic mark
+        lines.forEach(l => {
+            expect(l.getAttribute('stroke')).toBe('#5B6470');
+            expect(l.getAttribute('stroke-width')).toBe('1');
         });
+    });
+
+    it('does not draw ticks for a non-tick graphic-stroke mark (leaves the plain box)', () => {
+        const svg = createPolygonSymbol([borderSymbolizer, graphicStrokeSymbolizer('shape://slash')]);
+        expect(svg.querySelectorAll('line')).toHaveLength(0);
+        expect(svg.querySelectorAll('rect')).toHaveLength(1);
     });
 
     it('draws no ticks when there is no graphic-stroke', () => {

--- a/src/lib/legend/symbolizers/__tests__/polygon.test.ts
+++ b/src/lib/legend/symbolizers/__tests__/polygon.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createPolygonSymbol } from '../polygon';
+import type { Symbolizer } from '../../../types/geoserver-types';
+
+describe('createPolygonSymbol', () => {
+    it('renders inward perpendicular border ticks for a polygon graphic-stroke (closed-basin hachures)', () => {
+        // Mirrors GetLegendGraphic JSON: a solid border symbolizer + a graphic-stroke symbolizer.
+        const symbolizers: Symbolizer[] = [
+            { Polygon: { stroke: '#5B6470', 'stroke-width': '1.2' } },
+            { Polygon: { 'graphic-stroke': { size: '6', graphics: [{ mark: 'shape://vertline', stroke: '#5B6470', 'stroke-width': '1' }] } } },
+        ];
+
+        const svg = createPolygonSymbol(symbolizers);
+
+        expect(svg.querySelectorAll('rect')).toHaveLength(1); // the hollow box
+        const lines = svg.querySelectorAll('line');
+        expect(lines.length).toBeGreaterThan(8); // ticks on all four edges
+
+        // ticks are styled from the graphic mark, and each meets a rect edge (x in {2,30} or y in {3,17})
+        const edges = new Set(['2', '30', '3', '17']);
+        lines.forEach(line => {
+            expect(line.getAttribute('stroke')).toBe('#5B6470');
+            const onEdge = edges.has(line.getAttribute('x1')!) || edges.has(line.getAttribute('y1')!);
+            expect(onEdge).toBe(true);
+        });
+    });
+
+    it('draws no ticks when there is no graphic-stroke', () => {
+        const svg = createPolygonSymbol([{ Polygon: { fill: '#aabbcc', 'fill-opacity': '1', stroke: '#000000' } }]);
+        expect(svg.querySelectorAll('line')).toHaveLength(0);
+        expect(svg.querySelectorAll('rect')).toHaveLength(1);
+    });
+});

--- a/src/lib/legend/symbolizers/polygon.ts
+++ b/src/lib/legend/symbolizers/polygon.ts
@@ -1,4 +1,4 @@
-import { FillSymbolizer, GraphicFillData, LineCap, LineJoin, StrokeSymbolizer, Symbolizer } from "@/lib/types/geoserver-types";
+import { FillSymbolizer, GraphicFillData, GraphicStrokeData, LineCap, LineJoin, StrokeSymbolizer, Symbolizer } from "@/lib/types/geoserver-types";
 import { createEmptySVG } from "@/lib/legend/symbol-generator";
 import { SYMBOL_CONSTANTS } from "@/lib/constants";
 
@@ -55,6 +55,7 @@ export function createPolygonSymbol(symbolizers: Symbolizer[]): SVGSVGElement {
     let strokeDasharray = "";
     let hasGraphicFill = false;
     let graphicFillPattern: SVGElement | null = null;
+    let graphicStrokeData: GraphicStrokeData | null = null;
 
     const PolygonSymbolizer = symbolizers.find(symbolizer => 'Polygon' in symbolizer)?.Polygon as StrokeSymbolizer;
 
@@ -73,6 +74,12 @@ export function createPolygonSymbol(symbolizers: Symbolizer[]): SVGSVGElement {
                 graphicFillPattern = createGraphicFillPatternElement(graphicFill);
             } else if ('fill' in symbolizer.Polygon) {
                 fillColorWithOpacity = handleFillSymbolizer(symbolizer.Polygon);
+            }
+
+            // Check for GraphicStroke (hachured / tick borders, e.g. the closed-basin depression symbol)
+            const graphicStroke = polygonData.GraphicStroke || polygonData['graphic-stroke'];
+            if (graphicStroke) {
+                graphicStrokeData = graphicStroke;
             }
 
             if ('stroke' in symbolizer.Polygon) {
@@ -125,7 +132,56 @@ export function createPolygonSymbol(symbolizers: Symbolizer[]): SVGSVGElement {
     }
 
     svg.appendChild(rect);
+
+    // GraphicStroke -> inward tick marks perpendicular to the rect border (ends meeting the edge).
+    // Renders the closed-basin / depression hachure symbol a fill pattern can't convey.
+    if (graphicStrokeData) {
+        appendBorderTicks(svg, graphicStrokeData, strokeColorWithOpacity);
+    }
+
     return svg;
+}
+
+/**
+ * Appends inward-pointing tick marks perpendicular to each edge of the legend rect, with the outer
+ * end meeting the border — the hachured closed-basin/depression symbol. Used when a polygon
+ * symbolizer carries a GraphicStroke (which the plain rect + fill-pattern path cannot represent).
+ * @param svg - The swatch SVG to append ticks to.
+ * @param graphicStroke - GraphicStroke data; its first graphic's stroke color/width style the ticks.
+ * @param fallbackStroke - Stroke color to fall back to when the graphic mark carries none.
+ */
+function appendBorderTicks(svg: SVGSVGElement, graphicStroke: GraphicStrokeData, fallbackStroke: string): void {
+    const mark = graphicStroke.graphics?.[0];
+    const stroke = mark?.stroke || fallbackStroke;
+    const strokeWidth = mark?.["stroke-width"] || "1";
+
+    // Rect geometry matches the rect drawn in createPolygonSymbol.
+    const x0 = SYMBOL_CONSTANTS.LINE_START_X, y0 = 3, w = 28, h = 14;
+    const x1 = x0 + w, y1 = y0 + h;
+    const tickLen = 4;   // inward length, perpendicular to the edge
+    const gap = 4.5;     // spacing along each edge
+
+    const lines: [number, number, number, number][] = [];
+    for (let dx = gap; dx < w; dx += gap) {
+        lines.push([x0 + dx, y0, x0 + dx, y0 + tickLen]);  // top edge -> ticks point down (inward)
+        lines.push([x0 + dx, y1, x0 + dx, y1 - tickLen]);  // bottom edge -> point up
+    }
+    for (let dy = gap; dy < h; dy += gap) {
+        lines.push([x0, y0 + dy, x0 + tickLen, y0 + dy]);  // left edge -> point right
+        lines.push([x1, y0 + dy, x1 - tickLen, y0 + dy]);  // right edge -> point left
+    }
+
+    for (const [ax, ay, bx, by] of lines) {
+        const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+        line.setAttribute("x1", ax.toString());
+        line.setAttribute("y1", ay.toString());
+        line.setAttribute("x2", bx.toString());
+        line.setAttribute("y2", by.toString());
+        line.setAttribute("stroke", stroke);
+        line.setAttribute("stroke-width", strokeWidth);
+        line.setAttribute("stroke-linecap", "round");
+        svg.appendChild(line);
+    }
 }
 
 /**

--- a/src/lib/legend/symbolizers/polygon.ts
+++ b/src/lib/legend/symbolizers/polygon.ts
@@ -76,9 +76,12 @@ export function createPolygonSymbol(symbolizers: Symbolizer[]): SVGSVGElement {
                 fillColorWithOpacity = handleFillSymbolizer(symbolizer.Polygon);
             }
 
-            // Check for GraphicStroke (hachured / tick borders, e.g. the closed-basin depression symbol)
+            // A polygon GraphicStroke whose mark is a tick (shape://vertline / horline) renders as inward
+            // border hachures (the closed-basin/depression symbol). Any other stroke graphic is left as the
+            // plain box (the prior behavior) rather than being misrepresented as ticks.
             const graphicStroke = polygonData.GraphicStroke || polygonData['graphic-stroke'];
-            if (graphicStroke) {
+            const graphicStrokeMark = graphicStroke?.graphics?.[0]?.mark?.toLowerCase() ?? '';
+            if (graphicStroke && (graphicStrokeMark.includes('vertline') || graphicStrokeMark.includes('horline'))) {
                 graphicStrokeData = graphicStroke;
             }
 


### PR DESCRIPTION
**TL;DR** — The polygon legend renderer now draws a proper closed‑basin/depression symbol — a rectangle with inward tick marks perpendicular to each edge (ends meeting the border) — for styles that use a `GraphicStroke`, instead of the plain box it drew before.

**Why** — `src/lib/legend/symbolizers/polygon.ts` builds the legend swatch client‑side from the `GetLegendGraphic` JSON. It handled `GraphicFill` patterns but ignored `GraphicStroke`, so hachured / tick‑border polygon styles rendered as an empty box. Surfaced by the new closed‑basin aquifer style (UGS-GIO/ugs-sld-styles#19), whose interim workaround is a `GraphicFill` hatch.

**What**
- Detect a polygon `graphic-stroke` in the symbolizer JSON (`Polygon['graphic-stroke'].graphics[0]` — already modeled in `geoserver-types.ts`) and draw inward ticks perpendicular to each edge of the 28×14 swatch rect, styled from the graphic mark's stroke. No change to the existing fill / `GraphicFill` / stroke behavior.
- Adds a jsdom unit test covering the tick rendering and the no‑graphic‑stroke case.

**Verify** — `tsc` + `vite build` pass (pre‑push hook); `vitest` unit test green. The pre‑existing `no-case-declarations` lint findings in `createPatternMarkElement` are untouched (out of scope).

**Follow‑up (coordinated)** — Once this is merged and deployed, the aquifer SLD (ugs-sld-styles#19) can switch its legend rule from the interim `GraphicFill` hatch back to a `GraphicStroke` border‑tick to render as the true depression symbol. Sequencing matters: don't switch the SLD before this ships, or the current renderer would show a plain box.

Closes #529
