### PR TITLE
feat(wetlandplants): add warehouse-sourced survey site and land ownership layers

### DIFF
--- a/src/routes/_map/wetlandplants/-data/layers/layers.tsx
+++ b/src/routes/_map/wetlandplants/-data/layers/layers.tsx
@@ -3,6 +3,13 @@ import { ArcGISMapServerLayerProps, LayerProps, PMTilesLayerProps } from "@/lib/
 // Wetland Survey Sites — STAC-driven: pmtilesUrl, sourceLayer, renders and parquet come from
 // the warehouse item `wetlands_plants_site`. ALL-5623.
 //
+// NOT VISIBLE YET (ALL-5625): wetlands_plants_site has no `ugs:renders` in STAC yet, and a
+// PMTiles layer with zero renders + no styleUrl never gets a style fragment — data-map.tsx
+// only renders layers with one loaded (see the pmtilesFragments.get(layer.title) gate), so
+// this layer is silently dropped from the map today. No error, it just doesn't draw. This is
+// wired up correctly and will appear once a render ships (ugs-styles → STAC ugs:renders),
+// not a bug here. Per ALL-3726: yellow for exact locations, red for confidential/approximate.
+//
 // PRIVACY: sites with privacystatus === 'Confidential' are geocoded to their true, exact
 // location in the warehouse today (dataELT passes `geom` through untouched — see the
 // wetlands_plants_site lineage). The old app's About text promises these show at "a randomly

--- a/src/routes/_map/wetlandplants/-data/layers/layers.tsx
+++ b/src/routes/_map/wetlandplants/-data/layers/layers.tsx
@@ -1,50 +1,111 @@
-import { PROD_GEOSERVER_URL, HAZARDS_WORKSPACE } from "@/lib/constants";
-import { LayerProps, WMSLayerProps } from "@/lib/types/mapping-types";
-//import GeoJSON from "geojson";
+import { ArcGISMapServerLayerProps, LayerProps, PMTilesLayerProps } from "@/lib/types/mapping-types";
 
-
-const studyAreasLayerName = 'studyareas_current';
-const studyAreasWMSTitle = 'Lorem Ipsum';
-const studyAreasWMSConfig: WMSLayerProps = {
-    type: 'wms',
-    url: `${PROD_GEOSERVER_URL}/wms`,
-    title: studyAreasWMSTitle,
+// Wetland Survey Sites — STAC-driven: pmtilesUrl, sourceLayer, renders and parquet come from
+// the warehouse item `wetlands_plants_site`. ALL-5623.
+//
+// PRIVACY: sites with privacystatus === 'Confidential' are geocoded to their true, exact
+// location in the warehouse today (dataELT passes `geom` through untouched — see the
+// wetlands_plants_site lineage). The old app's About text promises these show at "a randomly
+// assigned" nearby location instead, which isn't implemented anywhere upstream. Until a
+// dataELT fix adds a real offset before PMTiles are built, this layer is filtered client-side
+// (see wetlandplants/-index.tsx `vectorLayerFilters`) to exclude Confidential features rather
+// than render their real coordinates. Do not remove that filter without a warehouse fix.
+const wetlandSurveySitesLayerName = 'wetlands_plants_site';
+export const wetlandSurveySitesTitle = 'Wetland Survey Sites';
+const wetlandSurveySitesConfig: PMTilesLayerProps = {
+    type: 'pmtiles',
+    stacItemId: wetlandSurveySitesLayerName,
+    pmtilesUrl: '',
+    sourceLayer: wetlandSurveySitesLayerName,
+    title: wetlandSurveySitesTitle,
     visible: true,
-    crs: 'EPSG:26912',
+    sourceAgency: 'Utah Geological Survey',
+    opacity: 1,
     sublayers: [
         {
-            name: `${HAZARDS_WORKSPACE}:${studyAreasLayerName}`,
+            name: wetlandSurveySitesLayerName,
+            popupEnabled: false,
+            queryable: true,
+            popupFields: {
+                'Site Code': { field: 'sitecode', type: 'string' },
+                'Ecoregional Group': { field: 'ecoregionalgroup', type: 'string' },
+                'Wetland Type': {
+                    field: 'custom',
+                    type: 'custom',
+                    transform: (props) => {
+                        const primary = props?.['wetlandtype'];
+                        const secondary = props?.['wetlandtype2'];
+                        if (secondary && secondary !== 'N/A') return `${primary} / ${secondary}`;
+                        return `${primary ?? ''}`;
+                    },
+                },
+                'HGM Class': { field: 'hgm_class', type: 'string' },
+                'Watershed': { field: 'watershed', type: 'string' },
+                'Vegetation Condition': { field: 'vegetationcondition', type: 'string' },
+                'Owner': { field: 'owner', type: 'string' },
+                'Project': { field: 'project', type: 'string' },
+                'Survey Date': { field: 'surveydate', type: 'date' },
+                'Cover-Weighted Mean C': { field: 'cwmeanc', type: 'number', decimalPlaces: 1 },
+                'Relative Native Cover': { field: 'relnativecover', type: 'number', decimalPlaces: 1, unit: '%' },
+            },
+        },
+    ],
+};
+
+// Wetland Dashboard Site Attributes — STAC-driven from warehouse item
+// `wetlands_wetdash_siteattributes`. NOTE: despite the name suggesting it's a child/related
+// table of Wetland Survey Sites, the two datasets do NOT share a join key today — sitecode
+// (e.g. "CB-038") on plants_site has no overlap with siteid (e.g. "5971926_ip2_ref2015") on
+// this table, row counts differ (654 vs 1563), and neither STAC item carries
+// `ugs:foreign_keys`. Shipping it as its own independent layer instead of a related-table
+// popup until the relationship (if any) is confirmed with Nate and the warehouse publishes
+// the join metadata.
+const wetlandDashboardSitesLayerName = 'wetlands_wetdash_siteattributes';
+export const wetlandDashboardSitesTitle = 'Wetland Dashboard Sites';
+const wetlandDashboardSitesConfig: PMTilesLayerProps = {
+    type: 'pmtiles',
+    stacItemId: wetlandDashboardSitesLayerName,
+    pmtilesUrl: '',
+    sourceLayer: wetlandDashboardSitesLayerName,
+    title: wetlandDashboardSitesTitle,
+    subtitle: 'Wetland dashboard site attributes',
+    visible: false,
+    sourceAgency: 'Utah Geological Survey',
+    opacity: 1,
+    sublayers: [
+        {
+            name: wetlandDashboardSitesLayerName,
             popupEnabled: false,
             queryable: true,
             popupFields: {
                 'Name': { field: 'name', type: 'string' },
-                'Report ID': { field: 'repor_id', type: 'string' },
-                'Mapped Hazards': { field: 'hazard_name', type: 'string' },
+                'Site ID': { field: 'siteid', type: 'string' },
+                'Ecoregion': { field: 'ecoregion', type: 'string' },
+                'Watershed (HUC8)': { field: 'huc_name', type: 'string' },
+                'System Class': { field: 'sysclass', type: 'string' },
+                'Wetland Type': { field: 'wet_type', type: 'string' },
+                'Project': { field: 'project', type: 'string' },
+                'Date': { field: 'date', type: 'date' },
             },
-            linkFields: {
-                'repor_id': {
-                    baseUrl: '',
-                    transform: (value: string) => {
-                        const values = value.split(','); // Split the input value by a comma
-                        const transformedValues = values.map(val => {
-                            const trimmedVal = val.trim();
-                            const href = /^\d+$/.test(trimmedVal)
-                                ? `https://geodata.geology.utah.gov/pages/view.php?ref=${trimmedVal}`
-                                : `https://doi.org/10.34191/${trimmedVal}`;
-                            const label = trimmedVal;
-                            return { label, href };
-                        });
-
-                        return transformedValues;
-                    }
-                }
-            }
         },
     ],
-}
+};
+
+// Land Ownership (SITLA) — ALL-5630. Not yet in the warehouse; copied source/naming from the
+// same layer already used in geophysics (src/routes/_map/geophysics/-data/layers/layers.tsx)
+// per the ticket's own instruction to reuse it rather than re-source it.
+const landOwnershipConfig: ArcGISMapServerLayerProps = {
+    type: 'map-image',
+    url: 'https://gis.trustlands.utah.gov/mapping/rest/services/Land_Ownership_WM/MapServer',
+    title: 'Land Ownership',
+    opacity: 0.5,
+    visible: false,
+};
 
 const layersConfig: LayerProps[] = [
-    studyAreasWMSConfig
+    wetlandSurveySitesConfig,
+    wetlandDashboardSitesConfig,
+    landOwnershipConfig,
 ];
 
 export default layersConfig;

--- a/src/routes/_map/wetlandplants/-index.tsx
+++ b/src/routes/_map/wetlandplants/-index.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+import type { FilterSpecification } from 'maplibre-gl'
 import { Layout } from '@/components/layout/layout'
 import { TopNav } from '@/components/top-nav'
 import { MapFooter } from '@/components/maps/map-footer'
@@ -9,12 +11,21 @@ import { useIsMobile } from '@/hooks/use-mobile'
 import { useMapContextState } from '@/hooks/use-map-context-state'
 import { MapContext } from '@/context/map-context'
 import { TourAutoStart } from '@/components/tour-auto-start'
+import { wetlandSurveySitesTitle } from './-data/layers/layers'
 
 export default function Map() {
     const { isCollapsed, sidebarWidthPx } = useSidebar();
     const isMobile = useIsMobile();
     const sidebarMargin = isMobile ? 0 : (isCollapsed ? 56 : sidebarWidthPx);
     const { contextValue } = useMapContextState();
+
+    // PRIVACY: the warehouse does not yet offset Confidential wetland survey site
+    // coordinates (see comment in -data/layers/layers.tsx). Hide those features entirely
+    // rather than render their true location until a dataELT fix lands. Do not remove this
+    // without confirming the warehouse pipeline now jitters confidential geometries.
+    const vectorLayerFilters = useMemo<Record<string, FilterSpecification>>(() => ({
+        [wetlandSurveySitesTitle]: ['!=', ['get', 'privacystatus'], 'Confidential'],
+    }), []);
 
     return (
         <MapContext.Provider value={contextValue}>
@@ -38,7 +49,7 @@ export default function Map() {
 
                         {/* ===== Main ===== */}
                         <Layout.Body>
-                            <GenericMapContainer />
+                            <GenericMapContainer vectorLayerFilters={vectorLayerFilters} />
                         </Layout.Body>
 
                         {/* ===== Footer ===== */}


### PR DESCRIPTION
ALL-5624, ALL-5623

Adds warehouse-sourced layers to the wetlandplants submap:
- Wetland Survey Sites (wetlands_plants_site) - STAC/PMTiles, popups formatted (ALL-5623)
- Wetland Dashboard Sites (wetlands_wetdash_siteattributes) - shipped as its own layer, not a related table (confirmed it doesn't share a join key with plants_site: different sitecode/siteid formats, different row counts, no ugs:foreign_keys on either STAC item)
- Land Ownership (SITLA) - copied source/naming from geophysics, ALL-5630

Closes ALL-5630

Removed the leftover placeholder 'Lorem Ipsum' WMS study-areas layer that didn't belong to this app.

### Not visible yet - blocked on ALL-5625
Wetland Survey Sites is wired up correctly but won't render on the map until ALL-5625 (symbology) ships. Its STAC item has no `renders` yet, and PMTiles layers with no renders/styleUrl are silently dropped from the map (no fallback style, no error - see the `pmtilesFragments.get(layer.title)` gate in data-map.tsx). Flagging so this isn't mistaken for a bug in review.

### Privacy: confidential site coordinates
Found that confidential wetland survey sites are not actually offset anywhere upstream - old app's About text promises it, but neither the legacy app nor the dataELT pipeline implements it. The `geom` used to build PMTiles carries the true coordinates even when `privacystatus = 'Confidential'`. Client-side filter in this PR hides those features from the map entirely until the real fix lands. See ALL-3727 / ALL-5709 for the upstream dataELT fix needed.

### Left out this round
Ecoregional Groups and Watershed Boundaries aren't in scope here - not yet published to the warehouse (ALL-5631/ALL-5627 pipeline loads still open).