### PR TITLE
fix(hazards): stop the ±deadband contour flash on cold load

### DIFF
--- a/src/routes/_map/hazards-review/-components/popups/displacement-filter-context.tsx
+++ b/src/routes/_map/hazards-review/-components/popups/displacement-filter-context.tsx
@@ -296,8 +296,11 @@ function quoteCqlLiteral(value: string): string {
 export function useDisplacementLayerFilters(): Record<string, string> {
     const { yearOverridesByType, basinsByType, excludedDataQualsByType } = useDisplacementFilters()
     const effective = useEffectiveThresholdsIn()
+    const cumulativeSld = useDisplacementSldZeroBound('Cumulative')
+    const yearlySld = useDisplacementSldZeroBound('Yearly')
     const latestByType = useDisplacementLatestYearByType()
     return useMemo(() => {
+        const zeroBoundByType: Record<ChartedType, number | null> = { 'Cumulative': cumulativeSld, 'Yearly': yearlySld }
         const out: Record<DisplacementLayerTitle, string> = {} as Record<DisplacementLayerTitle, string>
         for (const [title, typeValue] of Object.entries(DISPLACEMENT_LAYER_TYPES) as [DisplacementLayerTitle, DisplacementType][]) {
             const clauses: string[] = []
@@ -311,6 +314,14 @@ export function useDisplacementLayerFilters(): Record<string, string> {
                 const thresholdIn = effective[typeValue]
                 if (thresholdIn > 0) {
                     clauses.push(`(value_inches >= ${thresholdIn} OR value_inches <= ${-thresholdIn})`)
+                }
+                // Exclude the SLD "within uncertainty" deadband so the map matches
+                // the chart (which never plots deadband features) — including during
+                // the load window before the data-driven default tightens past the
+                // bound, otherwise the ±deadband contours flash in and back out.
+                const zeroBound = zeroBoundByType[typeValue]
+                if (zeroBound != null && zeroBound > 0) {
+                    clauses.push(`(value_inches > ${zeroBound} OR value_inches < ${-zeroBound})`)
                 }
             }
             const basins = basinsByType[typeValue]
@@ -329,5 +340,5 @@ export function useDisplacementLayerFilters(): Record<string, string> {
             if (clauses.length > 0) out[title] = clauses.join(' AND ')
         }
         return out
-    }, [yearOverridesByType, latestByType, effective, basinsByType, excludedDataQualsByType])
+    }, [yearOverridesByType, latestByType, effective, cumulativeSld, yearlySld, basinsByType, excludedDataQualsByType])
 }


### PR DESCRIPTION
**TL;DR** — Follow-up to the #525 threshold work (landed via #528 onto this branch): kills the brief flash where the ±1 "within uncertainty" contours show up on the map at first load and then disappear.

**Why it happened** — the map threshold resolves from two async queries (the SLD legend, then the 20k features). On a cold load the SLD returns first, so the default briefly sits at the deadband bound (1) and the map draws the ±1 contours; a couple seconds later the feature data lands, the data-driven floor (3 for Cumulative, 2 for Yearly) is computed, and they drop out.

**Fix** — exclude the deadband directly in the charted-layer map cql, using the SLD's own zero bound (already loaded during that window), so the ±deadband band is never drawn regardless of load timing. Redundant at steady state (the floor already excludes it); fully dynamic, nothing hard-coded. One file, +12 lines.

**Verified** — tsc clean, `vite build` passes, eslint clean (no new warnings), no new test failures.

Stacked on `feat/data-reviewer-insights-dashboard`; ships with #426 alongside the rest of the InSAR viewer work.
